### PR TITLE
Fix preconditioner

### DIFF
--- a/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
+++ b/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
@@ -87,46 +87,43 @@ ruiz_scale_qp_in_place( //
         switch (sym) {
           case Symmetry::upper: { // upper triangular part
             T aux = sqrt(std::max({
-                                 infty_norm(H.col(k).head(k)),
-                                 infty_norm(H.row(k).tail(n - k)),
-                                 infty_norm(A.col(k)),
-                                 infty_norm(C.col(k)),
-                               })) ;
-            if (aux==T(0)){
+              infty_norm(H.col(k).head(k)),
+              infty_norm(H.row(k).tail(n - k)),
+              infty_norm(A.col(k)),
+              infty_norm(C.col(k)),
+            }));
+            if (aux == T(0)) {
               aux = T(1);
             }
 
-            delta(k) = T(1) / (aux +
-                               machine_eps);
+            delta(k) = T(1) / (aux + machine_eps);
             break;
           }
           case Symmetry::lower: { // lower triangular part
 
             T aux = sqrt(std::max({
-                                 infty_norm(H.col(k).head(k)),
-                                 infty_norm(H.col(k).tail(n - k)),
-                                 infty_norm(A.col(k)),
-                                 infty_norm(C.col(k)),
-                               })) ;
-            if (aux==T(0)){
+              infty_norm(H.col(k).head(k)),
+              infty_norm(H.col(k).tail(n - k)),
+              infty_norm(A.col(k)),
+              infty_norm(C.col(k)),
+            }));
+            if (aux == T(0)) {
               aux = T(1);
             }
-            delta(k) = T(1) / (aux +
-                               machine_eps);
+            delta(k) = T(1) / (aux + machine_eps);
             break;
           }
           case Symmetry::general: {
 
             T aux = sqrt(std::max({
-                                 infty_norm(H.col(k)),
-                                 infty_norm(A.col(k)),
-                                 infty_norm(C.col(k)),
-                               })) ;
-            if (aux==T(0)){
+              infty_norm(H.col(k)),
+              infty_norm(A.col(k)),
+              infty_norm(C.col(k)),
+            }));
+            if (aux == T(0)) {
               aux = T(1);
             }
-            delta(k) = T(1) / (aux +
-                               machine_eps);
+            delta(k) = T(1) / (aux + machine_eps);
 
             break;
           }
@@ -135,14 +132,14 @@ ruiz_scale_qp_in_place( //
 
       for (isize k = 0; k < n_eq; ++k) {
         T aux = sqrt(infty_norm(A.row(k)));
-        if (aux==T(0)){
+        if (aux == T(0)) {
           aux = T(1);
         }
         delta(n + k) = T(1) / (aux + machine_eps);
       }
       for (isize k = 0; k < n_in; ++k) {
         T aux = sqrt(infty_norm(C.row(k)));
-        if (aux==T(0)){
+        if (aux == T(0)) {
           aux = T(1);
         }
         delta(k + n + n_eq) = T(1) / (aux + machine_eps);

--- a/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
+++ b/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
@@ -108,9 +108,11 @@ ruiz_scale_qp_in_place( //
               infty_norm(C.col(k)),
             }));
             if (aux == T(0)) {
-              aux = T(1);
+              delta(k) = T(1);
             }
-            delta(k) = T(1) / (aux + machine_eps);
+            else {
+              delta(k) = T(1) / (aux + machine_eps);
+            }
             break;
           }
           case Symmetry::general: {

--- a/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
+++ b/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
@@ -109,8 +109,7 @@ ruiz_scale_qp_in_place( //
             }));
             if (aux == T(0)) {
               delta(k) = T(1);
-            }
-            else {
+            } else {
               delta(k) = T(1) / (aux + machine_eps);
             }
             break;

--- a/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
+++ b/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
@@ -86,31 +86,46 @@ ruiz_scale_qp_in_place( //
       for (isize k = 0; k < n; ++k) {
         switch (sym) {
           case Symmetry::upper: { // upper triangular part
-            delta(k) = T(1) / (sqrt(std::max({
+            T aux = sqrt(std::max({
                                  infty_norm(H.col(k).head(k)),
                                  infty_norm(H.row(k).tail(n - k)),
                                  infty_norm(A.col(k)),
                                  infty_norm(C.col(k)),
-                               })) +
+                               })) ;
+            if (aux==T(0)){
+              aux = T(1);
+            }
+
+            delta(k) = T(1) / (aux +
                                machine_eps);
             break;
           }
           case Symmetry::lower: { // lower triangular part
-            delta(k) = T(1) / (sqrt(std::max({
-                                 infty_norm(H.row(k).head(k)),
+
+            T aux = sqrt(std::max({
+                                 infty_norm(H.col(k).head(k)),
                                  infty_norm(H.col(k).tail(n - k)),
                                  infty_norm(A.col(k)),
                                  infty_norm(C.col(k)),
-                               })) +
+                               })) ;
+            if (aux==T(0)){
+              aux = T(1);
+            }
+            delta(k) = T(1) / (aux +
                                machine_eps);
             break;
           }
           case Symmetry::general: {
-            delta(k) = T(1) / (sqrt(std::max({
+
+            T aux = sqrt(std::max({
                                  infty_norm(H.col(k)),
                                  infty_norm(A.col(k)),
                                  infty_norm(C.col(k)),
-                               })) +
+                               })) ;
+            if (aux==T(0)){
+              aux = T(1);
+            }
+            delta(k) = T(1) / (aux +
                                machine_eps);
 
             break;
@@ -120,10 +135,16 @@ ruiz_scale_qp_in_place( //
 
       for (isize k = 0; k < n_eq; ++k) {
         T aux = sqrt(infty_norm(A.row(k)));
+        if (aux==T(0)){
+          aux = T(1);
+        }
         delta(n + k) = T(1) / (aux + machine_eps);
       }
       for (isize k = 0; k < n_in; ++k) {
         T aux = sqrt(infty_norm(C.row(k)));
+        if (aux==T(0)){
+          aux = T(1);
+        }
         delta(k + n + n_eq) = T(1) / (aux + machine_eps);
       }
     }

--- a/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
+++ b/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
@@ -93,10 +93,10 @@ ruiz_scale_qp_in_place( //
               infty_norm(C.col(k)),
             }));
             if (aux == T(0)) {
-              aux = T(1);
+              delta(k) = T(1);
+            } else {
+              delta(k) = T(1) / (aux + machine_eps);
             }
-
-            delta(k) = T(1) / (aux + machine_eps);
             break;
           }
           case Symmetry::lower: { // lower triangular part
@@ -122,10 +122,10 @@ ruiz_scale_qp_in_place( //
               infty_norm(C.col(k)),
             }));
             if (aux == T(0)) {
-              aux = T(1);
+              delta(k) = T(1);
+            } else {
+              delta(k) = T(1) / (aux + machine_eps);
             }
-            delta(k) = T(1) / (aux + machine_eps);
-
             break;
           }
         }
@@ -134,16 +134,18 @@ ruiz_scale_qp_in_place( //
       for (isize k = 0; k < n_eq; ++k) {
         T aux = sqrt(infty_norm(A.row(k)));
         if (aux == T(0)) {
-          aux = T(1);
+          delta(n + k) = T(1);
+        } else {
+          delta(n + k) = T(1) / (aux + machine_eps);
         }
-        delta(n + k) = T(1) / (aux + machine_eps);
       }
       for (isize k = 0; k < n_in; ++k) {
         T aux = sqrt(infty_norm(C.row(k)));
         if (aux == T(0)) {
-          aux = T(1);
+          delta(k + n + n_eq) = T(1);
+        } else {
+          delta(k + n + n_eq) = T(1) / (aux + machine_eps);
         }
-        delta(k + n + n_eq) = T(1) / (aux + machine_eps);
       }
     }
     {


### PR DESCRIPTION
While debugging the unittests from cvxpy, we added these changes here to make our API more robust and easy to maintain with @Bambade.

- allocate delta the same way as done in the sparse counterpart
- make sure that 0 cols do not cause any problems