### PR TITLE
add missing includes

### DIFF
--- a/examples/cpp/loading_sparse_qp.cpp
+++ b/examples/cpp/loading_sparse_qp.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <proxsuite/proxqp/sparse/sparse.hpp> // get the sparse API of ProxQP
 #include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
 

--- a/examples/cpp/solve_without_api.cpp
+++ b/examples/cpp/solve_without_api.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "proxsuite/proxqp/sparse/sparse.hpp" // get the sparse backend of ProxQP
 #include "proxsuite/proxqp/dense/dense.hpp"   // get the dense backend of ProxQP
 #include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp

--- a/examples/cpp/solve_without_api_and_option.cpp
+++ b/examples/cpp/solve_without_api_and_option.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <proxsuite/proxqp/sparse/sparse.hpp> // get the sparse backend of ProxQP
 #include <proxsuite/proxqp/dense/dense.hpp>   // get the dense backend of ProxQP
 #include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp

--- a/examples/cpp/update_sparse_qp.cpp
+++ b/examples/cpp/update_sparse_qp.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <proxsuite/proxqp/sparse/sparse.hpp> // get the sparse API of ProxQP
 #include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
 

--- a/test/src/sparse_qp.cpp
+++ b/test/src/sparse_qp.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2022 INRIA
 //
+#include <iostream>
 #include <proxsuite/proxqp/sparse/wrapper.hpp>
 #include <proxsuite/proxqp/utils/random_qp_problems.hpp>
 #include <doctest.hpp>

--- a/test/src/sparse_qp_solve.cpp
+++ b/test/src/sparse_qp_solve.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2022 INRIA
 //
+#include <iostream>
 #include <doctest.hpp>
 #include <proxsuite/proxqp/sparse/sparse.hpp>
 #include <proxsuite/proxqp/utils/random_qp_problems.hpp>

--- a/test/src/sparse_qp_wrapper.cpp
+++ b/test/src/sparse_qp_wrapper.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2022 INRIA
 //
+#include <iostream>
 #include <proxsuite/proxqp/sparse/sparse.hpp>
 #include <proxsuite/proxqp/utils/random_qp_problems.hpp>
 #include <doctest.hpp>

--- a/test/src/sparse_ruiz_equilibration.cpp
+++ b/test/src/sparse_ruiz_equilibration.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2022 INRIA
 //
+#include <iostream>
 #include <proxsuite/proxqp/sparse/solver.hpp>
 #include <proxsuite/proxqp/dense/preconditioner/ruiz.hpp>
 #include <proxsuite/proxqp/utils/random_qp_problems.hpp>


### PR DESCRIPTION
Hi,

On a standard ubuntu 20.04, with gcc 9.4 and eigen 3.3.7, eigen has a `std::cerr` somewhere and compilation raise some occurences of : 
```
In file included from /usr/include/eigen3/unsupported/Eigen/IterativeSolvers:29,
                 from ../include/proxsuite/proxqp/sparse/views.hpp:21,
                 from ../include/proxsuite/proxqp/sparse/solver.hpp:20,
                 from ../include/proxsuite/proxqp/sparse/wrapper.hpp:12,
                 from ../test/src/sparse_qp.cpp:4:
/usr/include/eigen3/unsupported/Eigen/src/IterativeSolvers/ConstrainedConjGrad.h: In function ‘void Eigen::internal::constrained_cg(const TMatrix&, const CMatrix&, VectorX&, const VectorB&, const VectorF&, Eigen::IterationController&)’:
/usr/include/eigen3/unsupported/Eigen/src/IterativeSolvers/ConstrainedConjGrad.h:162:51: error: ‘cerr’ is not a member of ‘std’
  162 |     if (iter.noiseLevel() > 0 && transition) std::cerr << "CCG: transition\n";
      |                                                   ^~~~
/usr/include/eigen3/unsupported/Eigen/src/IterativeSolvers/ConstrainedConjGrad.h:30:1: note: ‘std::cerr’ is defined in header ‘<iostream>’; did you forget to ‘#include <iostream>’?
   29 | #include "../../../../Eigen/src/Core/util/NonMPL2.h"
  +++ |+#include <iostream>
   30 |
```

Here is a quick fix, but this is not super satisfying…

PS: I pushed to simple-robotics/devel by mistake, and reverted back a few seconds after that, sorry for the mess :(