### PR TITLE
Add default proximal step sizes

### DIFF
--- a/bindings/python/src/expose-settings.hpp
+++ b/bindings/python/src/expose-settings.hpp
@@ -28,6 +28,9 @@ exposeSettings(pybind11::module_ m)
 
   ::pybind11::class_<Settings<T>>(m, "Settings", pybind11::module_local())
     .def(::pybind11::init(), "Default constructor.") // constructor
+    .def_readwrite("default_rho", &Settings<T>::default_rho)
+    .def_readwrite("default_mu_eq", &Settings<T>::default_mu_eq)
+    .def_readwrite("default_mu_in", &Settings<T>::default_mu_in)
     .def_readwrite("alpha_bcl", &Settings<T>::alpha_bcl)
     .def_readwrite("beta_bcl", &Settings<T>::beta_bcl)
     .def_readwrite("refactor_dual_feasibility_threshold",

--- a/doc/2-PROXQP_API/2-ProxQP_api.md
+++ b/doc/2-PROXQP_API/2-ProxQP_api.md
@@ -304,7 +304,7 @@ In this table you have on the three columns from left to right: the name of the 
 | VERBOSE                             | False                          | If set to true, the solver prints information at each loop.
 | default_rho                         | 1.E-6                          | Default rho parameter of result class (i.e., for each initial guess, except WARM_START_WITH_PREVIOUS_RESULT, after a new solve or update, the solver initializes rho to this value).
 | default_mu_eq                       | 1.E-3                          | Default mu_eq parameter of result class (i.e., for each initial guess, except WARM_START_WITH_PREVIOUS_RESULT, after a new solve or update, the solver initializes mu_eq to this value).
-| default_mu_in                       | 1.E-1                          | Default mu_in parameter of result class (i.e., for each initial guess, except WARM_START_WITH_PREVIOUS_RESULT, after a new solve or update, the solver initializes mu_in to this value). 
+| default_mu_in                       | 1.E-1                          | Default mu_in parameter of result class (i.e., for each initial guess, except WARM_START_WITH_PREVIOUS_RESULT, after a new solve or update, the solver initializes mu_in to this value).
 | compute_timings                     | True                           | If set to true, timings will be computed by the solver (setup time, solving time, and run time = setup time + solving time).
 | max_iter                            | 1.E4                           | Maximal number of authorized outer iterations.
 | max_iter_in                         | 1500                           | Maximal number of authorized inner iterations.

--- a/doc/2-PROXQP_API/2-ProxQP_api.md
+++ b/doc/2-PROXQP_API/2-ProxQP_api.md
@@ -434,7 +434,7 @@ In this table you have on the three columns from left to right: the name of the 
 | dua_res                             | 0                              | The dual residual.
 
 
-Note finally that when initializing a Qp object, by default the proximal step sizes (i.e., rho, mu_eq and mu_in) are set up by the default values defined in the Setting class. Hence, when doing mutliple solves, if not specified, their values are re-set respectively to default_rho, default_mu_eq and default_mu_in. A small example is given below in c++ and python.
+Note finally that when initializing a QP object, by default the proximal step sizes (i.e., rho, mu_eq and mu_in) are set up by the default values defined in the Setting class. Hence, when doing multiple solves, if not specified, their values are re-set respectively to default_rho, default_mu_eq and default_mu_in. A small example is given below in c++ and python.
 
 <table class="manual">
   <tr>

--- a/doc/2-PROXQP_API/2-ProxQP_api.md
+++ b/doc/2-PROXQP_API/2-ProxQP_api.md
@@ -302,6 +302,9 @@ In this table you have on the three columns from left to right: the name of the 
 | eps_abs                             | 1.E-3                          | Asbolute stopping criterion of the solver.
 | eps_rel                             | 0                              | Relative stopping criterion of the solver.
 | VERBOSE                             | False                          | If set to true, the solver prints information at each loop.
+| default_rho                         | 1.E-6                          | Default rho parameter of result class (i.e., for each initial guess, except WARM_START_WITH_PREVIOUS_RESULT, after a new solve or update, the solver initializes rho to this value).
+| default_mu_eq                       | 1.E-3                          | Default mu_eq parameter of result class (i.e., for each initial guess, except WARM_START_WITH_PREVIOUS_RESULT, after a new solve or update, the solver initializes mu_eq to this value).
+| default_mu_in                       | 1.E-1                          | Default mu_in parameter of result class (i.e., for each initial guess, except WARM_START_WITH_PREVIOUS_RESULT, after a new solve or update, the solver initializes mu_in to this value). 
 | compute_timings                     | True                           | If set to true, timings will be computed by the solver (setup time, solving time, and run time = setup time + solving time).
 | max_iter                            | 1.E4                           | Maximal number of authorized outer iterations.
 | max_iter_in                         | 1500                           | Maximal number of authorized inner iterations.
@@ -386,6 +389,7 @@ This option has also been thought initially for being used in optimal control li
 
 Note finally that at the first solve, as there is no previous results, x, y and z are warm started with the 0 vector value.
 
+
 \section OverviewResults The results subclass
 
 The result subclass is composed of:
@@ -429,6 +433,25 @@ In this table you have on the three columns from left to right: the name of the 
 | objValue                            | 0                              | The objective value to minimize.
 | pri_res                             | 0                              | The primal residual.
 | dua_res                             | 0                              | The dual residual.
+
+
+Note finally that when initializing a Qp object, by default the proximal step sizes (i.e., rho, mu_eq and mu_in) are set up by the default values defined in the Setting class. Hence, when doing mutliple solves, if not specified, their values are re-set respectively to default_rho, default_mu_eq and default_mu_in. A small example is given below in c++ and python.
+
+<table class="manual">
+  <tr>
+    <th>examples/cpp/init_with_default_options.cpp</th>
+    <th>examples/python/init_with_default_options.py</th>
+  </tr>
+  <tr>
+    <td valign="top">
+      \include init_with_default_options.cpp
+    </td>
+    <td valign="top">
+      \include init_with_default_options.py
+    </td>
+  </tr>
+</table>
+
 
 \subsection OverviewSolverStatus The solver's status
 

--- a/doc/2-PROXQP_API/2-ProxQP_api.md
+++ b/doc/2-PROXQP_API/2-ProxQP_api.md
@@ -389,7 +389,6 @@ This option has also been thought initially for being used in optimal control li
 
 Note finally that at the first solve, as there is no previous results, x, y and z are warm started with the 0 vector value.
 
-
 \section OverviewResults The results subclass
 
 The result subclass is composed of:

--- a/examples/cpp/init_dense_qp.cpp
+++ b/examples/cpp/init_dense_qp.cpp
@@ -16,6 +16,12 @@ main()
   dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> qp(dim, n_eq, n_in);                  // create the QP object
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l); // initialize the model
+  dense::QP<T> qp(dim, n_eq, n_in); // create the QP object
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l); // initialize the model
 }

--- a/examples/cpp/init_dense_qp.cpp
+++ b/examples/cpp/init_dense_qp.cpp
@@ -1,5 +1,5 @@
 #include <proxsuite/proxqp/dense/dense.hpp> // load the dense solver backend
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite::proxqp;
 using T = double;
@@ -13,9 +13,9 @@ main()
   // generate a random qp
   T sparsity_factor(0.15);
   T strong_convexity_factor(1.e-2);
-  dense::Model<T> qp = utils::dense_strongly_convex_qp(
+  dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);                  // create the QP object
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l); // initialize the model
+  dense::QP<T> qp(dim, n_eq, n_in);                  // create the QP object
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l); // initialize the model
 }

--- a/examples/cpp/init_dense_qp_with_other_options.cpp
+++ b/examples/cpp/init_dense_qp_with_other_options.cpp
@@ -18,7 +18,15 @@ main()
   dense::QP<T> qp(
     dim, n_eq, n_in); // create the QP
                       // initialize the model, along with another rho parameter
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, /*rho*/ 1.e-7);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          true,
+          /*rho*/ 1.e-7);
   // in c++ you must follow the order speficied in the API for the parameters
   // if you don't want to change one parameter (here compute_preconditioner),
   // just let it be std::nullopt

--- a/examples/cpp/init_dense_qp_with_other_options.cpp
+++ b/examples/cpp/init_dense_qp_with_other_options.cpp
@@ -1,5 +1,5 @@
 #include <proxsuite/proxqp/dense/dense.hpp> // load the dense solver backend
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite::proxqp;
 using T = double;
@@ -12,13 +12,13 @@ main()
   // generate a random qp
   T sparsity_factor(0.15);
   T strong_convexity_factor(1.e-2);
-  dense::Model<T> qp = utils::dense_strongly_convex_qp(
+  dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(
+  dense::QP<T> qp(
     dim, n_eq, n_in); // create the QP
                       // initialize the model, along with another rho parameter
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true, /*rho*/ 1.e-7);
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, /*rho*/ 1.e-7);
   // in c++ you must follow the order speficied in the API for the parameters
   // if you don't want to change one parameter (here compute_preconditioner),
   // just let it be std::nullopt

--- a/examples/cpp/init_dense_qp_with_timings.cpp
+++ b/examples/cpp/init_dense_qp_with_timings.cpp
@@ -15,7 +15,13 @@ main()
   dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> qp(dim, n_eq, n_in);                  // create the QP object
-  qp.settings.compute_timings = true;                // compute all timings
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l); // initialize the model
+  dense::QP<T> qp(dim, n_eq, n_in);   // create the QP object
+  qp.settings.compute_timings = true; // compute all timings
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l); // initialize the model
 }

--- a/examples/cpp/init_dense_qp_with_timings.cpp
+++ b/examples/cpp/init_dense_qp_with_timings.cpp
@@ -1,5 +1,5 @@
 #include <proxsuite/proxqp/dense/dense.hpp> // load the dense solver backend
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite::proxqp;
 using T = double;
@@ -12,10 +12,10 @@ main()
   // generate a random qp
   T sparsity_factor(0.15);
   T strong_convexity_factor(1.e-2);
-  dense::Model<T> qp = utils::dense_strongly_convex_qp(
+  dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);                  // create the QP object
-  Qp.settings.compute_timings = true;                // compute all timings
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l); // initialize the model
+  dense::QP<T> qp(dim, n_eq, n_in);                  // create the QP object
+  qp.settings.compute_timings = true;                // compute all timings
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l); // initialize the model
 }

--- a/examples/cpp/init_with_default_options.cpp
+++ b/examples/cpp/init_with_default_options.cpp
@@ -18,7 +18,7 @@ main()
   dense::QP<T> Qp(
     dim, n_eq, n_in); // create the QP
                       // initialize the model, along with another rho parameter
-  Qp.settings.initial_guess.NO_INITIAL_GUESS;
+  Qp.settings.initial_guess = = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
   Qp.init(qp.H,
           qp.g,
           qp.A,

--- a/examples/cpp/init_with_default_options.cpp
+++ b/examples/cpp/init_with_default_options.cpp
@@ -18,7 +18,7 @@ main()
   dense::QP<T> Qp(
     dim, n_eq, n_in); // create the QP
                       // initialize the model, along with another rho parameter
-  Qp.settings.initial_guess = = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  Qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
   Qp.init(qp.H,
           qp.g,
           qp.A,

--- a/examples/cpp/init_with_default_options.cpp
+++ b/examples/cpp/init_with_default_options.cpp
@@ -1,5 +1,5 @@
 #include <proxsuite/proxqp/dense/dense.hpp> // load the dense solver backend
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite::proxqp;
 using T = double;
@@ -12,30 +12,30 @@ main()
   // generate a random qp
   T sparsity_factor(0.15);
   T strong_convexity_factor(1.e-2);
-  dense::Model<T> qp = utils::dense_strongly_convex_qp(
+  dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(
+  dense::QP<T> qp(
     dim, n_eq, n_in); // create the QP
                       // initialize the model, along with another rho parameter
-  Qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
-  Qp.init(qp.H,
-          qp.g,
-          qp.A,
-          qp.b,
-          qp.C,
-          qp.u,
-          qp.l,
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
           true,
           /*rho*/ 1.e-7,
           /*mu_eq*/ 1.e-4);
-  // Initializing rho sets in practive Qp.settings.default_rho value,
-  // hence, after each solve or update method, the Qp.results.info.rho value
-  // will be reset to Qp.settings.default_rho value.
-  Qp.solve();
-  // So if we redo a solve, Qp.settings.default_rho value = 1.e-7, hence
-  // Qp.results.info.rho restarts at 1.e-7 The same occurs for mu_eq.
-  Qp.solve();
+  // Initializing rho sets in practive qp.settings.default_rho value,
+  // hence, after each solve or update method, the qp.results.info.rho value
+  // will be reset to qp.settings.default_rho value.
+  qp.solve();
+  // So if we redo a solve, qp.settings.default_rho value = 1.e-7, hence
+  // qp.results.info.rho restarts at 1.e-7 The same occurs for mu_eq.
+  qp.solve();
   // There might be a different result with WARM_START_WITH_PREVIOUS_RESULT
   // initial guess option, as by construction, it reuses the last proximal step
   // sizes of the last solving method.

--- a/examples/cpp/init_with_default_options.cpp
+++ b/examples/cpp/init_with_default_options.cpp
@@ -18,15 +18,25 @@ main()
   dense::QP<T> Qp(
     dim, n_eq, n_in); // create the QP
                       // initialize the model, along with another rho parameter
-  Qp.settings.initial_guess.NO_INITIAL_GUESS; 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true, /*rho*/ 1.e-7, /*mu_eq*/ 1.e-4);
+  Qp.settings.initial_guess.NO_INITIAL_GUESS;
+  Qp.init(qp.H,
+          qp.g,
+          qp.A,
+          qp.b,
+          qp.C,
+          qp.u,
+          qp.l,
+          true,
+          /*rho*/ 1.e-7,
+          /*mu_eq*/ 1.e-4);
   // Initializing rho sets in practive Qp.settings.default_rho value,
-  // hence, after each solve or update method, the Qp.results.info.rho value will be reset to
-  // Qp.settings.default_rho value. 
+  // hence, after each solve or update method, the Qp.results.info.rho value
+  // will be reset to Qp.settings.default_rho value.
   Qp.solve();
-  // So if we redo a solve, Qp.settings.default_rho value = 1.e-7, hence Qp.results.info.rho restarts at 1.e-7
-  // The same occurs for mu_eq.
+  // So if we redo a solve, Qp.settings.default_rho value = 1.e-7, hence
+  // Qp.results.info.rho restarts at 1.e-7 The same occurs for mu_eq.
   Qp.solve();
-  // There might be a different result with WARM_START_WITH_PREVIOUS_RESULT initial guess option, as by
-  // construction, it reuses the last proximal step sizes of the last solving method.
+  // There might be a different result with WARM_START_WITH_PREVIOUS_RESULT
+  // initial guess option, as by construction, it reuses the last proximal step
+  // sizes of the last solving method.
 }

--- a/examples/cpp/init_with_default_options.cpp
+++ b/examples/cpp/init_with_default_options.cpp
@@ -1,0 +1,32 @@
+#include <proxsuite/proxqp/dense/dense.hpp> // load the dense solver backend
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+
+using namespace proxsuite::proxqp;
+using T = double;
+int
+main()
+{
+  isize dim = 10;
+  isize n_eq(dim / 4);
+  isize n_in(dim / 4);
+  // generate a random qp
+  T sparsity_factor(0.15);
+  T strong_convexity_factor(1.e-2);
+  dense::Model<T> qp = utils::dense_strongly_convex_qp(
+    dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
+
+  dense::QP<T> Qp(
+    dim, n_eq, n_in); // create the QP
+                      // initialize the model, along with another rho parameter
+  Qp.settings.initial_guess.NO_INITIAL_GUESS; 
+  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true, /*rho*/ 1.e-7, /*mu_eq*/ 1.e-4);
+  // Initializing rho sets in practive Qp.settings.default_rho value,
+  // hence, after each solve or update method, the Qp.results.info.rho value will be reset to
+  // Qp.settings.default_rho value. 
+  Qp.solve();
+  // So if we redo a solve, Qp.settings.default_rho value = 1.e-7, hence Qp.results.info.rho restarts at 1.e-7
+  // The same occurs for mu_eq.
+  Qp.solve();
+  // There might be a different result with WARM_START_WITH_PREVIOUS_RESULT initial guess option, as by
+  // construction, it reuses the last proximal step sizes of the last solving method.
+}

--- a/examples/cpp/initializing_with_none.cpp
+++ b/examples/cpp/initializing_with_none.cpp
@@ -1,5 +1,5 @@
 #include "proxsuite/proxqp/dense/dense.hpp"
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite::proxqp;
 using T = double;
@@ -9,27 +9,27 @@ main()
   dense::isize dim = 10;
   dense::isize n_eq(0);
   dense::isize n_in(0);
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
   T strong_convexity_factor(0.1);
   T sparsity_factor(0.15);
   // we generate a qp, so the function used from helpers.hpp is
   // in proxqp namespace. The qp is in dense eigen format and
   // you can control its sparsity ratio and strong convexity factor.
-  dense::Model<T> qp = utils::dense_strongly_convex_qp(
+  dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  Qp.init(qp.H,
-          qp.g,
-          qp.A,
-          qp.b,
-          qp.C,
-          qp.u,
-          qp.l); // initialization with zero shape matrices
-  // it is equivalent to do Qp.init(qp.H, qp.g,
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l); // initialization with zero shape matrices
+  // it is equivalent to do qp.init(qp_random.H, qp_random.g,
   // std::nullopt,std::nullopt,std::nullopt,std::nullopt,std::nullopt);
-  Qp.solve();
+  qp.solve();
   // print an optimal solution x,y and z
-  std::cout << "optimal x: " << Qp.results.x << std::endl;
-  std::cout << "optimal y: " << Qp.results.y << std::endl;
-  std::cout << "optimal z: " << Qp.results.z << std::endl;
+  std::cout << "optimal x: " << qp.results.x << std::endl;
+  std::cout << "optimal y: " << qp.results.y << std::endl;
+  std::cout << "optimal z: " << qp.results.z << std::endl;
 }

--- a/examples/cpp/initializing_with_none_without_api.cpp
+++ b/examples/cpp/initializing_with_none_without_api.cpp
@@ -1,5 +1,5 @@
 #include "proxsuite/proxqp/dense/dense.hpp"
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite::proxqp;
 using T = double;
@@ -14,18 +14,18 @@ main()
   // we generate a qp, so the function used from helpers.hpp is
   // in proxqp namespace. The qp is in dense eigen format and
   // you can control its sparsity ratio and strong convexity factor.
-  dense::Model<T> qp = utils::dense_strongly_convex_qp(
+  dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
   Results<T> results =
-    dense::solve<T>(qp.H,
-                    qp.g,
-                    qp.A,
-                    qp.b,
-                    qp.C,
-                    qp.u,
-                    qp.l); // initialization with zero shape matrices
-  // it is equivalent to do dense::solve<T>(qp.H, qp.g,
+    dense::solve<T>(qp_random.H,
+                    qp_random.g,
+                    qp_random.A,
+                    qp_random.b,
+                    qp_random.C,
+                    qp_random.u,
+                    qp_random.l); // initialization with zero shape matrices
+  // it is equivalent to do dense::solve<T>(qp_random.H, qp_random.g,
   // std::nullopt,std::nullopt,std::nullopt,std::nullopt,std::nullopt);
   //  print an optimal solution x,y and z
   std::cout << "optimal x: " << results.x << std::endl;

--- a/examples/cpp/loading_dense_qp.cpp
+++ b/examples/cpp/loading_dense_qp.cpp
@@ -8,5 +8,5 @@ main()
   dense::isize dim = 10;
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 }

--- a/examples/cpp/loading_sparse_qp.cpp
+++ b/examples/cpp/loading_sparse_qp.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <proxsuite/proxqp/sparse/sparse.hpp> // get the sparse API of ProxQP
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite::proxqp;
 using T = double;
@@ -8,11 +8,11 @@ using T = double;
 int
 main()
 {
-  // design a Qp object using QP problem dimensions
+  // design a qp object using QP problem dimensions
   isize n = 10;
   isize n_eq(n / 4);
   isize n_in(n / 4);
-  sparse::QP<T, isize> Qp(n, n_eq, n_in);
+  sparse::QP<T, isize> qp(n, n_eq, n_in);
 
   // assume you generate these matrices H, A and C for your QP problem
 
@@ -24,7 +24,7 @@ main()
   auto A = ::proxsuite::proxqp::utils::rand::sparse_matrix_rand<T>(n_eq, n, p);
   auto C = ::proxsuite::proxqp::utils::rand::sparse_matrix_rand<T>(n_in, n, p);
 
-  // design a Qp2 object using sparsity masks of H, A and C
-  proxsuite::proxqp::sparse::QP<T, isize> Qp2(
+  // design a qp2 object using sparsity masks of H, A and C
+  proxsuite::proxqp::sparse::QP<T, isize> qp2(
     H.cast<bool>(), A.cast<bool>(), C.cast<bool>());
 }

--- a/examples/cpp/overview-simple.cpp
+++ b/examples/cpp/overview-simple.cpp
@@ -1,5 +1,5 @@
 #include <proxsuite/proxqp/dense/dense.hpp>
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite::proxqp;
 using T = double;
@@ -16,15 +16,15 @@ main()
   // we generate a qp, so the function used from helpers.hpp is
   // in proxqp namespace. The qp is in dense eigen format and
   // you can control its sparsity ratio and strong convexity factor.
-  dense::Model<T> qp = utils::dense_strongly_convex_qp(
+  dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
   // load PROXQP solver with dense backend and solve the problem
-  dense::QP<T> Qp(dim, n_eq, n_in);
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  dense::QP<T> qp(dim, n_eq, n_in);
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
   // print an optimal solution x,y and z
-  std::cout << "optimal x: " << Qp.results.x << std::endl;
-  std::cout << "optimal y: " << Qp.results.y << std::endl;
-  std::cout << "optimal z: " << Qp.results.z << std::endl;
+  std::cout << "optimal x: " << qp.results.x << std::endl;
+  std::cout << "optimal y: " << qp.results.y << std::endl;
+  std::cout << "optimal z: " << qp.results.z << std::endl;
 }

--- a/examples/cpp/overview-simple.cpp
+++ b/examples/cpp/overview-simple.cpp
@@ -21,7 +21,13 @@ main()
 
   // load PROXQP solver with dense backend and solve the problem
   dense::QP<T> qp(dim, n_eq, n_in);
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
   // print an optimal solution x,y and z
   std::cout << "optimal x: " << qp.results.x << std::endl;

--- a/examples/cpp/solve_dense_qp.cpp
+++ b/examples/cpp/solve_dense_qp.cpp
@@ -17,9 +17,15 @@ main()
   dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> qp(dim, n_eq, n_in);                  // create the QP object
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l); // initialize the model
-  qp.solve(); // solve the problem without warm start
+  dense::QP<T> qp(dim, n_eq, n_in); // create the QP object
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l); // initialize the model
+  qp.solve();           // solve the problem without warm start
   auto x_wm = utils::rand::vector_rand<T>(dim);
   auto y_wm = utils::rand::vector_rand<T>(n_eq);
   auto z_wm = utils::rand::vector_rand<T>(n_in);

--- a/examples/cpp/solve_dense_qp.cpp
+++ b/examples/cpp/solve_dense_qp.cpp
@@ -1,5 +1,5 @@
 #include <proxsuite/proxqp/dense/dense.hpp> // load the dense solver backend
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite::proxqp;
 using T = double;
@@ -14,19 +14,19 @@ main()
   T sparsity_factor(0.15);
   T strong_convexity_factor(1.e-2);
 
-  dense::Model<T> qp = utils::dense_strongly_convex_qp(
+  dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);                  // create the QP object
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l); // initialize the model
-  Qp.solve(); // solve the problem without warm start
+  dense::QP<T> qp(dim, n_eq, n_in);                  // create the QP object
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l); // initialize the model
+  qp.solve(); // solve the problem without warm start
   auto x_wm = utils::rand::vector_rand<T>(dim);
   auto y_wm = utils::rand::vector_rand<T>(n_eq);
   auto z_wm = utils::rand::vector_rand<T>(n_in);
-  Qp.solve(x_wm, y_wm,
+  qp.solve(x_wm, y_wm,
            z_wm); // if you have a warm start, put it here
   // print an optimal solution x,y and z
-  std::cout << "optimal x: " << Qp.results.x << std::endl;
-  std::cout << "optimal y: " << Qp.results.y << std::endl;
-  std::cout << "optimal z: " << Qp.results.z << std::endl;
+  std::cout << "optimal x: " << qp.results.x << std::endl;
+  std::cout << "optimal y: " << qp.results.y << std::endl;
+  std::cout << "optimal z: " << qp.results.z << std::endl;
 }

--- a/examples/cpp/solve_dense_qp_with_setting.cpp
+++ b/examples/cpp/solve_dense_qp_with_setting.cpp
@@ -1,5 +1,5 @@
 #include <proxsuite/proxqp/dense/dense.hpp> // load the dense solver backend
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite::proxqp;
 using T = double;
@@ -13,16 +13,16 @@ main()
   // generate a random qp
   T sparsity_factor(0.15);
   T strong_convexity_factor(1.e-2);
-  dense::Model<T> qp = utils::dense_strongly_convex_qp(
+  dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);                  // create the QP object
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l); // initialize the model
-  Qp.settings.eps_abs = T(1.E-9); // set accuracy threshold to 1.e-9
-  Qp.settings.verbose = true;     // print some intermediary results
-  Qp.solve();                     // solve the problem with previous settings
+  dense::QP<T> qp(dim, n_eq, n_in);                  // create the QP object
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l); // initialize the model
+  qp.settings.eps_abs = T(1.E-9); // set accuracy threshold to 1.e-9
+  qp.settings.verbose = true;     // print some intermediary results
+  qp.solve();                     // solve the problem with previous settings
   // print an optimal solution x,y and z
-  std::cout << "optimal x: " << Qp.results.x << std::endl;
-  std::cout << "optimal y: " << Qp.results.y << std::endl;
-  std::cout << "optimal z: " << Qp.results.z << std::endl;
+  std::cout << "optimal x: " << qp.results.x << std::endl;
+  std::cout << "optimal y: " << qp.results.y << std::endl;
+  std::cout << "optimal z: " << qp.results.z << std::endl;
 }

--- a/examples/cpp/solve_dense_qp_with_setting.cpp
+++ b/examples/cpp/solve_dense_qp_with_setting.cpp
@@ -16,8 +16,14 @@ main()
   dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> qp(dim, n_eq, n_in);                  // create the QP object
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l); // initialize the model
+  dense::QP<T> qp(dim, n_eq, n_in); // create the QP object
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);           // initialize the model
   qp.settings.eps_abs = T(1.E-9); // set accuracy threshold to 1.e-9
   qp.settings.verbose = true;     // print some intermediary results
   qp.solve();                     // solve the problem with previous settings

--- a/examples/cpp/solve_without_api.cpp
+++ b/examples/cpp/solve_without_api.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include "proxsuite/proxqp/sparse/sparse.hpp" // get the sparse backend of ProxQP
 #include "proxsuite/proxqp/dense/dense.hpp"   // get the dense backend of ProxQP
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite::proxqp;
 using T = double;

--- a/examples/cpp/solve_without_api_and_option.cpp
+++ b/examples/cpp/solve_without_api_and_option.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <proxsuite/proxqp/sparse/sparse.hpp> // get the sparse backend of ProxQP
 #include <proxsuite/proxqp/dense/dense.hpp>   // get the dense backend of ProxQP
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite::proxqp;
 using T = double;

--- a/examples/cpp/update_dense_qp.cpp
+++ b/examples/cpp/update_dense_qp.cpp
@@ -16,10 +16,16 @@ main()
   dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> qp(dim, n_eq, n_in);                  // create the QP object
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l); // initialize the model
-  qp.solve();                                        // solve the problem
-                                                     // a new qp problem
+  dense::QP<T> qp(dim, n_eq, n_in); // create the QP object
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l); // initialize the model
+  qp.solve();           // solve the problem
+                        // a new qp problem
   dense::Model<T> qp2 = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
   // re update the model

--- a/examples/cpp/update_dense_qp.cpp
+++ b/examples/cpp/update_dense_qp.cpp
@@ -1,5 +1,5 @@
 #include <proxsuite/proxqp/dense/dense.hpp> // load the dense solver backend
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite::proxqp;
 using T = double;
@@ -13,21 +13,21 @@ main()
   // generate a random qp
   T sparsity_factor(0.15);
   T strong_convexity_factor(1.e-2);
-  dense::Model<T> qp = utils::dense_strongly_convex_qp(
+  dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);                  // create the QP object
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l); // initialize the model
-  Qp.solve();                                        // solve the problem
-                                                     // a new Qp problem
+  dense::QP<T> qp(dim, n_eq, n_in);                  // create the QP object
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l); // initialize the model
+  qp.solve();                                        // solve the problem
+                                                     // a new qp problem
   dense::Model<T> qp2 = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
   // re update the model
-  Qp.update(qp2.H, qp2.g, qp2.A, qp2.b, qp2.C, qp2.u, qp2.l);
+  qp.update(qp2.H, qp2.g, qp2.A, qp2.b, qp2.C, qp2.u, qp2.l);
   // solve it
-  Qp.solve();
+  qp.solve();
   // print an optimal solution x,y and z
-  std::cout << "optimal x: " << Qp.results.x << std::endl;
-  std::cout << "optimal y: " << Qp.results.y << std::endl;
-  std::cout << "optimal z: " << Qp.results.z << std::endl;
+  std::cout << "optimal x: " << qp.results.x << std::endl;
+  std::cout << "optimal y: " << qp.results.y << std::endl;
+  std::cout << "optimal z: " << qp.results.z << std::endl;
 }

--- a/examples/cpp/update_dense_qp_ws_previous_result.cpp
+++ b/examples/cpp/update_dense_qp_ws_previous_result.cpp
@@ -16,9 +16,15 @@ main()
   dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> qp(dim, n_eq, n_in);                  // create the QP object
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l); // initialize the model
-  qp.solve();                                        // solve the problem
+  dense::QP<T> qp(dim, n_eq, n_in); // create the QP object
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l); // initialize the model
+  qp.solve();           // solve the problem
   // re update the linear cost taking previous result
   qp.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;

--- a/examples/cpp/update_dense_qp_ws_previous_result.cpp
+++ b/examples/cpp/update_dense_qp_ws_previous_result.cpp
@@ -1,5 +1,5 @@
 #include <proxsuite/proxqp/dense/dense.hpp> // load the dense solver backend
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite;
 using namespace proxsuite::proxqp;
@@ -13,30 +13,30 @@ main()
   // generate a random qp
   T sparsity_factor(0.15);
   T strong_convexity_factor(1.e-2);
-  dense::Model<T> qp = utils::dense_strongly_convex_qp(
+  dense::Model<T> qp_random = utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);                  // create the QP object
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l); // initialize the model
-  Qp.solve();                                        // solve the problem
+  dense::QP<T> qp(dim, n_eq, n_in);                  // create the QP object
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l); // initialize the model
+  qp.solve();                                        // solve the problem
   // re update the linear cost taking previous result
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
   // it takes effect at the update because it is set before
   // (the workspace is not erased at the update method, hence
   // the previous factorization is kept)
   // a new linear cost slightly modified
-  auto g = qp.g * 0.95;
-  Qp.update(std::nullopt,
+  auto g = qp_random.g * 0.95;
+  qp.update(std::nullopt,
             g,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt);
-  Qp.solve();
+  qp.solve();
   // print an optimal solution x,y and z
-  std::cout << "optimal x: " << Qp.results.x << std::endl;
-  std::cout << "optimal y: " << Qp.results.y << std::endl;
-  std::cout << "optimal z: " << Qp.results.z << std::endl;
+  std::cout << "optimal x: " << qp.results.x << std::endl;
+  std::cout << "optimal y: " << qp.results.y << std::endl;
+  std::cout << "optimal z: " << qp.results.z << std::endl;
 }

--- a/examples/cpp/update_sparse_qp.cpp
+++ b/examples/cpp/update_sparse_qp.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <proxsuite/proxqp/sparse/sparse.hpp> // get the sparse API of ProxQP
-#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex Qp
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp> // used for generating a random convex qp
 
 using namespace proxsuite::proxqp;
 using T = double;
@@ -23,25 +23,25 @@ main()
   auto b = A * x_sol;
   auto l = C * x_sol;
   auto u = (l.array() + 10).matrix().eval();
-  // design a Qp2 object using sparsity masks of H, A and C
-  proxsuite::proxqp::sparse::QP<T, int> Qp(
+  // design a qp2 object using sparsity masks of H, A and C
+  proxsuite::proxqp::sparse::QP<T, int> qp(
     H.cast<bool>(), A.cast<bool>(), C.cast<bool>());
-  Qp.init(H, g, A, b, C, u, l);
-  Qp.solve();
+  qp.init(H, g, A, b, C, u, l);
+  qp.solve();
   // update H
   auto H_new = 2 * H; // keep the same sparsity structure
-  Qp.update(H_new,
+  qp.update(H_new,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt); // update H with H_new, it will work
-  Qp.solve();
+  qp.solve();
   // generate H2 with another sparsity structure
   auto H2 = ::proxsuite::proxqp::utils::rand::sparse_positive_definite_rand(
     n, conditioning, p);
-  Qp.update(H2,
+  qp.update(H2,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -50,21 +50,21 @@ main()
             std::nullopt); // nothing will happen
   // if only a vector changes, then the update takes effect
   auto g_new = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             g,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt);
-  Qp.solve(); // it solves the problem with another vector
-  // to solve the problem with H2 matrix create a new Qp object
-  proxsuite::proxqp::sparse::QP<T, isize> Qp2(
+  qp.solve(); // it solves the problem with another vector
+  // to solve the problem with H2 matrix create a new qp object
+  proxsuite::proxqp::sparse::QP<T, isize> qp2(
     H2.cast<bool>(), A.cast<bool>(), C.cast<bool>());
-  Qp2.init(H2, g_new, A, b, C, u, l);
-  Qp2.solve(); // it will solve the new problem
+  qp2.init(H2, g_new, A, b, C, u, l);
+  qp2.solve(); // it will solve the new problem
   // print an optimal solution x,y and z
-  std::cout << "optimal x: " << Qp2.results.x << std::endl;
-  std::cout << "optimal y: " << Qp2.results.y << std::endl;
-  std::cout << "optimal z: " << Qp2.results.z << std::endl;
+  std::cout << "optimal x: " << qp2.results.x << std::endl;
+  std::cout << "optimal y: " << qp2.results.y << std::endl;
+  std::cout << "optimal z: " << qp2.results.z << std::endl;
 }

--- a/examples/julia/overview-simple.jl
+++ b/examples/julia/overview-simple.jl
@@ -42,14 +42,14 @@ n_eq = A.shape[1]
 n_in = C.shape[1]
 
 # solve it
-Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-Qp.settings.eps_abs = EPS
-Qp.init(H, g, A, b, C, u, l)
-Qp.solve()
+qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+qp.settings.eps_abs = EPS
+qp.init(H, g, A, b, C, u, l)
+qp.solve()
 
-x_res = Qp.results.x
-y_res = Qp.results.y
-z_res = Qp.results.z
+x_res = qp.results.x
+y_res = qp.results.y
+z_res = qp.results.z
 
 # calculate primal and dual residual
 prim_res = max(
@@ -59,15 +59,15 @@ prim_res = max(
 dual_res = np.linalg.norm(H * x_res + g + np.transpose(A) * y_res + np.transpose(C) * z_res )
 
 # assert that solved with required precision
-@assert Qp.results.info.pri_res < EPS
-@assert Qp.results.info.dua_res < EPS
-@assert np.isclose(prim_res, Qp.results.info.pri_res)
-@assert np.isclose(dual_res, Qp.results.info.dua_res)
+@assert qp.results.info.pri_res < EPS
+@assert qp.results.info.dua_res < EPS
+@assert np.isclose(prim_res, qp.results.info.pri_res)
+@assert np.isclose(dual_res, qp.results.info.dua_res)
 
 # print stats
 @printf("Done solving the qp with dim %i having %i equality and %i inequality constraints.\n", n, n_eq, n_in)
-@printf("Primal residual: %f\n", Qp.results.info.pri_res)
-@printf("Dual residual: %f\n", Qp.results.info.dua_res)
-@printf("Total number of iteration %i.\n", Qp.results.info.iter)
-@printf("Setup time %fms, solve time %fms.\n", Qp.results.info.setup_time, Qp.results.info.solve_time)
-@printf("Epsilon absolute %f, epsilon relative %f.\n", Qp.settings.eps_abs, Qp.settings.eps_rel)
+@printf("Primal residual: %f\n", qp.results.info.pri_res)
+@printf("Dual residual: %f\n", qp.results.info.dua_res)
+@printf("Total number of iteration %i.\n", qp.results.info.iter)
+@printf("Setup time %fms, solve time %fms.\n", qp.results.info.setup_time, qp.results.info.solve_time)
+@printf("Epsilon absolute %f, epsilon relative %f.\n", qp.settings.eps_abs, qp.settings.eps_rel)

--- a/examples/python/init_dense_qp.py
+++ b/examples/python/init_dense_qp.py
@@ -4,7 +4,7 @@ import scipy.sparse as spa
 
 
 def generate_mixed_qp(n, seed=1):
-    # A function for generating random convex Qps
+    # A function for generating random convex qps
 
     np.random.seed(seed)
     n_eq = int(n / 4)
@@ -29,12 +29,12 @@ def generate_mixed_qp(n, seed=1):
     return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
 
 
-# load a Qp object using Qp problem dimensions
+# load a qp object using qp problem dimensions
 n = 10
 n_eq = 2
 n_in = 2
-Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
 # generate a random QP
 H, g, A, b, C, u, l = generate_mixed_qp(n)
 # initialize the model of the problem to solve
-Qp.init(H, g, A, b, C, u, l)
+qp.init(H, g, A, b, C, u, l)

--- a/examples/python/init_dense_qp_with_other_options.py
+++ b/examples/python/init_dense_qp_with_other_options.py
@@ -4,7 +4,7 @@ import scipy.sparse as spa
 
 
 def generate_mixed_qp(n, seed=1):
-    # A function for generating random convex Qps
+    # A function for generating random convex qps
 
     np.random.seed(seed)
     n_eq = int(n / 4)
@@ -29,12 +29,12 @@ def generate_mixed_qp(n, seed=1):
     return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
 
 
-# load a Qp object using Qp problem dimensions
+# load a qp object using qp problem dimensions
 n = 10
 n_eq = 2
 n_in = 2
-Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
 # generate a random QP
 H, g, A, b, C, u, l = generate_mixed_qp(n)
 # initialize the model of the problem to solve with another rho parameter
-Qp.init(H, g, A, b, C, u, l, rho=1.0e-7)
+qp.init(H, g, A, b, C, u, l, rho=1.0e-7)

--- a/examples/python/init_dense_qp_with_timings.py
+++ b/examples/python/init_dense_qp_with_timings.py
@@ -4,7 +4,7 @@ import scipy.sparse as spa
 
 
 def generate_mixed_qp(n, seed=1):
-    # A function for generating random convex Qps
+    # A function for generating random convex qps
 
     np.random.seed(seed)
     n_eq = int(n / 4)
@@ -29,13 +29,13 @@ def generate_mixed_qp(n, seed=1):
     return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
 
 
-# load a Qp object using Qp problem dimensions
+# load a qp object using qp problem dimensions
 n = 10
 n_eq = 2
 n_in = 2
-Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
 # generate a random QP
 H, g, A, b, C, u, l = generate_mixed_qp(n)
 # initialize the model of the problem to solve
-Qp.settings.compute_timings  # compute all timings
-Qp.init(H, g, A, b, C, u, l)
+qp.settings.compute_timings  # compute all timings
+qp.init(H, g, A, b, C, u, l)

--- a/examples/python/init_with_default_options.py
+++ b/examples/python/init_with_default_options.py
@@ -37,7 +37,7 @@ Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
 # generate a random QP
 H, g, A, b, C, u, l = generate_mixed_qp(n)
 # initialize the model of the problem to solve
-Qp.init(H, g, A, b, C, u, l,rho=1.e-7,mu_eq=1.e_4)
+Qp.init(H, g, A, b, C, u, l,rho=1.e-7,mu_eq=1.e-4)
 Qp.solve()
 # If we redo a solve, Qp.settings.default_rho value = 1.e-7, hence Qp.results.info.rho restarts at 1.e-7
 # The same occurs for mu_eq.

--- a/examples/python/init_with_default_options.py
+++ b/examples/python/init_with_default_options.py
@@ -37,7 +37,7 @@ Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
 # generate a random QP
 H, g, A, b, C, u, l = generate_mixed_qp(n)
 # initialize the model of the problem to solve
-Qp.init(H, g, A, b, C, u, l,rho=1.e-7,mu_eq=1.e-4)
+Qp.init(H, g, A, b, C, u, l, rho=1.0e-7, mu_eq=1.0e-4)
 Qp.solve()
 # If we redo a solve, Qp.settings.default_rho value = 1.e-7, hence Qp.results.info.rho restarts at 1.e-7
 # The same occurs for mu_eq.

--- a/examples/python/init_with_default_options.py
+++ b/examples/python/init_with_default_options.py
@@ -4,7 +4,7 @@ import scipy.sparse as spa
 
 
 def generate_mixed_qp(n, seed=1):
-    # A function for generating random convex Qps
+    # A function for generating random convex qps
 
     np.random.seed(seed)
     n_eq = int(n / 4)
@@ -29,18 +29,18 @@ def generate_mixed_qp(n, seed=1):
     return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
 
 
-# load a Qp object using Qp problem dimensions
+# load a qp object using qp problem dimensions
 n = 10
 n_eq = 2
 n_in = 2
-Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
 # generate a random QP
 H, g, A, b, C, u, l = generate_mixed_qp(n)
 # initialize the model of the problem to solve
-Qp.init(H, g, A, b, C, u, l, rho=1.0e-7, mu_eq=1.0e-4)
-Qp.solve()
-# If we redo a solve, Qp.settings.default_rho value = 1.e-7, hence Qp.results.info.rho restarts at 1.e-7
+qp.init(H, g, A, b, C, u, l, rho=1.0e-7, mu_eq=1.0e-4)
+qp.solve()
+# If we redo a solve, qp.settings.default_rho value = 1.e-7, hence qp.results.info.rho restarts at 1.e-7
 # The same occurs for mu_eq.
-Qp.solve()
+qp.solve()
 # There might be a different result with WARM_START_WITH_PREVIOUS_RESULT initial guess option, as
 # by construction, it reuses the last proximal step sizes of the last solving method.

--- a/examples/python/init_with_default_options.py
+++ b/examples/python/init_with_default_options.py
@@ -1,0 +1,46 @@
+import proxsuite
+import numpy as np
+import scipy.sparse as spa
+
+
+def generate_mixed_qp(n, seed=1):
+    # A function for generating random convex Qps
+
+    np.random.seed(seed)
+    n_eq = int(n / 4)
+    n_in = int(n / 4)
+    m = n_eq + n_in
+
+    P = spa.random(
+        n, n, density=0.075, data_rvs=np.random.randn, format="csc"
+    ).toarray()
+    P = (P + P.T) / 2.0
+
+    s = max(np.absolute(np.linalg.eigvals(P)))
+    P += (abs(s) + 1e-02) * spa.eye(n)
+    P = spa.coo_matrix(P)
+    q = np.random.randn(n)
+    A = spa.random(m, n, density=0.15, data_rvs=np.random.randn, format="csc")
+    v = np.random.randn(n)  # Fictitious solution
+    delta = np.random.rand(m)  # To get inequality
+    u = A @ v
+    l = -1.0e20 * np.ones(m)
+
+    return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
+
+
+# load a Qp object using Qp problem dimensions
+n = 10
+n_eq = 2
+n_in = 2
+Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+# generate a random QP
+H, g, A, b, C, u, l = generate_mixed_qp(n)
+# initialize the model of the problem to solve
+Qp.init(H, g, A, b, C, u, l,rho=1.e-7,mu_eq=1.e_4)
+Qp.solve()
+# If we redo a solve, Qp.settings.default_rho value = 1.e-7, hence Qp.results.info.rho restarts at 1.e-7
+# The same occurs for mu_eq.
+Qp.solve()
+# There might be a different result with WARM_START_WITH_PREVIOUS_RESULT initial guess option, as
+# by construction, it reuses the last proximal step sizes of the last solving method.

--- a/examples/python/initializing_with_none.py
+++ b/examples/python/initializing_with_none.py
@@ -9,7 +9,7 @@ C = None
 u = None
 l = None
 
-Qp = proxsuite.proxqp.dense.QP(3, 0, 0)
-Qp.init(H, g, A, b, C, u, l)  # it is equivalent to do as well Qp.init(H, g)
-Qp.solve()
-print("optimal x: {}".format(Qp.results.x))
+qp = proxsuite.proxqp.dense.QP(3, 0, 0)
+qp.init(H, g, A, b, C, u, l)  # it is equivalent to do as well qp.init(H, g)
+qp.solve()
+print("optimal x: {}".format(qp.results.x))

--- a/examples/python/loading_dense_qp.py
+++ b/examples/python/loading_dense_qp.py
@@ -3,4 +3,4 @@ import proxsuite
 n = 10
 n_eq = 2
 n_in = 2
-Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)

--- a/examples/python/loading_sparse_qp.py
+++ b/examples/python/loading_sparse_qp.py
@@ -1,17 +1,17 @@
 import proxsuite
 
-# load a Qp object using Qp problem dimensions
+# load a qp object using qp problem dimensions
 n = 10
 n_eq = 2
 n_in = 2
-Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
 
 import numpy as np
 import scipy.sparse as spa
 
 
 def generate_mixed_qp(n, seed=1):
-    # A function for generating random convex Qps
+    # A function for generating random convex qps
 
     np.random.seed(seed)
     n_eq = int(n / 4)
@@ -36,10 +36,10 @@ def generate_mixed_qp(n, seed=1):
     return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
 
 
-# load a Qp2 object using matrix masks
+# load a qp2 object using matrix masks
 H, g, A, b, C, u, l = generate_mixed_qp(n)
 
 H_ = H != 0.0
 A_ = A != 0.0
 C_ = C != 0.0
-Qp2 = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+qp2 = proxsuite.proxqp.sparse.QP(H_, A_, C_)

--- a/examples/python/overview-simple.py
+++ b/examples/python/overview-simple.py
@@ -35,10 +35,10 @@ n_eq = A.shape[0]
 n_in = C.shape[0]
 
 # solve it
-Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-Qp.init(H, g, A, b, C, u, l)
-Qp.solve()
+qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+qp.init(H, g, A, b, C, u, l)
+qp.solve()
 # print an optimal solution
-print("optimal x: {}".format(Qp.results.x))
-print("optimal y: {}".format(Qp.results.y))
-print("optimal z: {}".format(Qp.results.z))
+print("optimal x: {}".format(qp.results.x))
+print("optimal y: {}".format(qp.results.y))
+print("optimal z: {}".format(qp.results.z))

--- a/examples/python/solve_dense_qp.py
+++ b/examples/python/solve_dense_qp.py
@@ -4,7 +4,7 @@ import scipy.sparse as spa
 
 
 def generate_mixed_qp(n, seed=1):
-    # A function for generating random convex Qps
+    # A function for generating random convex qps
 
     np.random.seed(seed)
     n_eq = int(n / 4)
@@ -29,20 +29,20 @@ def generate_mixed_qp(n, seed=1):
     return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
 
 
-# load a Qp object using Qp problem dimensions
+# load a qp object using qp problem dimensions
 n = 10
 n_eq = 2
 n_in = 2
-Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
 # generate a random QP
 H, g, A, b, C, u, l = generate_mixed_qp(n)
 # initialize the model of the problem to solve
-Qp.init(H, g, A, b, C, u, l)
+qp.init(H, g, A, b, C, u, l)
 # solve without warm start
-Qp.solve()
+qp.solve()
 # solve with a warm start, for ex random one
-Qp.solve(np.random.randn(n), np.random.randn(n_eq), np.random.randn(n_in))
+qp.solve(np.random.randn(n), np.random.randn(n_eq), np.random.randn(n_in))
 # print an optimal solution
-print("optimal x: {}".format(Qp.results.x))
-print("optimal y: {}".format(Qp.results.y))
-print("optimal z: {}".format(Qp.results.z))
+print("optimal x: {}".format(qp.results.x))
+print("optimal y: {}".format(qp.results.y))
+print("optimal z: {}".format(qp.results.z))

--- a/examples/python/solve_dense_qp_with_setting.py
+++ b/examples/python/solve_dense_qp_with_setting.py
@@ -4,7 +4,7 @@ import scipy.sparse as spa
 
 
 def generate_mixed_qp(n, seed=1):
-    # A function for generating random convex Qps
+    # A function for generating random convex qps
 
     np.random.seed(seed)
     n_eq = int(n / 4)
@@ -29,20 +29,20 @@ def generate_mixed_qp(n, seed=1):
     return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
 
 
-# load a Qp object using Qp problem dimensions
+# load a qp object using qp problem dimensions
 n = 10
 n_eq = 2
 n_in = 2
-Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
 # generate a random QP
 H, g, A, b, C, u, l = generate_mixed_qp(n)
 # initialize the model of the problem to solve
-Qp.init(H, g, A, b, C, u, l)
-Qp.settings.eps_abs = 1.0e-9
-Qp.settings.verbose = True
+qp.init(H, g, A, b, C, u, l)
+qp.settings.eps_abs = 1.0e-9
+qp.settings.verbose = True
 # solve with previous settings
-Qp.solve()
+qp.solve()
 # print an optimal solution
-print("optimal x: {}".format(Qp.results.x))
-print("optimal y: {}".format(Qp.results.y))
-print("optimal z: {}".format(Qp.results.z))
+print("optimal x: {}".format(qp.results.x))
+print("optimal y: {}".format(qp.results.y))
+print("optimal z: {}".format(qp.results.z))

--- a/examples/python/solve_without_api.py
+++ b/examples/python/solve_without_api.py
@@ -4,7 +4,7 @@ import scipy.sparse as spa
 
 
 def generate_mixed_qp(n, seed=1):
-    # A function for generating random convex Qps
+    # A function for generating random convex qps
 
     np.random.seed(seed)
     n_eq = int(n / 4)
@@ -29,7 +29,7 @@ def generate_mixed_qp(n, seed=1):
     return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
 
 
-# load a Qp object using Qp problem dimensions
+# load a qp object using qp problem dimensions
 n = 10
 n_eq = 2
 n_in = 2

--- a/examples/python/solve_without_api_and_option.py
+++ b/examples/python/solve_without_api_and_option.py
@@ -4,7 +4,7 @@ import scipy.sparse as spa
 
 
 def generate_mixed_qp(n, seed=1):
-    # A function for generating random convex Qps
+    # A function for generating random convex qps
 
     np.random.seed(seed)
     n_eq = int(n / 4)
@@ -29,7 +29,7 @@ def generate_mixed_qp(n, seed=1):
     return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
 
 
-# load a Qp object using Qp problem dimensions
+# load a qp object using qp problem dimensions
 n = 10
 n_eq = 2
 n_in = 2

--- a/examples/python/update_dense_qp.py
+++ b/examples/python/update_dense_qp.py
@@ -4,7 +4,7 @@ import scipy.sparse as spa
 
 
 def generate_mixed_qp(n, seed=1):
-    # A function for generating random convex Qps
+    # A function for generating random convex qps
 
     np.random.seed(seed)
     n_eq = int(n / 4)
@@ -29,23 +29,23 @@ def generate_mixed_qp(n, seed=1):
     return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
 
 
-# load a Qp object using Qp problem dimensions
+# load a qp object using qp problem dimensions
 n = 10
 n_eq = 2
 n_in = 2
-Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
 # generate a random QP
 H, g, A, b, C, u, l = generate_mixed_qp(n)
 # initialize the model of the problem to solve
-Qp.init(H, g, A, b, C, u, l)
+qp.init(H, g, A, b, C, u, l)
 # solve without warm start
-Qp.solve()
-# create a new problem and update Qp
+qp.solve()
+# create a new problem and update qp
 H_new, g_new, A_new, b_new, C_new, u_new, l_new = generate_mixed_qp(n, seed=2)
-Qp.update(H_new, g_new, A_new, b_new, C_new, u_new, l_new)
+qp.update(H_new, g_new, A_new, b_new, C_new, u_new, l_new)
 # solve it
-Qp.solve()
+qp.solve()
 # print an optimal solution
-print("optimal x: {}".format(Qp.results.x))
-print("optimal y: {}".format(Qp.results.y))
-print("optimal z: {}".format(Qp.results.z))
+print("optimal x: {}".format(qp.results.x))
+print("optimal y: {}".format(qp.results.y))
+print("optimal z: {}".format(qp.results.z))

--- a/examples/python/update_dense_qp_ws_previous_result.py
+++ b/examples/python/update_dense_qp_ws_previous_result.py
@@ -4,7 +4,7 @@ import scipy.sparse as spa
 
 
 def generate_mixed_qp(n, seed=1):
-    # A function for generating random convex Qps
+    # A function for generating random convex qps
 
     np.random.seed(seed)
     n_eq = int(n / 4)
@@ -29,26 +29,26 @@ def generate_mixed_qp(n, seed=1):
     return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
 
 
-# load a Qp object using Qp problem dimensions
+# load a qp object using qp problem dimensions
 n = 10
 n_eq = 2
 n_in = 2
-Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
 # generate a random QP
 H, g, A, b, C, u, l = generate_mixed_qp(n)
 # initialize the model of the problem to solve
-Qp.init(H, g, A, b, C, u, l)
+qp.init(H, g, A, b, C, u, l)
 # solve without warm start
-Qp.solve()
-# create a new problem and update Qp
+qp.solve()
+# create a new problem and update qp
 g_new = 0.95 * g  # slightly different g_new
-Qp.settings.initial_guess = (
+qp.settings.initial_guess = (
     proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
 )
-Qp.update(g=g_new)
+qp.update(g=g_new)
 # solve it
-Qp.solve()
+qp.solve()
 # print an optimal solution
-print("optimal x: {}".format(Qp.results.x))
-print("optimal y: {}".format(Qp.results.y))
-print("optimal z: {}".format(Qp.results.z))
+print("optimal x: {}".format(qp.results.x))
+print("optimal y: {}".format(qp.results.y))
+print("optimal z: {}".format(qp.results.z))

--- a/examples/python/update_sparse_qp.py
+++ b/examples/python/update_sparse_qp.py
@@ -4,7 +4,7 @@ import scipy.sparse as spa
 
 
 def generate_mixed_qp(n, seed=1):
-    # A function for generating random convex Qps
+    # A function for generating random convex qps
 
     np.random.seed(seed)
     n_eq = int(n / 4)
@@ -29,30 +29,30 @@ def generate_mixed_qp(n, seed=1):
     return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
 
 
-# load a Qp object using Qp problem dimensions
+# load a qp object using qp problem dimensions
 n = 10
 n_eq = 2
 n_in = 2
-Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
 # generate a random QP
 H, g, A, b, C, u, l = generate_mixed_qp(n)
 # initialize the model of the problem to solve
-Qp.init(H, g, A, b, C, u, l)
-Qp.solve()
+qp.init(H, g, A, b, C, u, l)
+qp.solve()
 H_new = 2 * H  # keep the same sparsity structure
-Qp.update(H_new)  # update H with H_new, it will work
-Qp.solve()
+qp.update(H_new)  # update H with H_new, it will work
+qp.solve()
 # generate a QP with another sparsity structure
-# create a new problem and update Qp
+# create a new problem and update qp
 H2, g_new, A_new, b_new, C_new, u_new, l_new = generate_mixed_qp(n)
-Qp.update(H=H2)  # nothing will happen
-Qp.update(g=g_new)  # if only a vector changes, then the update takes effect
-Qp.solve()  # it solves the problem with the QP H,g_new,A,b,C,u,l
-# to solve the problem with H2 matrix create a new Qp object in the sparse case
-Qp2 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-Qp2.init(H2, g_new, A, b, C, u, l)
-Qp2.solve()  # it will solve the new problem
+qp.update(H=H2)  # nothing will happen
+qp.update(g=g_new)  # if only a vector changes, then the update takes effect
+qp.solve()  # it solves the problem with the QP H,g_new,A,b,C,u,l
+# to solve the problem with H2 matrix create a new qp object in the sparse case
+qp2 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+qp2.init(H2, g_new, A, b, C, u, l)
+qp2.solve()  # it will solve the new problem
 # print an optimal solution
-print("optimal x: {}".format(Qp.results.x))
-print("optimal y: {}".format(Qp.results.y))
-print("optimal z: {}".format(Qp.results.z))
+print("optimal x: {}".format(qp.results.x))
+print("optimal y: {}".format(qp.results.y))
+print("optimal z: {}".format(qp.results.z))

--- a/include/proxsuite/proxqp/dense/helpers.hpp
+++ b/include/proxsuite/proxqp/dense/helpers.hpp
@@ -474,15 +474,13 @@ setup( //
  */
 template<typename T>
 void
-update_proximal_parameters(
-                           Settings<T>& settings,
+update_proximal_parameters(Settings<T>& settings,
                            Results<T>& results,
                            Workspace<T>& work,
                            std::optional<T> rho_new,
                            std::optional<T> mu_eq_new,
                            std::optional<T> mu_in_new)
 {
-
 
   if (rho_new != std::nullopt) {
     settings.default_rho = rho_new.value();

--- a/include/proxsuite/proxqp/dense/helpers.hpp
+++ b/include/proxsuite/proxqp/dense/helpers.hpp
@@ -474,23 +474,29 @@ setup( //
  */
 template<typename T>
 void
-update_proximal_parameters(Results<T>& results,
+update_proximal_parameters(
+                           Settings<T>& settings,
+                           Results<T>& results,
                            Workspace<T>& work,
                            std::optional<T> rho_new,
                            std::optional<T> mu_eq_new,
                            std::optional<T> mu_in_new)
 {
 
+
   if (rho_new != std::nullopt) {
+    settings.default_rho = rho_new.value();
     results.info.rho = rho_new.value();
     work.proximal_parameter_update = true;
   }
   if (mu_eq_new != std::nullopt) {
+    settings.default_mu_eq = mu_eq_new.value();
     results.info.mu_eq = mu_eq_new.value();
     results.info.mu_eq_inv = T(1) / results.info.mu_eq;
     work.proximal_parameter_update = true;
   }
   if (mu_in_new != std::nullopt) {
+    settings.default_mu_in = mu_in_new.value();
     results.info.mu_in = mu_in_new.value();
     results.info.mu_in_inv = T(1) / results.info.mu_in;
     work.proximal_parameter_update = true;

--- a/include/proxsuite/proxqp/dense/helpers.hpp
+++ b/include/proxsuite/proxqp/dense/helpers.hpp
@@ -345,7 +345,7 @@ setup( //
       if (qpwork.proximal_parameter_update) {
         qpresults.cleanup_all_except_prox_parameters();
       } else {
-        qpresults.cleanup();
+        qpresults.cleanup(qpsettings);
       }
       qpwork.cleanup();
       break;
@@ -355,7 +355,7 @@ setup( //
       if (qpwork.proximal_parameter_update) {
         qpresults.cleanup_statistics();
       } else {
-        qpresults.cold_start();
+        qpresults.cold_start(qpsettings);
       }
       qpwork.cleanup();
       break;
@@ -364,7 +364,7 @@ setup( //
       if (qpwork.proximal_parameter_update) {
         qpresults.cleanup_all_except_prox_parameters();
       } else {
-        qpresults.cleanup();
+        qpresults.cleanup(qpsettings);
       }
       qpwork.cleanup();
       break;
@@ -375,7 +375,7 @@ setup( //
           .cleanup_all_except_prox_parameters(); // the warm start is given at
                                                  // the solve function
       } else {
-        qpresults.cleanup();
+        qpresults.cleanup(qpsettings);
       }
       qpwork.cleanup();
       break;

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -778,17 +778,13 @@ qp_solve( //
     switch (qpsettings.initial_guess) {
       case InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS: {
         qpwork.cleanup();
-        qpresults.cleanup(qpsettings.default_rho,
-                          qpsettings.default_mu_eq,
-                          qpsettings.default_mu_in);
+        qpresults.cleanup(qpsettings);
         break;
       }
       case InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT: {
         // keep solutions but restart workspace and results
         qpwork.cleanup();
-        qpresults.cold_start(qpsettings.default_rho,
-                             qpsettings.default_mu_eq,
-                             qpsettings.default_mu_in);
+        qpresults.cold_start(qpsettings);
         ruiz.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen, qpresults.x });
         ruiz.scale_dual_in_place_eq(
@@ -799,17 +795,12 @@ qp_solve( //
       }
       case InitialGuessStatus::NO_INITIAL_GUESS: {
         qpwork.cleanup();
-        qpresults.cleanup(qpsettings.default_rho,
-                          qpsettings.default_mu_eq,
-                          qpsettings.default_mu_in);
+        qpresults.cleanup(qpsettings);
         break;
       }
       case InitialGuessStatus::WARM_START: {
         qpwork.cleanup();
-        qpresults.cold_start(
-          qpsettings.default_rho,
-          qpsettings.default_mu_eq,
-          qpsettings.default_mu_in); // because there was already a solve,
+        qpresults.cold_start(qpsettings); // because there was already a solve,
                                      // precond was already computed if set so
         ruiz.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen,

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -800,8 +800,9 @@ qp_solve( //
       }
       case InitialGuessStatus::WARM_START: {
         qpwork.cleanup();
-        qpresults.cold_start(qpsettings); // because there was already a solve,
-                                     // precond was already computed if set so
+        qpresults.cold_start(
+          qpsettings); // because there was already a solve,
+                       // precond was already computed if set so
         ruiz.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen,
             qpresults

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -778,13 +778,13 @@ qp_solve( //
     switch (qpsettings.initial_guess) {
       case InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS: {
         qpwork.cleanup();
-        qpresults.cleanup();
+        qpresults.cleanup(qpsettings.default_rho,qpsettings.default_mu_eq,qpsettings.default_mu_in);
         break;
       }
       case InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT: {
         // keep solutions but restart workspace and results
         qpwork.cleanup();
-        qpresults.cold_start();
+        qpresults.cold_start(qpsettings.default_rho,qpsettings.default_mu_eq,qpsettings.default_mu_in);
         ruiz.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen, qpresults.x });
         ruiz.scale_dual_in_place_eq(
@@ -795,12 +795,12 @@ qp_solve( //
       }
       case InitialGuessStatus::NO_INITIAL_GUESS: {
         qpwork.cleanup();
-        qpresults.cleanup();
+        qpresults.cleanup(qpsettings.default_rho,qpsettings.default_mu_eq,qpsettings.default_mu_in);
         break;
       }
       case InitialGuessStatus::WARM_START: {
         qpwork.cleanup();
-        qpresults.cold_start(); // because there was already a solve, precond
+        qpresults.cold_start(qpsettings.default_rho,qpsettings.default_mu_eq,qpsettings.default_mu_in); // because there was already a solve, precond
                                 // was already computed if set so
         ruiz.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen,

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -778,13 +778,17 @@ qp_solve( //
     switch (qpsettings.initial_guess) {
       case InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS: {
         qpwork.cleanup();
-        qpresults.cleanup(qpsettings.default_rho,qpsettings.default_mu_eq,qpsettings.default_mu_in);
+        qpresults.cleanup(qpsettings.default_rho,
+                          qpsettings.default_mu_eq,
+                          qpsettings.default_mu_in);
         break;
       }
       case InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT: {
         // keep solutions but restart workspace and results
         qpwork.cleanup();
-        qpresults.cold_start(qpsettings.default_rho,qpsettings.default_mu_eq,qpsettings.default_mu_in);
+        qpresults.cold_start(qpsettings.default_rho,
+                             qpsettings.default_mu_eq,
+                             qpsettings.default_mu_in);
         ruiz.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen, qpresults.x });
         ruiz.scale_dual_in_place_eq(
@@ -795,13 +799,18 @@ qp_solve( //
       }
       case InitialGuessStatus::NO_INITIAL_GUESS: {
         qpwork.cleanup();
-        qpresults.cleanup(qpsettings.default_rho,qpsettings.default_mu_eq,qpsettings.default_mu_in);
+        qpresults.cleanup(qpsettings.default_rho,
+                          qpsettings.default_mu_eq,
+                          qpsettings.default_mu_in);
         break;
       }
       case InitialGuessStatus::WARM_START: {
         qpwork.cleanup();
-        qpresults.cold_start(qpsettings.default_rho,qpsettings.default_mu_eq,qpsettings.default_mu_in); // because there was already a solve, precond
-                                // was already computed if set so
+        qpresults.cold_start(
+          qpsettings.default_rho,
+          qpsettings.default_mu_eq,
+          qpsettings.default_mu_in); // because there was already a solve,
+                                     // precond was already computed if set so
         ruiz.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen,
             qpresults

--- a/include/proxsuite/proxqp/dense/wrapper.hpp
+++ b/include/proxsuite/proxqp/dense/wrapper.hpp
@@ -343,7 +343,7 @@ struct QP
       preconditioner_status = proxsuite::proxqp::PreconditionerStatus::IDENTITY;
     }
     proxsuite::proxqp::dense::update_proximal_parameters(
-      settings,results, work, rho, mu_eq, mu_in);
+      settings, results, work, rho, mu_eq, mu_in);
     proxsuite::proxqp::dense::setup(H,
                                     g,
                                     A,
@@ -410,7 +410,7 @@ struct QP
       proxsuite::proxqp::dense::update(H, g, A, b, C, u, l, model, work);
     }
     proxsuite::proxqp::dense::update_proximal_parameters(
-      settings,results, work, rho, mu_eq, mu_in);
+      settings, results, work, rho, mu_eq, mu_in);
     proxsuite::proxqp::dense::setup(std::optional(model.H),
                                     std::optional(dense::VecRef<T>(model.g)),
                                     std::optional(model.A),
@@ -477,7 +477,7 @@ struct QP
       proxsuite::proxqp::dense::update(H, g, A, b, C, u, l, model, work);
     }
     proxsuite::proxqp::dense::update_proximal_parameters(
-      settings,results, work, rho, mu_eq, mu_in);
+      settings, results, work, rho, mu_eq, mu_in);
     proxsuite::proxqp::dense::setup(std::optional(model.H),
                                     std::optional(dense::VecRef<T>(model.g)),
                                     std::optional(model.A),
@@ -582,7 +582,7 @@ struct QP
       }
     }
     proxsuite::proxqp::dense::update_proximal_parameters(
-      settings,results, work, rho, mu_eq, mu_in);
+      settings, results, work, rho, mu_eq, mu_in);
     proxsuite::proxqp::dense::setup(std::optional(model.H),
                                     std::optional(dense::VecRef<T>(model.g)),
                                     std::optional(model.A),
@@ -635,7 +635,8 @@ struct QP
    */
   void cleanup()
   {
-    results.cleanup(settings.default_rho,settings.default_mu_eq,settings.default_mu_in);
+    results.cleanup(
+      settings.default_rho, settings.default_mu_eq, settings.default_mu_in);
     work.cleanup();
   }
 };

--- a/include/proxsuite/proxqp/dense/wrapper.hpp
+++ b/include/proxsuite/proxqp/dense/wrapper.hpp
@@ -213,7 +213,7 @@ struct QP
       preconditioner_status = proxsuite::proxqp::PreconditionerStatus::IDENTITY;
     }
     proxsuite::proxqp::dense::update_proximal_parameters(
-      results, work, rho, mu_eq, mu_in);
+      settings, results, work, rho, mu_eq, mu_in);
     proxsuite::proxqp::dense::setup(H,
                                     g,
                                     A,
@@ -343,7 +343,7 @@ struct QP
       preconditioner_status = proxsuite::proxqp::PreconditionerStatus::IDENTITY;
     }
     proxsuite::proxqp::dense::update_proximal_parameters(
-      results, work, rho, mu_eq, mu_in);
+      settings,results, work, rho, mu_eq, mu_in);
     proxsuite::proxqp::dense::setup(H,
                                     g,
                                     A,
@@ -410,7 +410,7 @@ struct QP
       proxsuite::proxqp::dense::update(H, g, A, b, C, u, l, model, work);
     }
     proxsuite::proxqp::dense::update_proximal_parameters(
-      results, work, rho, mu_eq, mu_in);
+      settings,results, work, rho, mu_eq, mu_in);
     proxsuite::proxqp::dense::setup(std::optional(model.H),
                                     std::optional(dense::VecRef<T>(model.g)),
                                     std::optional(model.A),
@@ -477,7 +477,7 @@ struct QP
       proxsuite::proxqp::dense::update(H, g, A, b, C, u, l, model, work);
     }
     proxsuite::proxqp::dense::update_proximal_parameters(
-      results, work, rho, mu_eq, mu_in);
+      settings,results, work, rho, mu_eq, mu_in);
     proxsuite::proxqp::dense::setup(std::optional(model.H),
                                     std::optional(dense::VecRef<T>(model.g)),
                                     std::optional(model.A),
@@ -582,7 +582,7 @@ struct QP
       }
     }
     proxsuite::proxqp::dense::update_proximal_parameters(
-      results, work, rho, mu_eq, mu_in);
+      settings,results, work, rho, mu_eq, mu_in);
     proxsuite::proxqp::dense::setup(std::optional(model.H),
                                     std::optional(dense::VecRef<T>(model.g)),
                                     std::optional(model.A),
@@ -635,7 +635,7 @@ struct QP
    */
   void cleanup()
   {
-    results.cleanup();
+    results.cleanup(settings.default_rho,settings.default_mu_eq,settings.default_mu_in);
     work.cleanup();
   }
 };

--- a/include/proxsuite/proxqp/dense/wrapper.hpp
+++ b/include/proxsuite/proxqp/dense/wrapper.hpp
@@ -635,8 +635,7 @@ struct QP
    */
   void cleanup()
   {
-    results.cleanup(
-      settings);
+    results.cleanup(settings);
     work.cleanup();
   }
 };

--- a/include/proxsuite/proxqp/dense/wrapper.hpp
+++ b/include/proxsuite/proxqp/dense/wrapper.hpp
@@ -636,7 +636,7 @@ struct QP
   void cleanup()
   {
     results.cleanup(
-      settings.default_rho, settings.default_mu_eq, settings.default_mu_in);
+      settings);
     work.cleanup();
   }
 };

--- a/include/proxsuite/proxqp/results.hpp
+++ b/include/proxsuite/proxqp/results.hpp
@@ -7,6 +7,7 @@
 #ifndef PROXSUITE_QP_RESULTS_HPP
 #define PROXSUITE_QP_RESULTS_HPP
 
+#include <optional>
 #include <Eigen/Core>
 #include <proxsuite/linalg/veg/type_traits/core.hpp>
 #include <proxsuite/linalg/veg/vec.hpp>

--- a/include/proxsuite/proxqp/results.hpp
+++ b/include/proxsuite/proxqp/results.hpp
@@ -108,13 +108,13 @@ struct Results
    * values.
    */
   void cleanup(std::optional<T> rho = std::nullopt,
-            std::optional<T> mu_eq = std::nullopt,
-            std::optional<T> mu_in = std::nullopt)
+               std::optional<T> mu_eq = std::nullopt,
+               std::optional<T> mu_in = std::nullopt)
   {
     x.setZero();
     y.setZero();
     z.setZero();
-    cold_start(rho,mu_eq,mu_in);
+    cold_start(rho, mu_eq, mu_in);
   }
   void cleanup_statistics()
   {
@@ -131,26 +131,26 @@ struct Results
     info.status = QPSolverOutput::PROXQP_MAX_ITER_REACHED;
   }
   void cold_start(std::optional<T> rho = std::nullopt,
-            std::optional<T> mu_eq = std::nullopt,
-            std::optional<T> mu_in = std::nullopt)
+                  std::optional<T> mu_eq = std::nullopt,
+                  std::optional<T> mu_in = std::nullopt)
   {
 
     if (rho != std::nullopt) {
       info.rho = rho.value();
-    } else{
+    } else {
       info.rho = 1e-6;
     }
     if (mu_eq != std::nullopt) {
       info.mu_eq = mu_eq.value();
       info.mu_eq_inv = T(1) / info.mu_eq;
-    }else{
+    } else {
       info.mu_eq_inv = 1e3;
       info.mu_eq = 1e-3;
     }
     if (mu_in != std::nullopt) {
       info.mu_in = mu_in.value();
       info.mu_in_inv = T(1) / info.mu_in;
-    }else{
+    } else {
       info.mu_in_inv = 1e1;
       info.mu_in = 1e-1;
     }

--- a/include/proxsuite/proxqp/results.hpp
+++ b/include/proxsuite/proxqp/results.hpp
@@ -144,7 +144,7 @@ struct Results
       info.mu_eq_inv = T(1) / info.mu_eq;
       info.mu_in = settings.value().default_mu_in;
       info.mu_in_inv = T(1) / info.mu_in;
-    } 
+    }
     cleanup_statistics();
   }
   void cleanup_all_except_prox_parameters()

--- a/include/proxsuite/proxqp/results.hpp
+++ b/include/proxsuite/proxqp/results.hpp
@@ -107,12 +107,14 @@ struct Results
    * cleanups the Result variables and set the info variables to their initial
    * values.
    */
-  void cleanup()
+  void cleanup(std::optional<T> rho = std::nullopt,
+            std::optional<T> mu_eq = std::nullopt,
+            std::optional<T> mu_in = std::nullopt)
   {
     x.setZero();
     y.setZero();
     z.setZero();
-    cold_start();
+    cold_start(rho,mu_eq,mu_in);
   }
   void cleanup_statistics()
   {
@@ -128,14 +130,31 @@ struct Results
     info.dua_res = 0.;
     info.status = QPSolverOutput::PROXQP_MAX_ITER_REACHED;
   }
-  void cold_start()
+  void cold_start(std::optional<T> rho = std::nullopt,
+            std::optional<T> mu_eq = std::nullopt,
+            std::optional<T> mu_in = std::nullopt)
   {
 
-    info.rho = 1e-6;
-    info.mu_eq_inv = 1e3;
-    info.mu_eq = 1e-3;
-    info.mu_in_inv = 1e1;
-    info.mu_in = 1e-1;
+    if (rho != std::nullopt) {
+      info.rho = rho.value();
+    } else{
+      info.rho = 1e-6;
+    }
+    if (mu_eq != std::nullopt) {
+      info.mu_eq = mu_eq.value();
+      info.mu_eq_inv = T(1) / info.mu_eq;
+    }else{
+      info.mu_eq_inv = 1e3;
+      info.mu_eq = 1e-3;
+    }
+    if (mu_in != std::nullopt) {
+      info.mu_in = mu_in.value();
+      info.mu_in_inv = T(1) / info.mu_in;
+    }else{
+      info.mu_in_inv = 1e1;
+      info.mu_in = 1e-1;
+    }
+
     info.nu = 1.;
     cleanup_statistics();
   }

--- a/include/proxsuite/proxqp/settings.hpp
+++ b/include/proxsuite/proxqp/settings.hpp
@@ -25,7 +25,7 @@ namespace proxqp {
 template<typename T>
 struct Settings
 {
-  
+
   T default_rho;
   T default_mu_eq;
   T default_mu_in;
@@ -123,8 +123,7 @@ struct Settings
    * used.
    */
 
-  Settings(
-           T default_rho_ = 1.E-6,
+  Settings(T default_rho_ = 1.E-6,
            T default_mu_eq_ = 1.E-3,
            T default_mu_in_ = 1.E-1,
            T alpha_bcl_ = 0.1,

--- a/include/proxsuite/proxqp/settings.hpp
+++ b/include/proxsuite/proxqp/settings.hpp
@@ -25,6 +25,11 @@ namespace proxqp {
 template<typename T>
 struct Settings
 {
+  
+  T default_rho;
+  T default_mu_eq;
+  T default_mu_in;
+
   T alpha_bcl;
   T beta_bcl;
 
@@ -65,6 +70,9 @@ struct Settings
   bool bcl_update;
   /*!
    * Default constructor.
+   * @param default_rho default rho parameter of result class
+   * @param default_mu_eq default mu_eq parameter of result class
+   * @param default_mu_in default mu_in parameter of result class
    * @param alpha_bcl_ alpha parameter of the BCL algorithm.
    * @param beta_bcl_ beta parameter of the BCL algorithm.
    * @param refactor_dual_feasibility_threshold_ threshold above which
@@ -115,7 +123,11 @@ struct Settings
    * used.
    */
 
-  Settings(T alpha_bcl_ = 0.1,
+  Settings(
+           T default_rho_ = 1.E-6,
+           T default_mu_eq_ = 1.E-3,
+           T default_mu_in_ = 1.E-1,
+           T alpha_bcl_ = 0.1,
            T beta_bcl_ = 0.9,
            T refactor_dual_feasibility_threshold_ = 1e-2,
            T refactor_rho_threshold_ = 1e-7,
@@ -129,7 +141,7 @@ struct Settings
            T cold_reset_mu_in_ = 1. / 1.1,
            T cold_reset_mu_eq_inv_ = 1.1,
            T cold_reset_mu_in_inv_ = 1.1,
-           T eps_abs_ = 1.e-3,
+           T eps_abs_ = 1.e-8,
            T eps_rel_ = 0,
            isize max_iter_ = 10000,
            isize max_iter_in_ = 1500,
@@ -147,7 +159,10 @@ struct Settings
            T eps_primal_inf_ = 1.E-4,
            T eps_dual_inf_ = 1.E-4,
            bool bcl_update_ = true)
-    : alpha_bcl(alpha_bcl_)
+    : default_rho(default_rho_)
+    , default_mu_eq(default_mu_eq_)
+    , default_mu_in(default_mu_in_)
+    , alpha_bcl(alpha_bcl_)
     , beta_bcl(beta_bcl_)
     , refactor_dual_feasibility_threshold(refactor_dual_feasibility_threshold_)
     , refactor_rho_threshold(refactor_rho_threshold_)
@@ -180,6 +195,75 @@ struct Settings
     , bcl_update(bcl_update_)
   {
   }
+  /*
+ void set(
+           T alpha_bcl_ = 0.1,
+           T beta_bcl_ = 0.9,
+           T refactor_dual_feasibility_threshold_ = 1e-2,
+           T refactor_rho_threshold_ = 1e-7,
+           T mu_min_eq_ = 1e-9,
+           T mu_min_in_ = 1e-8,
+           T mu_max_eq_inv_ = 1e9,
+           T mu_max_in_inv_ = 1e8,
+           T mu_update_factor_ = 0.1,
+           T mu_update_inv_factor_ = 10,
+           T cold_reset_mu_eq_ = 1. / 1.1,
+           T cold_reset_mu_in_ = 1. / 1.1,
+           T cold_reset_mu_eq_inv_ = 1.1,
+           T cold_reset_mu_in_inv_ = 1.1,
+           T eps_abs_ = 1.e-8,
+           T eps_rel_ = 0,
+           isize max_iter_ = 10000,
+           isize max_iter_in_ = 1500,
+           isize safe_guard_ = 1.E4,
+           isize nb_iterative_refinement_ = 10,
+           T eps_refact_ = 1.e-6, // before eps_refact_=1.e-6
+           bool VERBOSE = false,
+           InitialGuessStatus initial_guess_ =
+             InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT,
+           bool update_preconditioner_ = true,
+           bool compute_preconditioner_ = true,
+           bool compute_timings_ = true,
+           isize preconditioner_max_iter_ = 10,
+           T preconditioner_accuracy_ = 1.e-3,
+           T eps_primal_inf_ = 1.E-4,
+           T eps_dual_inf_ = 1.E-4,
+           bool bcl_update_ = true
+ ){
+    alpha_bcl = alpha_bcl_;
+    beta_bcl = beta_bcl_ ;
+    refactor_dual_feasibility_threshold = refactor_dual_feasibility_threshold_;
+    refactor_rho_threshold = refactor_rho_threshold_;
+    mu_min_eq = mu_min_eq_;
+    mu_min_in = mu_min_in_;
+    mu_max_eq_inv = mu_max_eq_inv_;
+    mu_max_in_inv = mu_max_in_inv_;
+    mu_update_factor = mu_update_factor_;
+    mu_update_inv_factor = mu_update_inv_factor_;
+    cold_reset_mu_eq = cold_reset_mu_eq_;
+    cold_reset_mu_in = cold_reset_mu_in_;
+    cold_reset_mu_eq_inv = cold_reset_mu_eq_inv_;
+    cold_reset_mu_in_inv = cold_reset_mu_in_inv_;
+    eps_abs = eps_abs_;
+    eps_rel = eps_rel_;
+    max_iter = max_iter_;
+    max_iter_in = max_iter_in_;
+    safe_guard = safe_guard_;
+    nb_iterative_refinement = nb_iterative_refinement_;
+    eps_refact = eps_refact_;
+    verbose = VERBOSE;
+    initial_guess = initial_guess_;
+    update_preconditioner = update_preconditioner_;
+    compute_preconditioner = compute_preconditioner_;
+    compute_timings = compute_timings_;
+    preconditioner_max_iter = preconditioner_max_iter_;
+    preconditioner_accuracy = preconditioner_accuracy_;
+    eps_primal_inf = eps_primal_inf_;
+    eps_dual_inf = eps_dual_inf_;
+    bcl_update = bcl_update_;
+
+ }
+ */
 };
 
 } // namespace proxqp

--- a/include/proxsuite/proxqp/sparse/helpers.hpp
+++ b/include/proxsuite/proxqp/sparse/helpers.hpp
@@ -25,8 +25,7 @@ namespace sparse {
  */
 template<typename T, typename I>
 void
-update_proximal_parameters(
-                           Settings<T>& settings,
+update_proximal_parameters(Settings<T>& settings,
                            Results<T>& results,
                            Workspace<T, I>& work,
                            std::optional<T> rho_new,

--- a/include/proxsuite/proxqp/sparse/helpers.hpp
+++ b/include/proxsuite/proxqp/sparse/helpers.hpp
@@ -25,22 +25,27 @@ namespace sparse {
  */
 template<typename T, typename I>
 void
-update_proximal_parameters(Results<T>& results,
+update_proximal_parameters(
+                           Settings<T>& settings,
+                           Results<T>& results,
                            Workspace<T, I>& work,
                            std::optional<T> rho_new,
                            std::optional<T> mu_eq_new,
                            std::optional<T> mu_in_new)
 {
   if (rho_new != std::nullopt) {
+    settings.default_rho = rho_new.value();
     results.info.rho = rho_new.value();
     work.internal.proximal_parameter_update = true;
   }
   if (mu_eq_new != std::nullopt) {
+    settings.default_mu_eq = mu_eq_new.value();
     results.info.mu_eq = mu_eq_new.value();
     results.info.mu_eq_inv = T(1) / results.info.mu_eq;
     work.internal.proximal_parameter_update = true;
   }
   if (mu_in_new != std::nullopt) {
+    settings.default_mu_in = mu_in_new.value();
     results.info.mu_in = mu_in_new.value();
     results.info.mu_in_inv = T(1) / results.info.mu_in;
     work.internal.proximal_parameter_update = true;

--- a/include/proxsuite/proxqp/sparse/helpers.hpp
+++ b/include/proxsuite/proxqp/sparse/helpers.hpp
@@ -210,7 +210,7 @@ qp_setup(QpView<T, I> qp,
       if (work.internal.proximal_parameter_update) {
         results.cleanup_all_except_prox_parameters();
       } else {
-        results.cleanup();
+        results.cleanup(settings);
       }
       break;
     }
@@ -220,7 +220,7 @@ qp_setup(QpView<T, I> qp,
       if (work.internal.proximal_parameter_update) {
         results.cleanup_statistics();
       } else {
-        results.cold_start();
+        results.cold_start(settings);
       }
       break;
     }
@@ -229,7 +229,7 @@ qp_setup(QpView<T, I> qp,
       if (work.internal.proximal_parameter_update) {
         results.cleanup_all_except_prox_parameters();
       } else {
-        results.cleanup();
+        results.cleanup(settings);
       }
       break;
     }
@@ -238,7 +238,7 @@ qp_setup(QpView<T, I> qp,
       if (work.internal.proximal_parameter_update) {
         results.cleanup_all_except_prox_parameters();
       } else {
-        results.cleanup();
+        results.cleanup(settings);
       }
       break;
     }

--- a/include/proxsuite/proxqp/sparse/solver.hpp
+++ b/include/proxsuite/proxqp/sparse/solver.hpp
@@ -378,13 +378,13 @@ qp_solve(Results<T>& results,
                                       // has already been executed
       case InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS: {
         results.cleanup(
-          settings.default_rho, settings.default_mu_eq, settings.default_mu_in);
+          settings);
         break;
       }
       case InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT: {
         // keep solutions but restart workspace and results
         results.cold_start(
-          settings.default_rho, settings.default_mu_eq, settings.default_mu_in);
+          settings);
         precond.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen, results.x });
         precond.scale_dual_in_place_eq(
@@ -395,14 +395,12 @@ qp_solve(Results<T>& results,
       }
       case InitialGuessStatus::NO_INITIAL_GUESS: {
         results.cleanup(
-          settings.default_rho, settings.default_mu_eq, settings.default_mu_in);
+          settings);
         break;
       }
       case InitialGuessStatus::WARM_START: {
         results.cold_start(
-          settings.default_rho,
-          settings.default_mu_eq,
-          settings.default_mu_in); // because there was already a solve, precond
+          settings); // because there was already a solve, precond
                                    // was already computed if set so
         precond.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen,

--- a/include/proxsuite/proxqp/sparse/solver.hpp
+++ b/include/proxsuite/proxqp/sparse/solver.hpp
@@ -377,12 +377,12 @@ qp_solve(Results<T>& results,
     switch (settings.initial_guess) { // the following is used when one solve
                                       // has already been executed
       case InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS: {
-        results.cleanup();
+        results.cleanup(settings.default_rho,settings.default_mu_eq,settings.default_mu_in);
         break;
       }
       case InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT: {
         // keep solutions but restart workspace and results
-        results.cold_start();
+        results.cold_start(settings.default_rho,settings.default_mu_eq,settings.default_mu_in);
         precond.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen, results.x });
         precond.scale_dual_in_place_eq(
@@ -392,11 +392,11 @@ qp_solve(Results<T>& results,
         break;
       }
       case InitialGuessStatus::NO_INITIAL_GUESS: {
-        results.cleanup();
+        results.cleanup(settings.default_rho,settings.default_mu_eq,settings.default_mu_in);
         break;
       }
       case InitialGuessStatus::WARM_START: {
-        results.cold_start(); // because there was already a solve, precond was
+        results.cold_start(settings.default_rho,settings.default_mu_eq,settings.default_mu_in); // because there was already a solve, precond was
                               // already computed if set so
         precond.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen,

--- a/include/proxsuite/proxqp/sparse/solver.hpp
+++ b/include/proxsuite/proxqp/sparse/solver.hpp
@@ -377,14 +377,12 @@ qp_solve(Results<T>& results,
     switch (settings.initial_guess) { // the following is used when one solve
                                       // has already been executed
       case InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS: {
-        results.cleanup(
-          settings);
+        results.cleanup(settings);
         break;
       }
       case InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT: {
         // keep solutions but restart workspace and results
-        results.cold_start(
-          settings);
+        results.cold_start(settings);
         precond.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen, results.x });
         precond.scale_dual_in_place_eq(
@@ -394,14 +392,12 @@ qp_solve(Results<T>& results,
         break;
       }
       case InitialGuessStatus::NO_INITIAL_GUESS: {
-        results.cleanup(
-          settings);
+        results.cleanup(settings);
         break;
       }
       case InitialGuessStatus::WARM_START: {
-        results.cold_start(
-          settings); // because there was already a solve, precond
-                                   // was already computed if set so
+        results.cold_start(settings); // because there was already a solve,
+                                      // precond was already computed if set so
         precond.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen,
             results.x }); // it contains the value given in entry for warm start

--- a/include/proxsuite/proxqp/sparse/solver.hpp
+++ b/include/proxsuite/proxqp/sparse/solver.hpp
@@ -377,12 +377,14 @@ qp_solve(Results<T>& results,
     switch (settings.initial_guess) { // the following is used when one solve
                                       // has already been executed
       case InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS: {
-        results.cleanup(settings.default_rho,settings.default_mu_eq,settings.default_mu_in);
+        results.cleanup(
+          settings.default_rho, settings.default_mu_eq, settings.default_mu_in);
         break;
       }
       case InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT: {
         // keep solutions but restart workspace and results
-        results.cold_start(settings.default_rho,settings.default_mu_eq,settings.default_mu_in);
+        results.cold_start(
+          settings.default_rho, settings.default_mu_eq, settings.default_mu_in);
         precond.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen, results.x });
         precond.scale_dual_in_place_eq(
@@ -392,12 +394,16 @@ qp_solve(Results<T>& results,
         break;
       }
       case InitialGuessStatus::NO_INITIAL_GUESS: {
-        results.cleanup(settings.default_rho,settings.default_mu_eq,settings.default_mu_in);
+        results.cleanup(
+          settings.default_rho, settings.default_mu_eq, settings.default_mu_in);
         break;
       }
       case InitialGuessStatus::WARM_START: {
-        results.cold_start(settings.default_rho,settings.default_mu_eq,settings.default_mu_in); // because there was already a solve, precond was
-                              // already computed if set so
+        results.cold_start(
+          settings.default_rho,
+          settings.default_mu_eq,
+          settings.default_mu_in); // because there was already a solve, precond
+                                   // was already computed if set so
         precond.scale_primal_in_place(
           { proxsuite::proxqp::from_eigen,
             results.x }); // it contains the value given in entry for warm start

--- a/include/proxsuite/proxqp/sparse/wrapper.hpp
+++ b/include/proxsuite/proxqp/sparse/wrapper.hpp
@@ -639,7 +639,7 @@ struct QP
   void cleanup()
   {
     results.cleanup(
-      settings.default_rho, settings.default_mu_eq, settings.default_mu_in);
+      settings);
   }
 };
 /*!

--- a/include/proxsuite/proxqp/sparse/wrapper.hpp
+++ b/include/proxsuite/proxqp/sparse/wrapper.hpp
@@ -244,7 +244,7 @@ struct QP
       preconditioner_status = proxsuite::proxqp::PreconditionerStatus::IDENTITY;
     }
     proxsuite::proxqp::sparse::update_proximal_parameters(
-      settings,results, work, rho, mu_eq, mu_in);
+      settings, results, work, rho, mu_eq, mu_in);
 
     if (g != std::nullopt) {
       model.g = g.value();
@@ -589,7 +589,7 @@ struct QP
       { proxsuite::linalg::sparse::from_eigen, model.u }
     };
     proxsuite::proxqp::sparse::update_proximal_parameters(
-      settings,results, work, rho, mu_eq, mu_in);
+      settings, results, work, rho, mu_eq, mu_in);
     qp_setup(qp,
              results,
              model,
@@ -636,7 +636,11 @@ struct QP
   /*!
    * Clean-ups solver's results.
    */
-  void cleanup() { results.cleanup(settings.default_rho,settings.default_mu_eq,settings.default_mu_in); }
+  void cleanup()
+  {
+    results.cleanup(
+      settings.default_rho, settings.default_mu_eq, settings.default_mu_in);
+  }
 };
 /*!
  * Solves the QP problem using PROXQP algorithm without the need to define a QP

--- a/include/proxsuite/proxqp/sparse/wrapper.hpp
+++ b/include/proxsuite/proxqp/sparse/wrapper.hpp
@@ -244,7 +244,7 @@ struct QP
       preconditioner_status = proxsuite::proxqp::PreconditionerStatus::IDENTITY;
     }
     proxsuite::proxqp::sparse::update_proximal_parameters(
-      results, work, rho, mu_eq, mu_in);
+      settings,results, work, rho, mu_eq, mu_in);
 
     if (g != std::nullopt) {
       model.g = g.value();
@@ -589,7 +589,7 @@ struct QP
       { proxsuite::linalg::sparse::from_eigen, model.u }
     };
     proxsuite::proxqp::sparse::update_proximal_parameters(
-      results, work, rho, mu_eq, mu_in);
+      settings,results, work, rho, mu_eq, mu_in);
     qp_setup(qp,
              results,
              model,
@@ -636,7 +636,7 @@ struct QP
   /*!
    * Clean-ups solver's results.
    */
-  void cleanup() { results.cleanup(); }
+  void cleanup() { results.cleanup(settings.default_rho,settings.default_mu_eq,settings.default_mu_in); }
 };
 /*!
  * Solves the QP problem using PROXQP algorithm without the need to define a QP

--- a/include/proxsuite/proxqp/sparse/wrapper.hpp
+++ b/include/proxsuite/proxqp/sparse/wrapper.hpp
@@ -636,11 +636,7 @@ struct QP
   /*!
    * Clean-ups solver's results.
    */
-  void cleanup()
-  {
-    results.cleanup(
-      settings);
-  }
+  void cleanup() { results.cleanup(settings); }
 };
 /*!
  * Solves the QP problem using PROXQP algorithm without the need to define a QP

--- a/test/src/cvxpy.py
+++ b/test/src/cvxpy.py
@@ -64,14 +64,14 @@ class CvxpyTest(unittest.TestCase):
         l = 0 * np.ones((n))
         u = np.ones(n)
 
-        Qp = proxsuite.proxqp.dense.QP(n, 0, n)
-        Qp.init(H, g, A, b, C, u, l)
-        Qp.settings.verbose = True
-        Qp.settings.eps_abs = 1e-8
-        Qp.solve()
+        qp = proxsuite.proxqp.dense.QP(n, 0, n)
+        qp.init(H, g, A, b, C, u, l)
+        qp.settings.verbose = True
+        qp.settings.eps_abs = 1e-8
+        qp.solve()
 
         x_sol = 0.5
-        assert (x_sol - Qp.results.x) <= 1e-4
+        assert (x_sol - qp.results.x) <= 1e-4
 
 
 if __name__ == "__main__":

--- a/test/src/dense_maros_meszaros.cpp
+++ b/test/src/dense_maros_meszaros.cpp
@@ -116,19 +116,19 @@ TEST_CASE("dense maros meszaros using the api")
       isize n_eq = A.rows();
       isize n_in = C.rows();
 
-      proxqp::dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-      Qp.init(H, g, A, b, C, u, l);
+      proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+      qp.init(H, g, A, b, C, u, l);
 
-      Qp.settings.verbose = false;
-      Qp.settings.eps_abs = 2e-8;
-      Qp.settings.eps_rel = 0;
-      auto& eps = Qp.settings.eps_abs;
+      qp.settings.verbose = false;
+      qp.settings.eps_abs = 2e-8;
+      qp.settings.eps_rel = 0;
+      auto& eps = qp.settings.eps_abs;
 
       for (size_t it = 0; it < 2; ++it) {
-        Qp.solve();
-        const auto& x = Qp.results.x;
-        const auto& y = Qp.results.y;
-        const auto& z = Qp.results.z;
+        qp.solve();
+        const auto& x = qp.results.x;
+        const auto& y = qp.results.y;
+        const auto& z = qp.results.z;
 
         T prim_eq = proxqp::dense::infty_norm(A * x - b);
         T prim_in =
@@ -147,7 +147,7 @@ TEST_CASE("dense maros meszaros using the api")
         CHECK((C * x - u).maxCoeff() < eps);
 
         if (it > 0) {
-          CHECK(Qp.results.info.iter == 0);
+          CHECK(qp.results.info.iter == 0);
         }
       }
     }

--- a/test/src/dense_qp_eq.cpp
+++ b/test/src/dense_qp_eq.cpp
@@ -74,14 +74,21 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality constraints "
       dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
     proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
     qp.settings.eps_abs = eps_abs;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
-    T pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    T pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+                 qp_random.A.transpose() * qp.results.y +
                  qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -121,15 +128,22 @@ DOCTEST_TEST_CASE("linear problem with equality  with equality constraints and "
     proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
-    T pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    T pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+                 qp_random.A.transpose() * qp.results.y +
                  qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);

--- a/test/src/dense_qp_with_eq_and_in.cpp
+++ b/test/src/dense_qp_with_eq_and_in.cpp
@@ -33,15 +33,22 @@ DOCTEST_TEST_CASE(
     proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
-    T pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    T pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+                 qp_random.A.transpose() * qp.results.y +
                  qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -77,14 +84,21 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with box inequality "
     proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
-    T pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    T pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+                 qp_random.A.transpose() * qp.results.y +
                  qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -113,20 +127,28 @@ DOCTEST_TEST_CASE("sparse random not strongly convex qp with inequality "
   for (proxqp::isize dim = 10; dim < 1000; dim += 100) {
     proxqp::isize n_in(dim / 2);
     proxqp::isize n_eq(0);
-    proxqp::dense::Model<T> qp_random = proxqp::utils::dense_not_strongly_convex_qp(
-      dim, n_eq, n_in, sparsity_factor);
+    proxqp::dense::Model<T> qp_random =
+      proxqp::utils::dense_not_strongly_convex_qp(
+        dim, n_eq, n_in, sparsity_factor);
 
     proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
-    T pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    T pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+                 qp_random.A.transpose() * qp.results.y +
                  qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -166,14 +188,21 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with degenerate inequality "
     proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
-    T pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    T pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+                 qp_random.A.transpose() * qp.results.y +
                  qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -201,26 +230,34 @@ DOCTEST_TEST_CASE("linear problem with equality inequality constraints and "
   for (proxqp::isize dim = 10; dim < 1000; dim += 100) {
     proxqp::isize n_in(dim / 2);
     proxqp::isize n_eq(0);
-    proxqp::dense::Model<T> qp_random = proxqp::utils::dense_not_strongly_convex_qp(
-      dim, n_eq, n_in, sparsity_factor);
+    proxqp::dense::Model<T> qp_random =
+      proxqp::utils::dense_not_strongly_convex_qp(
+        dim, n_eq, n_in, sparsity_factor);
     qp_random.H.setZero();
     auto z_sol = proxqp::utils::rand::vector_rand<T>(n_in);
     qp_random.g = -qp_random.C.transpose() *
-           z_sol; // make sure the LP is bounded within the feasible set
+                  z_sol; // make sure the LP is bounded within the feasible set
     // std::cout << "g : " << qp.g << " C " << qp.C  << " u " << qp.u << " l "
     // << qp.l << std::endl;
     proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;
     qp.settings.verbose = false;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
-    T pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    T pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+                 qp_random.A.transpose() * qp.results.y +
                  qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);

--- a/test/src/dense_qp_with_eq_and_in.cpp
+++ b/test/src/dense_qp_with_eq_and_in.cpp
@@ -27,22 +27,22 @@ DOCTEST_TEST_CASE(
     proxqp::isize n_eq(dim / 4);
     proxqp::isize n_in(dim / 4);
     T strong_convexity_factor(1.e-2);
-    proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+    proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
       dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-    Qp.settings.eps_abs = eps_abs;
-    Qp.settings.eps_rel = 0;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.eps_rel = 0;
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                proxqp::dense::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-                 qp.C.transpose() * Qp.results.z)
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+                 qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
@@ -51,7 +51,7 @@ DOCTEST_TEST_CASE(
               << " neq: " << n_eq << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
   }
 }
@@ -72,20 +72,20 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with box inequality "
     proxqp::isize n_eq(0);
     proxqp::isize n_in(dim);
     T strong_convexity_factor(1.e-2);
-    proxqp::dense::Model<T> qp = proxqp::utils::dense_box_constrained_qp(
+    proxqp::dense::Model<T> qp_random = proxqp::utils::dense_box_constrained_qp(
       dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
-    proxqp::dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-    Qp.settings.eps_abs = eps_abs;
-    Qp.settings.eps_rel = 0;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.eps_rel = 0;
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
     T pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                proxqp::dense::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-                 qp.C.transpose() * Qp.results.z)
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+                 qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
@@ -94,7 +94,7 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with box inequality "
               << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
   }
 }
@@ -113,21 +113,21 @@ DOCTEST_TEST_CASE("sparse random not strongly convex qp with inequality "
   for (proxqp::isize dim = 10; dim < 1000; dim += 100) {
     proxqp::isize n_in(dim / 2);
     proxqp::isize n_eq(0);
-    proxqp::dense::Model<T> qp = proxqp::utils::dense_not_strongly_convex_qp(
+    proxqp::dense::Model<T> qp_random = proxqp::utils::dense_not_strongly_convex_qp(
       dim, n_eq, n_in, sparsity_factor);
 
-    proxqp::dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-    Qp.settings.eps_abs = eps_abs;
-    Qp.settings.eps_rel = 0;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.eps_rel = 0;
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
     T pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                proxqp::dense::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-                 qp.C.transpose() * Qp.results.z)
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+                 qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
@@ -136,7 +136,7 @@ DOCTEST_TEST_CASE("sparse random not strongly convex qp with inequality "
               << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
   }
 }
@@ -157,24 +157,24 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with degenerate inequality "
     proxqp::isize m(dim / 4);
     proxqp::isize n_in(2 * m);
     proxqp::isize n_eq(0);
-    proxqp::dense::Model<T> qp = proxqp::utils::dense_degenerate_qp(
+    proxqp::dense::Model<T> qp_random = proxqp::utils::dense_degenerate_qp(
       dim,
       n_eq,
       m, // it n_in = 2 * m, it doubles the inequality constraints
       sparsity_factor,
       strong_convexity_factor);
-    proxqp::dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-    Qp.settings.eps_abs = eps_abs;
-    Qp.settings.eps_rel = 0;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.eps_rel = 0;
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
     T pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                proxqp::dense::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-                 qp.C.transpose() * Qp.results.z)
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+                 qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
@@ -183,7 +183,7 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with degenerate inequality "
               << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
   }
 }
@@ -201,27 +201,27 @@ DOCTEST_TEST_CASE("linear problem with equality inequality constraints and "
   for (proxqp::isize dim = 10; dim < 1000; dim += 100) {
     proxqp::isize n_in(dim / 2);
     proxqp::isize n_eq(0);
-    proxqp::dense::Model<T> qp = proxqp::utils::dense_not_strongly_convex_qp(
+    proxqp::dense::Model<T> qp_random = proxqp::utils::dense_not_strongly_convex_qp(
       dim, n_eq, n_in, sparsity_factor);
-    qp.H.setZero();
+    qp_random.H.setZero();
     auto z_sol = proxqp::utils::rand::vector_rand<T>(n_in);
-    qp.g = -qp.C.transpose() *
+    qp_random.g = -qp_random.C.transpose() *
            z_sol; // make sure the LP is bounded within the feasible set
     // std::cout << "g : " << qp.g << " C " << qp.C  << " u " << qp.u << " l "
     // << qp.l << std::endl;
-    proxqp::dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-    Qp.settings.eps_abs = eps_abs;
-    Qp.settings.eps_rel = 0;
-    Qp.settings.verbose = false;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.eps_rel = 0;
+    qp.settings.verbose = false;
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
     T pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                proxqp::dense::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-                 qp.C.transpose() * Qp.results.z)
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+                 qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
@@ -230,7 +230,7 @@ DOCTEST_TEST_CASE("linear problem with equality inequality constraints and "
               << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
   }
 }

--- a/test/src/dense_qp_wrapper.cpp
+++ b/test/src/dense_qp_wrapper.cpp
@@ -26,21 +26,21 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -49,23 +49,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
   std::cout << "before upating" << std::endl;
-  std::cout << "H :  " << qp.H << std::endl;
-  std::cout << "g :  " << qp.g << std::endl;
-  std::cout << "A :  " << qp.A << std::endl;
-  std::cout << "b :  " << qp.b << std::endl;
-  std::cout << "C :  " << qp.C << std::endl;
-  std::cout << "u :  " << qp.u << std::endl;
-  std::cout << "l :  " << qp.l << std::endl;
+  std::cout << "H :  " << qp_random.H << std::endl;
+  std::cout << "g :  " << qp_random.g << std::endl;
+  std::cout << "A :  " << qp_random.A << std::endl;
+  std::cout << "b :  " << qp_random.b << std::endl;
+  std::cout << "C :  " << qp_random.C << std::endl;
+  std::cout << "u :  " << qp_random.u << std::endl;
+  std::cout << "l :  " << qp_random.l << std::endl;
 
   std::cout << "testing updating H" << std::endl;
-  qp.H.setIdentity();
-  Qp.update(qp.H,
+  qp_random.H.setIdentity();
+  qp.update(qp_random.H,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -73,22 +73,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             std::nullopt);
   std::cout << "after upating" << std::endl;
-  std::cout << "H :  " << Qp.model.H << std::endl;
-  std::cout << "g :  " << Qp.model.g << std::endl;
-  std::cout << "A :  " << Qp.model.A << std::endl;
-  std::cout << "b :  " << Qp.model.b << std::endl;
-  std::cout << "C :  " << Qp.model.C << std::endl;
-  std::cout << "u :  " << Qp.model.u << std::endl;
-  std::cout << "l :  " << Qp.model.l << std::endl;
+  std::cout << "H :  " << qp.model.H << std::endl;
+  std::cout << "g :  " << qp.model.g << std::endl;
+  std::cout << "A :  " << qp.model.A << std::endl;
+  std::cout << "b :  " << qp.model.b << std::endl;
+  std::cout << "C :  " << qp.model.C << std::endl;
+  std::cout << "u :  " << qp.model.u << std::endl;
+  std::cout << "l :  " << qp.model.l << std::endl;
 
-  Qp.solve();
+  qp.solve();
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -97,24 +97,24 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.solve();
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.solve();
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -124,10 +124,10 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
@@ -145,21 +145,21 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   isize n_eq(dim / 4);
   isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -168,48 +168,48 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
   std::cout << "before upating" << std::endl;
-  std::cout << "H :  " << qp.H << std::endl;
-  std::cout << "g :  " << qp.g << std::endl;
-  std::cout << "A :  " << qp.A << std::endl;
-  std::cout << "b :  " << qp.b << std::endl;
-  std::cout << "C :  " << qp.C << std::endl;
-  std::cout << "u :  " << qp.u << std::endl;
-  std::cout << "l :  " << qp.l << std::endl;
+  std::cout << "H :  " << qp_random.H << std::endl;
+  std::cout << "g :  " << qp_random.g << std::endl;
+  std::cout << "A :  " << qp_random.A << std::endl;
+  std::cout << "b :  " << qp_random.b << std::endl;
+  std::cout << "C :  " << qp_random.C << std::endl;
+  std::cout << "u :  " << qp_random.u << std::endl;
+  std::cout << "l :  " << qp_random.l << std::endl;
 
   std::cout << "testing updating A" << std::endl;
-  qp.A = utils::rand::sparse_matrix_rand_not_compressed<T>(
+  qp_random.A = utils::rand::sparse_matrix_rand_not_compressed<T>(
     n_eq, dim, sparsity_factor);
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
-            qp.A,
+            qp_random.A,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt);
 
   std::cout << "after upating" << std::endl;
-  std::cout << "H :  " << Qp.model.H << std::endl;
-  std::cout << "g :  " << Qp.model.g << std::endl;
-  std::cout << "A :  " << Qp.model.A << std::endl;
-  std::cout << "b :  " << Qp.model.b << std::endl;
-  std::cout << "C :  " << Qp.model.C << std::endl;
-  std::cout << "u :  " << Qp.model.u << std::endl;
-  std::cout << "l :  " << Qp.model.l << std::endl;
+  std::cout << "H :  " << qp.model.H << std::endl;
+  std::cout << "g :  " << qp.model.g << std::endl;
+  std::cout << "A :  " << qp.model.A << std::endl;
+  std::cout << "b :  " << qp.model.b << std::endl;
+  std::cout << "C :  " << qp.model.C << std::endl;
+  std::cout << "u :  " << qp.model.u << std::endl;
+  std::cout << "l :  " << qp.model.l << std::endl;
 
-  Qp.solve();
+  qp.solve();
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -218,23 +218,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.solve();
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.solve();
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -244,10 +244,10 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
@@ -265,21 +265,21 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   isize n_eq(dim / 4);
   isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -288,48 +288,48 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
   std::cout << "before upating" << std::endl;
-  std::cout << "H :  " << qp.H << std::endl;
-  std::cout << "g :  " << qp.g << std::endl;
-  std::cout << "A :  " << qp.A << std::endl;
-  std::cout << "b :  " << qp.b << std::endl;
-  std::cout << "C :  " << qp.C << std::endl;
-  std::cout << "u :  " << qp.u << std::endl;
-  std::cout << "l :  " << qp.l << std::endl;
+  std::cout << "H :  " << qp_random.H << std::endl;
+  std::cout << "g :  " << qp_random.g << std::endl;
+  std::cout << "A :  " << qp_random.A << std::endl;
+  std::cout << "b :  " << qp_random.b << std::endl;
+  std::cout << "C :  " << qp_random.C << std::endl;
+  std::cout << "u :  " << qp_random.u << std::endl;
+  std::cout << "l :  " << qp_random.l << std::endl;
 
   std::cout << "testing updating C" << std::endl;
-  qp.C = utils::rand::sparse_matrix_rand_not_compressed<T>(
+  qp_random.C = utils::rand::sparse_matrix_rand_not_compressed<T>(
     n_in, dim, sparsity_factor);
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
-            qp.C,
+            qp_random.C,
             std::nullopt,
             std::nullopt);
 
   std::cout << "after upating" << std::endl;
-  std::cout << "H :  " << Qp.model.H << std::endl;
-  std::cout << "g :  " << Qp.model.g << std::endl;
-  std::cout << "A :  " << Qp.model.A << std::endl;
-  std::cout << "b :  " << Qp.model.b << std::endl;
-  std::cout << "C :  " << Qp.model.C << std::endl;
-  std::cout << "u :  " << Qp.model.u << std::endl;
-  std::cout << "l :  " << Qp.model.l << std::endl;
+  std::cout << "H :  " << qp.model.H << std::endl;
+  std::cout << "g :  " << qp.model.g << std::endl;
+  std::cout << "A :  " << qp.model.A << std::endl;
+  std::cout << "b :  " << qp.model.b << std::endl;
+  std::cout << "C :  " << qp.model.C << std::endl;
+  std::cout << "u :  " << qp.model.u << std::endl;
+  std::cout << "l :  " << qp.model.l << std::endl;
 
-  Qp.solve();
+  qp.solve();
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -338,23 +338,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.solve();
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.solve();
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -364,10 +364,10 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
@@ -385,21 +385,21 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   isize n_eq(dim / 4);
   isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -408,48 +408,48 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
   std::cout << "before upating" << std::endl;
-  std::cout << "H :  " << qp.H << std::endl;
-  std::cout << "g :  " << qp.g << std::endl;
-  std::cout << "A :  " << qp.A << std::endl;
-  std::cout << "b :  " << qp.b << std::endl;
-  std::cout << "C :  " << qp.C << std::endl;
-  std::cout << "u :  " << qp.u << std::endl;
-  std::cout << "l :  " << qp.l << std::endl;
+  std::cout << "H :  " << qp_random.H << std::endl;
+  std::cout << "g :  " << qp_random.g << std::endl;
+  std::cout << "A :  " << qp_random.A << std::endl;
+  std::cout << "b :  " << qp_random.b << std::endl;
+  std::cout << "C :  " << qp_random.C << std::endl;
+  std::cout << "u :  " << qp_random.u << std::endl;
+  std::cout << "l :  " << qp_random.l << std::endl;
 
   std::cout << "testing updating b" << std::endl;
   auto x_sol = utils::rand::vector_rand<T>(dim);
-  qp.b = qp.A * x_sol;
-  Qp.update(std::nullopt,
+  qp_random.b = qp_random.A * x_sol;
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
-            qp.b,
+            qp_random.b,
             std::nullopt,
             std::nullopt,
             std::nullopt);
 
   std::cout << "after upating" << std::endl;
-  std::cout << "H :  " << Qp.model.H << std::endl;
-  std::cout << "g :  " << Qp.model.g << std::endl;
-  std::cout << "A :  " << Qp.model.A << std::endl;
-  std::cout << "b :  " << Qp.model.b << std::endl;
-  std::cout << "C :  " << Qp.model.C << std::endl;
-  std::cout << "u :  " << Qp.model.u << std::endl;
-  std::cout << "l :  " << Qp.model.l << std::endl;
+  std::cout << "H :  " << qp.model.H << std::endl;
+  std::cout << "g :  " << qp.model.g << std::endl;
+  std::cout << "A :  " << qp.model.A << std::endl;
+  std::cout << "b :  " << qp.model.b << std::endl;
+  std::cout << "C :  " << qp.model.C << std::endl;
+  std::cout << "u :  " << qp.model.u << std::endl;
+  std::cout << "l :  " << qp.model.l << std::endl;
 
-  Qp.solve();
+  qp.solve();
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -458,23 +458,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.solve();
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.solve();
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -484,10 +484,10 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
@@ -504,20 +504,20 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   isize n_eq(dim / 4);
   isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -526,19 +526,19 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
   std::cout << "before upating" << std::endl;
-  std::cout << "H :  " << qp.H << std::endl;
-  std::cout << "g :  " << qp.g << std::endl;
-  std::cout << "A :  " << qp.A << std::endl;
-  std::cout << "b :  " << qp.b << std::endl;
-  std::cout << "C :  " << qp.C << std::endl;
-  std::cout << "u :  " << qp.u << std::endl;
-  std::cout << "l :  " << qp.l << std::endl;
+  std::cout << "H :  " << qp_random.H << std::endl;
+  std::cout << "g :  " << qp_random.g << std::endl;
+  std::cout << "A :  " << qp_random.A << std::endl;
+  std::cout << "b :  " << qp_random.b << std::endl;
+  std::cout << "C :  " << qp_random.C << std::endl;
+  std::cout << "u :  " << qp_random.u << std::endl;
+  std::cout << "l :  " << qp_random.l << std::endl;
 
   std::cout << "testing updating b" << std::endl;
   auto x_sol = utils::rand::vector_rand<T>(dim);
@@ -547,32 +547,32 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     delta(i) = utils::rand::uniform_rand();
   }
 
-  qp.u = qp.C * x_sol + delta;
-  Qp.update(std::nullopt,
+  qp_random.u = qp_random.C * x_sol + delta;
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
-            qp.u,
+            qp_random.u,
             std::nullopt);
 
   std::cout << "after upating" << std::endl;
-  std::cout << "H :  " << Qp.model.H << std::endl;
-  std::cout << "g :  " << Qp.model.g << std::endl;
-  std::cout << "A :  " << Qp.model.A << std::endl;
-  std::cout << "b :  " << Qp.model.b << std::endl;
-  std::cout << "C :  " << Qp.model.C << std::endl;
-  std::cout << "u :  " << Qp.model.u << std::endl;
-  std::cout << "l :  " << Qp.model.l << std::endl;
+  std::cout << "H :  " << qp.model.H << std::endl;
+  std::cout << "g :  " << qp.model.g << std::endl;
+  std::cout << "A :  " << qp.model.A << std::endl;
+  std::cout << "b :  " << qp.model.b << std::endl;
+  std::cout << "C :  " << qp.model.C << std::endl;
+  std::cout << "u :  " << qp.model.u << std::endl;
+  std::cout << "l :  " << qp.model.l << std::endl;
 
-  Qp.solve();
+  qp.solve();
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -581,23 +581,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.solve();
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.solve();
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -607,10 +607,10 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
@@ -627,20 +627,20 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   isize n_eq(dim / 4);
   isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -649,26 +649,26 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
   std::cout << "before upating" << std::endl;
-  std::cout << "H :  " << qp.H << std::endl;
-  std::cout << "g :  " << qp.g << std::endl;
-  std::cout << "A :  " << qp.A << std::endl;
-  std::cout << "b :  " << qp.b << std::endl;
-  std::cout << "C :  " << qp.C << std::endl;
-  std::cout << "u :  " << qp.u << std::endl;
-  std::cout << "l :  " << qp.l << std::endl;
+  std::cout << "H :  " << qp_random.H << std::endl;
+  std::cout << "g :  " << qp_random.g << std::endl;
+  std::cout << "A :  " << qp_random.A << std::endl;
+  std::cout << "b :  " << qp_random.b << std::endl;
+  std::cout << "C :  " << qp_random.C << std::endl;
+  std::cout << "u :  " << qp_random.u << std::endl;
+  std::cout << "l :  " << qp_random.l << std::endl;
 
   std::cout << "testing updating g" << std::endl;
   auto g = utils::rand::vector_rand<T>(dim);
 
-  qp.g = g;
-  Qp.update(std::nullopt,
-            qp.g,
+  qp_random.g = g;
+  qp.update(std::nullopt,
+            qp_random.g,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -676,22 +676,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt);
 
   std::cout << "after upating" << std::endl;
-  std::cout << "H :  " << Qp.model.H << std::endl;
-  std::cout << "g :  " << Qp.model.g << std::endl;
-  std::cout << "A :  " << Qp.model.A << std::endl;
-  std::cout << "b :  " << Qp.model.b << std::endl;
-  std::cout << "C :  " << Qp.model.C << std::endl;
-  std::cout << "u :  " << Qp.model.u << std::endl;
-  std::cout << "l :  " << Qp.model.l << std::endl;
+  std::cout << "H :  " << qp.model.H << std::endl;
+  std::cout << "g :  " << qp.model.g << std::endl;
+  std::cout << "A :  " << qp.model.A << std::endl;
+  std::cout << "b :  " << qp.model.b << std::endl;
+  std::cout << "C :  " << qp.model.C << std::endl;
+  std::cout << "u :  " << qp.model.u << std::endl;
+  std::cout << "l :  " << qp.model.l << std::endl;
 
-  Qp.solve();
+  qp.solve();
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -700,23 +700,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.solve();
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.solve();
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -726,10 +726,10 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE(
@@ -748,20 +748,20 @@ DOCTEST_TEST_CASE(
   isize n_eq(dim / 4);
   isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -770,52 +770,52 @@ DOCTEST_TEST_CASE(
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
   std::cout << "before upating" << std::endl;
-  std::cout << "H :  " << qp.H << std::endl;
-  std::cout << "g :  " << qp.g << std::endl;
-  std::cout << "A :  " << qp.A << std::endl;
-  std::cout << "b :  " << qp.b << std::endl;
-  std::cout << "C :  " << qp.C << std::endl;
-  std::cout << "u :  " << qp.u << std::endl;
-  std::cout << "l :  " << qp.l << std::endl;
+  std::cout << "H :  " << qp_random.H << std::endl;
+  std::cout << "g :  " << qp_random.g << std::endl;
+  std::cout << "A :  " << qp_random.A << std::endl;
+  std::cout << "b :  " << qp_random.b << std::endl;
+  std::cout << "C :  " << qp_random.C << std::endl;
+  std::cout << "u :  " << qp_random.u << std::endl;
+  std::cout << "l :  " << qp_random.l << std::endl;
 
   std::cout << "testing updating b" << std::endl;
-  qp.H = utils::rand::sparse_positive_definite_rand_not_compressed<T>(
+  qp_random.H = utils::rand::sparse_positive_definite_rand_not_compressed<T>(
     dim, strong_convexity_factor, sparsity_factor);
-  qp.A = utils::rand::sparse_matrix_rand_not_compressed<T>(
+  qp_random.A = utils::rand::sparse_matrix_rand_not_compressed<T>(
     n_eq, dim, sparsity_factor);
   auto x_sol = utils::rand::vector_rand<T>(dim);
   auto delta = utils::Vec<T>(n_in);
   for (proxqp::isize i = 0; i < n_in; ++i) {
     delta(i) = utils::rand::uniform_rand();
   }
-  qp.b = qp.A * x_sol;
-  qp.u = qp.C * x_sol + delta;
-  qp.l = qp.C * x_sol - delta;
-  Qp.update(qp.H, std::nullopt, qp.A, qp.b, std::nullopt, qp.u, qp.l);
+  qp_random.b = qp_random.A * x_sol;
+  qp_random.u = qp_random.C * x_sol + delta;
+  qp_random.l = qp_random.C * x_sol - delta;
+  qp.update(qp_random.H, std::nullopt, qp_random.A, qp_random.b, std::nullopt, qp_random.u, qp_random.l);
 
   std::cout << "after upating" << std::endl;
-  std::cout << "H :  " << Qp.model.H << std::endl;
-  std::cout << "g :  " << Qp.model.g << std::endl;
-  std::cout << "A :  " << Qp.model.A << std::endl;
-  std::cout << "b :  " << Qp.model.b << std::endl;
-  std::cout << "C :  " << Qp.model.C << std::endl;
-  std::cout << "u :  " << Qp.model.u << std::endl;
-  std::cout << "l :  " << Qp.model.l << std::endl;
+  std::cout << "H :  " << qp.model.H << std::endl;
+  std::cout << "g :  " << qp.model.g << std::endl;
+  std::cout << "A :  " << qp.model.A << std::endl;
+  std::cout << "b :  " << qp.model.b << std::endl;
+  std::cout << "C :  " << qp.model.C << std::endl;
+  std::cout << "u :  " << qp.model.u << std::endl;
+  std::cout << "l :  " << qp.model.l << std::endl;
 
-  Qp.solve();
+  qp.solve();
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -824,23 +824,23 @@ DOCTEST_TEST_CASE(
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.solve();
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.solve();
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -850,10 +850,10 @@ DOCTEST_TEST_CASE(
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
@@ -870,20 +870,20 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   isize n_eq(dim / 4);
   isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -892,15 +892,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
   std::cout << "before upating" << std::endl;
-  std::cout << "rho :  " << Qp.results.info.rho << std::endl;
+  std::cout << "rho :  " << qp.results.info.rho << std::endl;
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -912,16 +912,16 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             std::nullopt); // restart the problem with default options
   std::cout << "after upating" << std::endl;
-  std::cout << "rho :  " << Qp.results.info.rho << std::endl;
+  std::cout << "rho :  " << qp.results.info.rho << std::endl;
 
-  Qp.solve();
+  qp.solve();
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -930,34 +930,34 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            true,
            T(1.e-7),
            std::nullopt,
            std::nullopt);
-  std::cout << "rho :  " << Qp2.results.info.rho << std::endl;
-  Qp2.solve();
+  std::cout << "rho :  " << qp2.results.info.rho << std::endl;
+  qp2.solve();
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -967,10 +967,10 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
@@ -987,20 +987,20 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   isize n_eq(dim / 4);
   isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -1009,16 +1009,16 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
   std::cout << "before upating" << std::endl;
-  std::cout << "mu_in :  " << Qp.results.info.mu_in << std::endl;
-  std::cout << "mu_eq :  " << Qp.results.info.mu_eq << std::endl;
+  std::cout << "mu_in :  " << qp.results.info.mu_in << std::endl;
+  std::cout << "mu_eq :  " << qp.results.info.mu_eq << std::endl;
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -1031,17 +1031,17 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             T(1.e-3));
 
   std::cout << "after upating" << std::endl;
-  std::cout << "mu_in :  " << Qp.results.info.mu_in << std::endl;
-  std::cout << "mu_eq :  " << Qp.results.info.mu_eq << std::endl;
+  std::cout << "mu_in :  " << qp.results.info.mu_in << std::endl;
+  std::cout << "mu_eq :  " << qp.results.info.mu_eq << std::endl;
 
-  Qp.solve();
+  qp.solve();
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -1050,34 +1050,34 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            true,
            std::nullopt,
            T(1.e-2),
            T(1.e-3));
-  Qp2.solve();
-  std::cout << "mu_in :  " << Qp2.results.info.mu_in << std::endl;
-  std::cout << "mu_eq :  " << Qp2.results.info.mu_eq << std::endl;
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  qp2.solve();
+  std::cout << "mu_in :  " << qp2.results.info.mu_in << std::endl;
+  std::cout << "mu_eq :  " << qp2.results.info.mu_eq << std::endl;
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -1087,10 +1087,10 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
@@ -1107,21 +1107,21 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   isize n_eq(dim / 4);
   isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -1130,10 +1130,10 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
   auto x_wm = utils::rand::vector_rand<T>(dim);
   auto y_wm = utils::rand::vector_rand<T>(n_eq);
@@ -1142,15 +1142,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   std::cout << "x_wm :  " << x_wm << std::endl;
   std::cout << "y_wm :  " << y_wm << std::endl;
   std::cout << "z_wm :  " << z_wm << std::endl;
-  Qp.settings.initial_guess = InitialGuessStatus::WARM_START;
-  Qp.solve(x_wm, y_wm, z_wm);
+  qp.settings.initial_guess = InitialGuessStatus::WARM_START;
+  qp.solve(x_wm, y_wm, z_wm);
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -1159,25 +1159,25 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.settings.initial_guess = InitialGuessStatus::WARM_START;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.solve(x_wm, y_wm, z_wm);
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.settings.initial_guess = InitialGuessStatus::WARM_START;
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.solve(x_wm, y_wm, z_wm);
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -1187,10 +1187,10 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
@@ -1208,31 +1208,31 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, to_eigen_layout(rowmajor)>(
-      qp.H),
-    qp.g,
+      qp_random.H),
+    qp_random.g,
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, to_eigen_layout(rowmajor)>(
-      qp.A),
-    qp.b,
+      qp_random.A),
+    qp_random.b,
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, to_eigen_layout(rowmajor)>(
-      qp.C),
-    qp.u,
-    qp.l);
-  Qp.solve();
+      qp_random.C),
+    qp_random.u,
+    qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -1253,58 +1253,58 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  std::cout << "------using API solving qp with dim with Qp: " << dim
+  std::cout << "------using API solving qp with dim with qp: " << dim
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.solve();
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.solve();
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  std::cout << "------using API solving qp with dim with Qp2: " << dim
+  std::cout << "------using API solving qp with dim with qp2: " << dim
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE(
@@ -1324,60 +1324,60 @@ DOCTEST_TEST_CASE(
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess =
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  std::cout << "------using API solving qp with dim with Qp: " << dim
+  std::cout << "------using API solving qp with dim with qp: " << dim
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.settings.initial_guess =
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.solve();
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.solve();
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  std::cout << "------using API solving qp with dim with Qp2: " << dim
+  std::cout << "------using API solving qp with dim with qp2: " << dim
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE(
@@ -1397,56 +1397,56 @@ DOCTEST_TEST_CASE(
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess =
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  std::cout << "------using API solving qp with dim with Qp: " << dim
+  std::cout << "------using API solving qp with dim with qp: " << dim
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.settings.initial_guess = InitialGuessStatus::WARM_START;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true);
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.settings.initial_guess = InitialGuessStatus::WARM_START;
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
 
-  auto x = Qp.results.x;
-  auto y = Qp.results.y;
-  auto z = Qp.results.z;
-  // std::cout << "after scaling x " << x <<  " Qp.results.x " << Qp.results.x
+  auto x = qp.results.x;
+  auto y = qp.results.y;
+  auto z = qp.results.z;
+  // std::cout << "after scaling x " << x <<  " qp.results.x " << qp.results.x
   // << std::endl;
-  Qp2.ruiz.scale_primal_in_place({ from_eigen, x });
-  Qp2.ruiz.scale_dual_in_place_eq({ from_eigen, y });
-  Qp2.ruiz.scale_dual_in_place_in({ from_eigen, z });
-  // std::cout << "after scaling x " << x <<  " Qp.results.x " << Qp.results.x
+  qp2.ruiz.scale_primal_in_place({ from_eigen, x });
+  qp2.ruiz.scale_dual_in_place_eq({ from_eigen, y });
+  qp2.ruiz.scale_dual_in_place_in({ from_eigen, z });
+  // std::cout << "after scaling x " << x <<  " qp.results.x " << qp.results.x
   // << std::endl;
-  Qp2.solve(x, y, z);
+  qp2.solve(x, y, z);
 
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -1454,40 +1454,40 @@ DOCTEST_TEST_CASE(
             std::nullopt,
             std::nullopt,
             false);
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
-  std::cout << "------using API solving qp with dim with Qp after warm start "
+  std::cout << "------using API solving qp with dim with qp after warm start "
                "with previous result: "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  std::cout << "------using API solving qp with dim with Qp2: " << dim
+  std::cout << "------using API solving qp with dim with qp2: " << dim
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
@@ -1505,56 +1505,56 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess =
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  std::cout << "------using API solving qp with dim with Qp: " << dim
+  std::cout << "------using API solving qp with dim with qp: " << dim
             << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.settings.initial_guess = InitialGuessStatus::WARM_START;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true);
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.settings.initial_guess = InitialGuessStatus::WARM_START;
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
 
-  auto x = Qp.results.x;
-  auto y = Qp.results.y;
-  auto z = Qp.results.z;
-  // std::cout << "after scaling x " << x <<  " Qp.results.x " << Qp.results.x
+  auto x = qp.results.x;
+  auto y = qp.results.y;
+  auto z = qp.results.z;
+  // std::cout << "after scaling x " << x <<  " qp.results.x " << qp.results.x
   // << std::endl;
-  Qp2.ruiz.scale_primal_in_place({ from_eigen, x });
-  Qp2.ruiz.scale_dual_in_place_eq({ from_eigen, y });
-  Qp2.ruiz.scale_dual_in_place_in({ from_eigen, z });
-  // std::cout << "after scaling x " << x <<  " Qp.results.x " << Qp.results.x
+  qp2.ruiz.scale_primal_in_place({ from_eigen, x });
+  qp2.ruiz.scale_dual_in_place_eq({ from_eigen, y });
+  qp2.ruiz.scale_dual_in_place_in({ from_eigen, z });
+  // std::cout << "after scaling x " << x <<  " qp.results.x " << qp.results.x
   // << std::endl;
-  Qp2.solve(x, y, z);
+  qp2.solve(x, y, z);
 
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -1562,29 +1562,29 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             std::nullopt,
             true);
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
-  std::cout << "------using API solving qp with dim with Qp after warm start "
+  std::cout << "------using API solving qp with dim with qp after warm start "
                "with cold start option: "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -1592,10 +1592,10 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE(
@@ -1615,51 +1615,51 @@ DOCTEST_TEST_CASE(
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess =
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  std::cout << "------using API solving qp with dim with Qp with "
+  std::cout << "------using API solving qp with dim with qp with "
                "preconditioner derived: "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "ruiz vector : " << Qp.ruiz.delta << " ruiz scalar factor "
-            << Qp.ruiz.c << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "ruiz vector : " << qp.ruiz.delta << " ruiz scalar factor "
+            << qp.ruiz.c << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.settings.initial_guess =
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, false);
-  Qp2.solve();
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, false);
+  qp2.solve();
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -1667,12 +1667,12 @@ DOCTEST_TEST_CASE(
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "ruiz vector : " << Qp2.ruiz.delta << " ruiz scalar factor "
-            << Qp2.ruiz.c << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "ruiz vector : " << qp2.ruiz.delta << " ruiz scalar factor "
+            << qp2.ruiz.c << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE(
@@ -1691,36 +1691,36 @@ DOCTEST_TEST_CASE(
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess =
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true);
-  Qp.solve();
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+  qp.solve();
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  std::cout << "------using API solving qp with dim with Qp with "
+  std::cout << "------using API solving qp with dim with qp with "
                "preconditioner derived: "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -1729,13 +1729,13 @@ DOCTEST_TEST_CASE(
             std::nullopt,
             true); // rederive preconditioner with previous options, i.e., redo
                    // exact same derivations
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -1744,36 +1744,36 @@ DOCTEST_TEST_CASE(
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.settings.initial_guess =
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true);
-  Qp2.solve();
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+  qp2.solve();
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   std::cout << "------using API solving qp with preconditioner derivation and "
                "another object QP: "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 
-  Qp2.update(
+  qp2.update(
     std::nullopt,
     std::nullopt,
     std::nullopt,
@@ -1782,19 +1782,19 @@ DOCTEST_TEST_CASE(
     std::nullopt,
     std::nullopt,
     false); // use previous preconditioner: should get same result as well
-  Qp2.solve();
+  qp2.solve();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   std::cout << "------using API solving qp without preconditioner derivation: "
             << dim << " neq: " << n_eq << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "ruiz vector : " << Qp2.ruiz.delta << " ruiz scalar factor "
-            << Qp2.ruiz.c << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "ruiz vector : " << qp2.ruiz.delta << " ruiz scalar factor "
+            << qp2.ruiz.c << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 /////  TESTS ALL INITIAL GUESS OPTIONS FOR MULTIPLE SOLVES AT ONCE
@@ -1811,27 +1811,27 @@ TEST_CASE(
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  dense::QP<T> qp(dim, n_eq, n_in);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
 
   std::cout << "Test with no initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -1839,19 +1839,19 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -1860,19 +1860,19 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -1881,19 +1881,19 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -1902,10 +1902,10 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 }
 
 TEST_CASE("sparse random strongly convex qp with equality and "
@@ -1921,28 +1921,28 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess =
+  dense::QP<T> qp(dim, n_eq, n_in);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
 
   std::cout << "Test with equality constrained initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -1950,19 +1950,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -1971,19 +1971,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -1992,19 +1992,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2013,10 +2013,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 }
 
 TEST_CASE("sparse random strongly convex qp with equality and "
@@ -2032,30 +2032,30 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess =
+  dense::QP<T> qp(dim, n_eq, n_in);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
 
   std::cout << "Test with warm start with previous result and first solve with "
                "equality constrained initial guess"
             << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2063,21 +2063,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2086,19 +2086,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2107,19 +2107,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2128,10 +2128,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 }
 
 TEST_CASE(
@@ -2147,30 +2147,30 @@ TEST_CASE(
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
 
   std::cout << "Test with warm start with previous result and first solve with "
                "no initial guess"
             << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2178,21 +2178,21 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2201,19 +2201,19 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2222,19 +2222,19 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2243,10 +2243,10 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 }
 
 TEST_CASE("sparse random strongly convex qp with equality and "
@@ -2262,31 +2262,31 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess =
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
 
   std::cout << "Test with cold start with previous result and first solve with "
                "equality constrained initial guess"
             << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2294,21 +2294,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2317,19 +2317,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2338,19 +2338,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2359,10 +2359,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 }
 
 TEST_CASE("sparse random strongly convex qp with equality and "
@@ -2377,29 +2377,29 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
 
   std::cout << "Test with warm start and first solve with no initial guess"
             << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2407,20 +2407,20 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  Qp.settings.initial_guess = InitialGuessStatus::WARM_START;
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z);
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.settings.initial_guess = InitialGuessStatus::WARM_START;
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve(qp.results.x, qp.results.y, qp.results.z);
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2429,19 +2429,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z);
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve(qp.results.x, qp.results.y, qp.results.z);
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2450,19 +2450,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z);
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve(qp.results.x, qp.results.y, qp.results.z);
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2471,10 +2471,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 }
 
 TEST_CASE("sparse random strongly convex qp with equality and "
@@ -2489,29 +2489,29 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
 
   std::cout << "Test with warm start and first solve with no initial guess"
             << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2519,24 +2519,24 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp2(dim, n_eq, n_in);
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp2.settings.initial_guess = InitialGuessStatus::WARM_START;
-  std::cout << "dirty workspace for Qp2 : " << Qp2.work.dirty << std::endl;
-  Qp2.solve(Qp.results.x, Qp.results.y, Qp.results.z);
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  dense::QP<T> qp2(dim, n_eq, n_in);
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp2.settings.initial_guess = InitialGuessStatus::WARM_START;
+  std::cout << "dirty workspace for qp2 : " << qp2.work.dirty << std::endl;
+  qp2.solve(qp.results.x, qp.results.y, qp.results.z);
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2545,10 +2545,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 /// TESTS WITH UPDATE + INITIAL GUESS OPTIONS
@@ -2566,28 +2566,28 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
 
   std::cout << "Test with no initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2595,24 +2595,24 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  qp.H *= 2.;
-  qp.g = utils::rand::vector_rand<T>(dim);
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp_random.H *= 2.;
+  qp_random.g = utils::rand::vector_rand<T>(dim);
   bool update_preconditioner = true;
-  Qp.update(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, update_preconditioner);
-  std::cout << "dirty workspace after update : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.update(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+  std::cout << "dirty workspace after update : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2621,19 +2621,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2642,19 +2642,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2663,10 +2663,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 }
 
 TEST_CASE("sparse random strongly convex qp with equality and "
@@ -2682,29 +2682,29 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess =
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
 
   std::cout << "Test with equality constrained initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2712,24 +2712,24 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  qp.H *= 2.;
-  qp.g = utils::rand::vector_rand<T>(dim);
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp_random.H *= 2.;
+  qp_random.g = utils::rand::vector_rand<T>(dim);
   bool update_preconditioner = true;
-  Qp.update(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, update_preconditioner);
-  std::cout << "dirty workspace after update : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.update(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+  std::cout << "dirty workspace after update : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2738,19 +2738,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2759,19 +2759,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2780,10 +2780,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 }
 
 TEST_CASE(
@@ -2800,31 +2800,31 @@ TEST_CASE(
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess =
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
 
   std::cout << "Test with warm start with previous result and first solve with "
                "equality constrained initial guess"
             << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2832,26 +2832,26 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  qp.H *= 2.;
-  qp.g = utils::rand::vector_rand<T>(dim);
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp_random.H *= 2.;
+  qp_random.g = utils::rand::vector_rand<T>(dim);
   bool update_preconditioner = true;
-  Qp.update(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, update_preconditioner);
-  std::cout << "dirty workspace after update : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.update(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+  std::cout << "dirty workspace after update : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2860,19 +2860,19 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2881,19 +2881,19 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2902,10 +2902,10 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 }
 
 TEST_CASE(
@@ -2921,30 +2921,30 @@ TEST_CASE(
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
 
   std::cout << "Test with warm start with previous result and first solve with "
                "no initial guess"
             << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2952,25 +2952,25 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  qp.H *= 2.;
-  qp.g = utils::rand::vector_rand<T>(dim);
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp_random.H *= 2.;
+  qp_random.g = utils::rand::vector_rand<T>(dim);
   bool update_preconditioner = true;
-  Qp.update(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, update_preconditioner);
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.update(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -2979,19 +2979,19 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3000,19 +3000,19 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3021,10 +3021,10 @@ TEST_CASE(
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 }
 
 TEST_CASE("sparse random strongly convex qp with equality and "
@@ -3040,31 +3040,31 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess =
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
 
   std::cout << "Test with cold start with previous result and first solve with "
                "equality constrained initial guess"
             << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3072,32 +3072,32 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  qp.H *= 2.;
-  qp.g = utils::rand::vector_rand<T>(dim);
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp_random.H *= 2.;
+  qp_random.g = utils::rand::vector_rand<T>(dim);
   bool update_preconditioner = true;
-  Qp.update(qp.H,
-            qp.g,
+  qp.update(qp_random.H,
+            qp_random.g,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             update_preconditioner);
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3106,19 +3106,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3127,19 +3127,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3148,10 +3148,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 }
 
 TEST_CASE("sparse random strongly convex qp with equality and "
@@ -3167,29 +3167,29 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
 
   std::cout << "Test with warm start and first solve with no initial guess"
             << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3197,54 +3197,54 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  Qp.settings.initial_guess = InitialGuessStatus::WARM_START;
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  auto x_wm = Qp.results.x; // keep previous result
-  auto y_wm = Qp.results.y;
-  auto z_wm = Qp.results.z;
+  qp.settings.initial_guess = InitialGuessStatus::WARM_START;
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  auto x_wm = qp.results.x; // keep previous result
+  auto y_wm = qp.results.y;
+  auto z_wm = qp.results.z;
   bool update_preconditioner = true;
   // test with a false update (the warm start should give the exact solution)
-  Qp.update(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, update_preconditioner);
-  std::cout << "dirty workspace after update: " << Qp.work.dirty << std::endl;
-  Qp.solve(x_wm, y_wm, z_wm);
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.update(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+  std::cout << "dirty workspace after update: " << qp.work.dirty << std::endl;
+  qp.solve(x_wm, y_wm, z_wm);
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   std::cout << "Second solve " << std::endl;
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  x_wm = Qp.results.x; // keep previous result
-  y_wm = Qp.results.y;
-  z_wm = Qp.results.z;
-  qp.H *= 2.;
-  qp.g = utils::rand::vector_rand<T>(dim);
+  x_wm = qp.results.x; // keep previous result
+  y_wm = qp.results.y;
+  z_wm = qp.results.z;
+  qp_random.H *= 2.;
+  qp_random.g = utils::rand::vector_rand<T>(dim);
   // try now with a real update
-  Qp.update(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, update_preconditioner);
-  std::cout << "dirty workspace after update: " << Qp.work.dirty << std::endl;
-  Qp.solve(x_wm, y_wm, z_wm);
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.update(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+  std::cout << "dirty workspace after update: " << qp.work.dirty << std::endl;
+  qp.solve(x_wm, y_wm, z_wm);
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3253,19 +3253,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z);
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve(qp.results.x, qp.results.y, qp.results.z);
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3274,19 +3274,19 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  std::cout << "dirty workspace : " << Qp.work.dirty << std::endl;
-  Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z);
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
+  qp.solve(qp.results.x, qp.results.y, qp.results.z);
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3295,10 +3295,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 }
 
 TEST_CASE("Test initializaton with rho for different initial guess")
@@ -3312,29 +3312,29 @@ TEST_CASE("Test initializaton with rho for different initial guess")
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
 
   std::cout << "Test initializaton with rho for different initial guess"
             << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true, T(1.E-7));
-  Qp.solve();
-  CHECK(Qp.results.info.rho == T(1.E-7));
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+  qp.solve();
+  CHECK(qp.results.info.rho == T(1.E-7));
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3342,25 +3342,25 @@ TEST_CASE("Test initializaton with rho for different initial guess")
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp2(dim, n_eq, n_in);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.settings.initial_guess =
+  dense::QP<T> qp2(dim, n_eq, n_in);
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true, T(1.E-7));
-  Qp2.solve();
-  CHECK(Qp2.results.info.rho == T(1.E-7));
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+  qp2.solve();
+  CHECK(qp2.results.info.rho == T(1.E-7));
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3368,25 +3368,25 @@ TEST_CASE("Test initializaton with rho for different initial guess")
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp3(dim, n_eq, n_in);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.settings.initial_guess =
+  dense::QP<T> qp3(dim, n_eq, n_in);
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true, T(1.E-7));
-  Qp3.solve();
-  CHECK(Qp3.results.info.rho == T(1.E-7));
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  qp3.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+  qp3.solve();
+  CHECK(qp3.results.info.rho == T(1.E-7));
+  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3394,25 +3394,25 @@ TEST_CASE("Test initializaton with rho for different initial guess")
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp3.results.info.iter
+  std::cout << "total number of iteration: " << qp3.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp3.results.info.setup_time << " solve time "
-            << Qp3.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp3.results.info.setup_time << " solve time "
+            << qp3.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp4(dim, n_eq, n_in);
-  Qp4.settings.eps_abs = eps_abs;
-  Qp4.settings.eps_rel = 0;
-  Qp4.settings.initial_guess =
+  dense::QP<T> qp4(dim, n_eq, n_in);
+  qp4.settings.eps_abs = eps_abs;
+  qp4.settings.eps_rel = 0;
+  qp4.settings.initial_guess =
     InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  Qp4.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true, T(1.E-7));
-  Qp4.solve();
-  CHECK(Qp4.results.info.rho == T(1.E-7));
-  pri_res = std::max((qp.A * Qp4.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp4.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp4.results.x - qp.l))
+  qp4.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+  qp4.solve();
+  CHECK(qp4.results.info.rho == T(1.E-7));
+  pri_res = std::max((qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp4.results.x + qp.g + qp.A.transpose() * Qp4.results.y +
-             qp.C.transpose() * Qp4.results.z)
+  dua_res = (qp_random.H * qp4.results.x + qp_random.g + qp_random.A.transpose() * qp4.results.y +
+             qp_random.C.transpose() * qp4.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3420,24 +3420,24 @@ TEST_CASE("Test initializaton with rho for different initial guess")
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp4.results.info.iter
+  std::cout << "total number of iteration: " << qp4.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp4.results.info.setup_time << " solve time "
-            << Qp4.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp4.results.info.setup_time << " solve time "
+            << qp4.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp5(dim, n_eq, n_in);
-  Qp5.settings.eps_abs = eps_abs;
-  Qp5.settings.eps_rel = 0;
-  Qp5.settings.initial_guess = InitialGuessStatus::WARM_START;
-  Qp5.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true, T(1.E-7));
-  Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z);
-  CHECK(Qp5.results.info.rho == T(1.E-7));
-  pri_res = std::max((qp.A * Qp5.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp5.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp5.results.x - qp.l))
+  dense::QP<T> qp5(dim, n_eq, n_in);
+  qp5.settings.eps_abs = eps_abs;
+  qp5.settings.eps_rel = 0;
+  qp5.settings.initial_guess = InitialGuessStatus::WARM_START;
+  qp5.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+  qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
+  CHECK(qp5.results.info.rho == T(1.E-7));
+  pri_res = std::max((qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp5.results.x + qp.g + qp.A.transpose() * Qp5.results.y +
-             qp.C.transpose() * Qp5.results.z)
+  dua_res = (qp_random.H * qp5.results.x + qp_random.g + qp_random.A.transpose() * qp5.results.y +
+             qp_random.C.transpose() * qp5.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3445,10 +3445,10 @@ TEST_CASE("Test initializaton with rho for different initial guess")
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp5.results.info.iter
+  std::cout << "total number of iteration: " << qp5.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp5.results.info.setup_time << " solve time "
-            << Qp5.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp5.results.info.setup_time << " solve time "
+            << qp5.results.info.solve_time << std::endl;
 }
 
 TEST_CASE("Test g update for different initial guess")
@@ -3462,230 +3462,230 @@ TEST_CASE("Test g update for different initial guess")
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
 
   std::cout << "Test g update for different initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  auto old_g = qp.g;
-  qp.g = utils::rand::vector_rand<T>(dim);
-  Qp.update(std::nullopt,
-            qp.g,
+  auto old_g = qp_random.g;
+  qp_random.g = utils::rand::vector_rand<T>(dim);
+  qp.update(std::nullopt,
+            qp_random.g,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt);
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK((Qp.model.g - qp.g).lpNorm<Eigen::Infinity>() <= eps_abs);
+  CHECK((qp.model.g - qp_random.g).lpNorm<Eigen::Infinity>() <= eps_abs);
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp2(dim, n_eq, n_in);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.settings.initial_guess =
+  dense::QP<T> qp2(dim, n_eq, n_in);
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  Qp2.init(qp.H, old_g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.solve();
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  qp2.init(qp_random.H, old_g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.solve();
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + old_g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + old_g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  Qp2.update(std::nullopt,
-             qp.g,
+  qp2.update(std::nullopt,
+             qp_random.g,
              std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt);
-  Qp2.solve();
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  qp2.solve();
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK((Qp2.model.g - qp.g).lpNorm<Eigen::Infinity>() <= eps_abs);
+  CHECK((qp2.model.g - qp_random.g).lpNorm<Eigen::Infinity>() <= eps_abs);
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp3(dim, n_eq, n_in);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.settings.initial_guess =
+  dense::QP<T> qp3(dim, n_eq, n_in);
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  Qp3.init(qp.H, old_g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp3.solve();
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  qp3.init(qp_random.H, old_g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp3.solve();
+  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + old_g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + old_g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  Qp3.update(std::nullopt,
-             qp.g,
+  qp3.update(std::nullopt,
+             qp_random.g,
              std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt);
-  Qp3.solve();
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  qp3.solve();
+  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK((Qp3.model.g - qp.g).lpNorm<Eigen::Infinity>() <= eps_abs);
+  CHECK((qp3.model.g - qp_random.g).lpNorm<Eigen::Infinity>() <= eps_abs);
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp3.results.info.iter
+  std::cout << "total number of iteration: " << qp3.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp3.results.info.setup_time << " solve time "
-            << Qp3.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp3.results.info.setup_time << " solve time "
+            << qp3.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp4(dim, n_eq, n_in);
-  Qp4.settings.eps_abs = eps_abs;
-  Qp4.settings.eps_rel = 0;
-  Qp4.settings.initial_guess =
+  dense::QP<T> qp4(dim, n_eq, n_in);
+  qp4.settings.eps_abs = eps_abs;
+  qp4.settings.eps_rel = 0;
+  qp4.settings.initial_guess =
     InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  Qp4.init(qp.H, old_g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp4.solve();
-  pri_res = std::max((qp.A * Qp4.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp4.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp4.results.x - qp.l))
+  qp4.init(qp_random.H, old_g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp4.solve();
+  pri_res = std::max((qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp4.results.x + old_g + qp.A.transpose() * Qp4.results.y +
-             qp.C.transpose() * Qp4.results.z)
+  dua_res = (qp_random.H * qp4.results.x + old_g + qp_random.A.transpose() * qp4.results.y +
+             qp_random.C.transpose() * qp4.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  Qp4.update(std::nullopt,
-             qp.g,
+  qp4.update(std::nullopt,
+             qp_random.g,
              std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt);
-  Qp4.solve();
-  pri_res = std::max((qp.A * Qp4.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp4.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp4.results.x - qp.l))
+  qp4.solve();
+  pri_res = std::max((qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp4.results.x + qp.g + qp.A.transpose() * Qp4.results.y +
-             qp.C.transpose() * Qp4.results.z)
+  dua_res = (qp_random.H * qp4.results.x + qp_random.g + qp_random.A.transpose() * qp4.results.y +
+             qp_random.C.transpose() * qp4.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK((Qp4.model.g - qp.g).lpNorm<Eigen::Infinity>() <= eps_abs);
+  CHECK((qp4.model.g - qp_random.g).lpNorm<Eigen::Infinity>() <= eps_abs);
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp4.results.info.iter
+  std::cout << "total number of iteration: " << qp4.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp4.results.info.setup_time << " solve time "
-            << Qp4.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp4.results.info.setup_time << " solve time "
+            << qp4.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp5(dim, n_eq, n_in);
-  Qp5.settings.eps_abs = eps_abs;
-  Qp5.settings.eps_rel = 0;
-  Qp5.settings.initial_guess = InitialGuessStatus::WARM_START;
-  Qp5.init(qp.H, old_g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z);
-  pri_res = std::max((qp.A * Qp5.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp5.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp5.results.x - qp.l))
+  dense::QP<T> qp5(dim, n_eq, n_in);
+  qp5.settings.eps_abs = eps_abs;
+  qp5.settings.eps_rel = 0;
+  qp5.settings.initial_guess = InitialGuessStatus::WARM_START;
+  qp5.init(qp_random.H, old_g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
+  pri_res = std::max((qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp5.results.x + old_g + qp.A.transpose() * Qp5.results.y +
-             qp.C.transpose() * Qp5.results.z)
+  dua_res = (qp_random.H * qp5.results.x + old_g + qp_random.A.transpose() * qp5.results.y +
+             qp_random.C.transpose() * qp5.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  Qp5.update(std::nullopt,
-             qp.g,
+  qp5.update(std::nullopt,
+             qp_random.g,
              std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt);
-  Qp5.solve();
-  pri_res = std::max((qp.A * Qp5.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp5.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp5.results.x - qp.l))
+  qp5.solve();
+  pri_res = std::max((qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp5.results.x + qp.g + qp.A.transpose() * Qp5.results.y +
-             qp.C.transpose() * Qp5.results.z)
+  dua_res = (qp_random.H * qp5.results.x + qp_random.g + qp_random.A.transpose() * qp5.results.y +
+             qp_random.C.transpose() * qp5.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK((Qp5.model.g - qp.g).lpNorm<Eigen::Infinity>() <= eps_abs);
+  CHECK((qp5.model.g - qp_random.g).lpNorm<Eigen::Infinity>() <= eps_abs);
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp5.results.info.iter
+  std::cout << "total number of iteration: " << qp5.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp5.results.info.setup_time << " solve time "
-            << Qp5.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp5.results.info.setup_time << " solve time "
+            << qp5.results.info.solve_time << std::endl;
 }
 
 TEST_CASE("Test A update for different initial guess")
@@ -3699,230 +3699,230 @@ TEST_CASE("Test A update for different initial guess")
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
 
   std::cout << "Test A update for different initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   auto new_A = utils::rand::sparse_matrix_rand_not_compressed<T>(
     n_eq, dim, sparsity_factor);
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             new_A,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt);
-  Qp.solve();
-  pri_res = std::max((new_A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.solve();
+  pri_res = std::max((new_A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + new_A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + new_A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK((Qp.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
+  CHECK((qp.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp2(dim, n_eq, n_in);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.settings.initial_guess =
+  dense::QP<T> qp2(dim, n_eq, n_in);
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.solve();
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.solve();
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  Qp2.update(std::nullopt,
+  qp2.update(std::nullopt,
              std::nullopt,
              new_A,
              std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt);
-  Qp2.solve();
-  pri_res = std::max((new_A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  qp2.solve();
+  pri_res = std::max((new_A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + new_A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + new_A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK((Qp2.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
+  CHECK((qp2.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp3(dim, n_eq, n_in);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.settings.initial_guess =
+  dense::QP<T> qp3(dim, n_eq, n_in);
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp3.solve();
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  qp3.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp3.solve();
+  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              new_A,
              std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt);
-  Qp3.solve();
-  pri_res = std::max((new_A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  qp3.solve();
+  pri_res = std::max((new_A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + qp.g + new_A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g + new_A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK((Qp3.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
+  CHECK((qp3.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp3.results.info.iter
+  std::cout << "total number of iteration: " << qp3.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp3.results.info.setup_time << " solve time "
-            << Qp3.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp3.results.info.setup_time << " solve time "
+            << qp3.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp4(dim, n_eq, n_in);
-  Qp4.settings.eps_abs = eps_abs;
-  Qp4.settings.eps_rel = 0;
-  Qp4.settings.initial_guess =
+  dense::QP<T> qp4(dim, n_eq, n_in);
+  qp4.settings.eps_abs = eps_abs;
+  qp4.settings.eps_rel = 0;
+  qp4.settings.initial_guess =
     InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  Qp4.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp4.solve();
-  pri_res = std::max((qp.A * Qp4.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp4.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp4.results.x - qp.l))
+  qp4.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp4.solve();
+  pri_res = std::max((qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp4.results.x + qp.g + qp.A.transpose() * Qp4.results.y +
-             qp.C.transpose() * Qp4.results.z)
+  dua_res = (qp_random.H * qp4.results.x + qp_random.g + qp_random.A.transpose() * qp4.results.y +
+             qp_random.C.transpose() * qp4.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  Qp4.update(std::nullopt,
+  qp4.update(std::nullopt,
              std::nullopt,
              new_A,
              std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt);
-  Qp4.solve();
-  pri_res = std::max((new_A * Qp4.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp4.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp4.results.x - qp.l))
+  qp4.solve();
+  pri_res = std::max((new_A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp4.results.x + qp.g + new_A.transpose() * Qp4.results.y +
-             qp.C.transpose() * Qp4.results.z)
+  dua_res = (qp_random.H * qp4.results.x + qp_random.g + new_A.transpose() * qp4.results.y +
+             qp_random.C.transpose() * qp4.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK((Qp4.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
+  CHECK((qp4.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp4.results.info.iter
+  std::cout << "total number of iteration: " << qp4.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp4.results.info.setup_time << " solve time "
-            << Qp4.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp4.results.info.setup_time << " solve time "
+            << qp4.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp5(dim, n_eq, n_in);
-  Qp5.settings.eps_abs = eps_abs;
-  Qp5.settings.eps_rel = 0;
-  Qp5.settings.initial_guess = InitialGuessStatus::WARM_START;
-  Qp5.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z);
-  pri_res = std::max((qp.A * Qp5.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp5.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp5.results.x - qp.l))
+  dense::QP<T> qp5(dim, n_eq, n_in);
+  qp5.settings.eps_abs = eps_abs;
+  qp5.settings.eps_rel = 0;
+  qp5.settings.initial_guess = InitialGuessStatus::WARM_START;
+  qp5.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
+  pri_res = std::max((qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp5.results.x + qp.g + qp.A.transpose() * Qp5.results.y +
-             qp.C.transpose() * Qp5.results.z)
+  dua_res = (qp_random.H * qp5.results.x + qp_random.g + qp_random.A.transpose() * qp5.results.y +
+             qp_random.C.transpose() * qp5.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  Qp5.update(std::nullopt,
+  qp5.update(std::nullopt,
              std::nullopt,
              new_A,
              std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt);
-  Qp5.solve();
-  pri_res = std::max((new_A * Qp5.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp5.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp5.results.x - qp.l))
+  qp5.solve();
+  pri_res = std::max((new_A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp5.results.x + qp.g + new_A.transpose() * Qp5.results.y +
-             qp.C.transpose() * Qp5.results.z)
+  dua_res = (qp_random.H * qp5.results.x + qp_random.g + new_A.transpose() * qp5.results.y +
+             qp_random.C.transpose() * qp5.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK((Qp5.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
+  CHECK((qp5.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp5.results.info.iter
+  std::cout << "total number of iteration: " << qp5.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp5.results.info.setup_time << " solve time "
-            << Qp5.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp5.results.info.setup_time << " solve time "
+            << qp5.results.info.solve_time << std::endl;
 }
 
 TEST_CASE("Test rho update for different initial guess")
@@ -3936,32 +3936,32 @@ TEST_CASE("Test rho update for different initial guess")
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
 
   std::cout << "Test rho update for different initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -3970,43 +3970,43 @@ TEST_CASE("Test rho update for different initial guess")
             std::nullopt,
             true,
             T(1.E-7));
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK(Qp.results.info.rho == T(1.E-7));
+  CHECK(qp.results.info.rho == T(1.E-7));
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp2(dim, n_eq, n_in);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.settings.initial_guess =
+  dense::QP<T> qp2(dim, n_eq, n_in);
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.solve();
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.solve();
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  Qp2.update(std::nullopt,
+  qp2.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -4015,43 +4015,43 @@ TEST_CASE("Test rho update for different initial guess")
              std::nullopt,
              true,
              T(1.E-7));
-  Qp2.solve();
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  qp2.solve();
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK(Qp2.results.info.rho == T(1.e-7));
+  CHECK(qp2.results.info.rho == T(1.e-7));
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp3(dim, n_eq, n_in);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.settings.initial_guess =
+  dense::QP<T> qp3(dim, n_eq, n_in);
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp3.solve();
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  qp3.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp3.solve();
+  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -4060,43 +4060,43 @@ TEST_CASE("Test rho update for different initial guess")
              std::nullopt,
              true,
              T(1.E-7));
-  Qp3.solve();
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  qp3.solve();
+  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK(Qp3.results.info.rho == T(1.e-7));
+  CHECK(qp3.results.info.rho == T(1.e-7));
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp3.results.info.iter
+  std::cout << "total number of iteration: " << qp3.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp3.results.info.setup_time << " solve time "
-            << Qp3.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp3.results.info.setup_time << " solve time "
+            << qp3.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp4(dim, n_eq, n_in);
-  Qp4.settings.eps_abs = eps_abs;
-  Qp4.settings.eps_rel = 0;
-  Qp4.settings.initial_guess =
+  dense::QP<T> qp4(dim, n_eq, n_in);
+  qp4.settings.eps_abs = eps_abs;
+  qp4.settings.eps_rel = 0;
+  qp4.settings.initial_guess =
     InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  Qp4.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp4.solve();
-  pri_res = std::max((qp.A * Qp4.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp4.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp4.results.x - qp.l))
+  qp4.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp4.solve();
+  pri_res = std::max((qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp4.results.x + qp.g + qp.A.transpose() * Qp4.results.y +
-             qp.C.transpose() * Qp4.results.z)
+  dua_res = (qp_random.H * qp4.results.x + qp_random.g + qp_random.A.transpose() * qp4.results.y +
+             qp_random.C.transpose() * qp4.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  Qp4.update(std::nullopt,
+  qp4.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -4105,42 +4105,42 @@ TEST_CASE("Test rho update for different initial guess")
              std::nullopt,
              true,
              T(1.E-7));
-  Qp4.solve();
-  pri_res = std::max((qp.A * Qp4.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp4.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp4.results.x - qp.l))
+  qp4.solve();
+  pri_res = std::max((qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp4.results.x + qp.g + qp.A.transpose() * Qp4.results.y +
-             qp.C.transpose() * Qp4.results.z)
+  dua_res = (qp_random.H * qp4.results.x + qp_random.g + qp_random.A.transpose() * qp4.results.y +
+             qp_random.C.transpose() * qp4.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK(Qp4.results.info.rho == T(1.e-7));
+  CHECK(qp4.results.info.rho == T(1.e-7));
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp4.results.info.iter
+  std::cout << "total number of iteration: " << qp4.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp4.results.info.setup_time << " solve time "
-            << Qp4.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp4.results.info.setup_time << " solve time "
+            << qp4.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp5(dim, n_eq, n_in);
-  Qp5.settings.eps_abs = eps_abs;
-  Qp5.settings.eps_rel = 0;
-  Qp5.settings.initial_guess = InitialGuessStatus::WARM_START;
-  Qp5.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z);
-  pri_res = std::max((qp.A * Qp5.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp5.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp5.results.x - qp.l))
+  dense::QP<T> qp5(dim, n_eq, n_in);
+  qp5.settings.eps_abs = eps_abs;
+  qp5.settings.eps_rel = 0;
+  qp5.settings.initial_guess = InitialGuessStatus::WARM_START;
+  qp5.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
+  pri_res = std::max((qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp5.results.x + qp.g + qp.A.transpose() * Qp5.results.y +
-             qp.C.transpose() * Qp5.results.z)
+  dua_res = (qp_random.H * qp5.results.x + qp_random.g + qp_random.A.transpose() * qp5.results.y +
+             qp_random.C.transpose() * qp5.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
-  Qp5.update(std::nullopt,
+  qp5.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -4149,25 +4149,25 @@ TEST_CASE("Test rho update for different initial guess")
              std::nullopt,
              true,
              T(1.E-7));
-  Qp5.solve();
-  pri_res = std::max((qp.A * Qp5.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp5.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp5.results.x - qp.l))
+  qp5.solve();
+  pri_res = std::max((qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp5.results.x + qp.g + qp.A.transpose() * Qp5.results.y +
-             qp.C.transpose() * Qp5.results.z)
+  dua_res = (qp_random.H * qp5.results.x + qp_random.g + qp_random.A.transpose() * qp5.results.y +
+             qp_random.C.transpose() * qp5.results.z)
               .lpNorm<Eigen::Infinity>();
-  CHECK(Qp5.results.info.rho == T(1.e-7));
+  CHECK(qp5.results.info.rho == T(1.e-7));
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp5.results.info.iter
+  std::cout << "total number of iteration: " << qp5.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp5.results.info.setup_time << " solve time "
-            << Qp5.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp5.results.info.setup_time << " solve time "
+            << qp5.results.info.solve_time << std::endl;
 }
 
 TEST_CASE("Test g update for different warm start with previous result option")
@@ -4181,29 +4181,29 @@ TEST_CASE("Test g update for different warm start with previous result option")
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  dense::QP<T> Qp(dim, n_eq, n_in);
+  dense::QP<T> qp(dim, n_eq, n_in);
 
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.settings.initial_guess =
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
 
   std::cout << "Test rho update for different initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -4211,28 +4211,28 @@ TEST_CASE("Test g update for different warm start with previous result option")
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
   // a new linear cost slightly modified
-  auto g = qp.g * 0.95;
+  auto g = qp_random.g * 0.95;
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             g,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt);
-  Qp.solve();
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  qp.solve();
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -4240,24 +4240,24 @@ TEST_CASE("Test g update for different warm start with previous result option")
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-            << Qp.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
 
-  dense::QP<T> Qp2(dim, n_eq, n_in);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.settings.initial_guess =
+  dense::QP<T> qp2(dim, n_eq, n_in);
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  Qp2.init(qp.H, g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp2.solve();
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  qp2.init(qp_random.H, g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.solve();
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -4265,10 +4265,10 @@ TEST_CASE("Test g update for different warm start with previous result option")
             << std::endl;
   std::cout << "; dual residual " << dua_res << "; primal residual " << pri_res
             << std::endl;
-  std::cout << "total number of iteration: " << Qp2.results.info.iter
+  std::cout << "total number of iteration: " << qp2.results.info.iter
             << std::endl;
-  std::cout << "setup timing " << Qp2.results.info.setup_time << " solve time "
-            << Qp2.results.info.solve_time << std::endl;
+  std::cout << "setup timing " << qp2.results.info.setup_time << " solve time "
+            << qp2.results.info.solve_time << std::endl;
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
@@ -4287,37 +4287,37 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -4326,93 +4326,93 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  dense::QP<T> qp3{ dim, n_eq, n_in }; // creating QP object
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -4422,18 +4422,18 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
              compute_preconditioner,
              1.e-6,
              1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
+  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -4455,39 +4455,39 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.initial_guess =
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -4496,97 +4496,97 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.initial_guess =
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
-  Qp3.settings.initial_guess =
+  dense::QP<T> qp3{ dim, n_eq, n_in }; // creating QP object
+  qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -4596,18 +4596,18 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
              compute_preconditioner,
              1.e-6,
              1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
+  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -4629,39 +4629,39 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.initial_guess =
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -4670,97 +4670,97 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.initial_guess =
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
-  Qp3.settings.initial_guess =
+  dense::QP<T> qp3{ dim, n_eq, n_in }; // creating QP object
+  qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -4770,18 +4770,18 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
              compute_preconditioner,
              1.e-6,
              1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
+  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -4803,38 +4803,38 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -4843,95 +4843,95 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
-  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  dense::QP<T> qp3{ dim, n_eq, n_in }; // creating QP object
+  qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -4941,18 +4941,18 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
              compute_preconditioner,
              1.e-6,
              1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
+  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                        .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -4974,52 +4974,52 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+    qp.solve();
+    DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
+    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -5029,79 +5029,79 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             compute_preconditioner,
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+    qp.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
+    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
     // warm start with previous result used, hence if the qp is small and
     // simple, the parameters should not changed during first solve, and also
     // after as we start at the solution
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-    Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp2.results.x - qp.l))
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+    qp2.solve();
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-               qp.C.transpose() * Qp2.results.z)
+    dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+               qp_random.C.transpose() * qp2.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  dense::QP<T> qp3{ dim, n_eq, n_in }; // creating QP object
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
@@ -5110,29 +5110,29 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     // warm start with previous result used, hence if the qp is small and
     // simple, the parameters should not changed during first solve, and also
     // after as we start at the solution
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-               qp.C.transpose() * Qp3.results.z)
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -5146,23 +5146,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     // warm start with previous result used, hence if the qp is small and
     // simple, the parameters should not changed during first solve, and also
     // after as we start at the solution
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-               qp.C.transpose() * Qp3.results.z)
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
@@ -5185,54 +5185,54 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.initial_guess =
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+    qp.solve();
+    DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
+    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -5242,108 +5242,108 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             compute_preconditioner,
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+    qp.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
+    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.initial_guess =
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-    Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp2.results.x - qp.l))
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+    qp2.solve();
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-               qp.C.transpose() * Qp2.results.z)
+    dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+               qp_random.C.transpose() * qp2.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
-  Qp3.settings.initial_guess =
+  dense::QP<T> qp3{ dim, n_eq, n_in }; // creating QP object
+  qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-               qp.C.transpose() * Qp3.results.z)
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -5354,23 +5354,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
              1.e-6,
              1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-               qp.C.transpose() * Qp3.results.z)
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
@@ -5394,54 +5394,54 @@ DOCTEST_TEST_CASE(
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.initial_guess =
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+    qp.solve();
+    DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
+    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -5451,108 +5451,108 @@ DOCTEST_TEST_CASE(
             compute_preconditioner,
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+    qp.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
+    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.initial_guess =
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-    Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp2.results.x - qp.l))
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+    qp2.solve();
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-               qp.C.transpose() * Qp2.results.z)
+    dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+               qp_random.C.transpose() * qp2.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
-  Qp3.settings.initial_guess =
+  dense::QP<T> qp3{ dim, n_eq, n_in }; // creating QP object
+  qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-               qp.C.transpose() * Qp3.results.z)
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -5563,23 +5563,23 @@ DOCTEST_TEST_CASE(
              1.e-6,
              1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-               qp.C.transpose() * Qp3.results.z)
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
@@ -5602,53 +5602,53 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_eq(dim / 4);
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+    qp.solve();
+    DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
+    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -5658,106 +5658,106 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             compute_preconditioner,
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+    qp.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
+    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
+  qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-    Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp2.results.x - qp.l))
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+    qp2.solve();
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-               qp.C.transpose() * Qp2.results.z)
+    dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+               qp_random.C.transpose() * qp2.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
-  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  dense::QP<T> qp3{ dim, n_eq, n_in }; // creating QP object
+  qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-               qp.C.transpose() * Qp3.results.z)
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -5768,23 +5768,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
              1.e-6,
              1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                          .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-               qp.C.transpose() * Qp3.results.z)
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);

--- a/test/src/dense_qp_wrapper.cpp
+++ b/test/src/dense_qp_wrapper.cpp
@@ -32,14 +32,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -83,11 +91,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
 
   qp.solve();
 
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -106,14 +116,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
   qp2.settings.eps_abs = eps_abs;
   qp2.settings.eps_rel = 0;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.solve();
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -151,14 +169,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -204,11 +230,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
 
   qp.solve();
 
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -226,14 +254,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
   qp2.settings.eps_abs = eps_abs;
   qp2.settings.eps_rel = 0;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.solve();
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -271,14 +307,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -324,11 +368,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
 
   qp.solve();
 
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -346,14 +392,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
   qp2.settings.eps_abs = eps_abs;
   qp2.settings.eps_rel = 0;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.solve();
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -391,14 +445,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -444,11 +506,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
 
   qp.solve();
 
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -466,14 +530,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
   qp2.settings.eps_abs = eps_abs;
   qp2.settings.eps_rel = 0;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.solve();
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -509,14 +581,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -567,11 +647,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
 
   qp.solve();
 
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -589,14 +671,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
   qp2.settings.eps_abs = eps_abs;
   qp2.settings.eps_rel = 0;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.solve();
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -632,14 +722,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -686,11 +784,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
 
   qp.solve();
 
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -708,14 +808,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
   qp2.settings.eps_abs = eps_abs;
   qp2.settings.eps_rel = 0;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.solve();
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -753,14 +861,22 @@ DOCTEST_TEST_CASE(
   dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -797,7 +913,13 @@ DOCTEST_TEST_CASE(
   qp_random.b = qp_random.A * x_sol;
   qp_random.u = qp_random.C * x_sol + delta;
   qp_random.l = qp_random.C * x_sol - delta;
-  qp.update(qp_random.H, std::nullopt, qp_random.A, qp_random.b, std::nullopt, qp_random.u, qp_random.l);
+  qp.update(qp_random.H,
+            std::nullopt,
+            qp_random.A,
+            qp_random.b,
+            std::nullopt,
+            qp_random.u,
+            qp_random.l);
 
   std::cout << "after upating" << std::endl;
   std::cout << "H :  " << qp.model.H << std::endl;
@@ -810,11 +932,13 @@ DOCTEST_TEST_CASE(
 
   qp.solve();
 
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -832,14 +956,22 @@ DOCTEST_TEST_CASE(
   dense::QP<T> qp2{ dim, n_eq, n_in }; // creating QP object
   qp2.settings.eps_abs = eps_abs;
   qp2.settings.eps_rel = 0;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.solve();
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -875,14 +1007,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -916,11 +1056,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
 
   qp.solve();
 
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -952,11 +1094,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   std::cout << "rho :  " << qp2.results.info.rho << std::endl;
   qp2.solve();
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -992,14 +1136,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1036,11 +1188,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
 
   qp.solve();
 
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1072,11 +1226,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   qp2.solve();
   std::cout << "mu_in :  " << qp2.results.info.mu_in << std::endl;
   std::cout << "mu_eq :  " << qp2.results.info.mu_eq << std::endl;
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1113,14 +1269,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1145,11 +1309,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   qp.settings.initial_guess = InitialGuessStatus::WARM_START;
   qp.solve(x_wm, y_wm, z_wm);
 
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1169,14 +1335,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   qp2.settings.eps_abs = eps_abs;
   qp2.settings.eps_rel = 0;
   qp2.settings.initial_guess = InitialGuessStatus::WARM_START;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.solve(x_wm, y_wm, z_wm);
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1227,11 +1401,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1260,14 +1436,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1285,14 +1469,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   qp2.settings.eps_abs = eps_abs;
   qp2.settings.eps_rel = 0;
   qp2.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.solve();
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1332,14 +1524,22 @@ DOCTEST_TEST_CASE(
   qp.settings.eps_rel = 0;
   qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1358,14 +1558,22 @@ DOCTEST_TEST_CASE(
   qp2.settings.eps_rel = 0;
   qp2.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.solve();
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1405,14 +1613,22 @@ DOCTEST_TEST_CASE(
   qp.settings.eps_rel = 0;
   qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1430,7 +1646,14 @@ DOCTEST_TEST_CASE(
   qp2.settings.eps_abs = eps_abs;
   qp2.settings.eps_rel = 0;
   qp2.settings.initial_guess = InitialGuessStatus::WARM_START;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
+           true);
 
   auto x = qp.results.x;
   auto y = qp.results.y;
@@ -1455,11 +1678,13 @@ DOCTEST_TEST_CASE(
             std::nullopt,
             false);
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   std::cout << "------using API solving qp with dim with qp after warm start "
@@ -1471,11 +1696,13 @@ DOCTEST_TEST_CASE(
             << std::endl;
   std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
             << qp.results.info.solve_time << std::endl;
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1513,14 +1740,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   qp.settings.eps_rel = 0;
   qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1538,7 +1773,14 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   qp2.settings.eps_abs = eps_abs;
   qp2.settings.eps_rel = 0;
   qp2.settings.initial_guess = InitialGuessStatus::WARM_START;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
+           true);
 
   auto x = qp.results.x;
   auto y = qp.results.y;
@@ -1563,11 +1805,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             true);
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   std::cout << "------using API solving qp with dim with qp after warm start "
@@ -1579,11 +1823,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             << std::endl;
   std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
             << qp.results.info.solve_time << std::endl;
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1623,14 +1869,23 @@ DOCTEST_TEST_CASE(
   qp.settings.eps_rel = 0;
   qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          true);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1652,13 +1907,22 @@ DOCTEST_TEST_CASE(
   qp2.settings.eps_rel = 0;
   qp2.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, false);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
+           false);
   qp2.solve();
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1699,13 +1963,22 @@ DOCTEST_TEST_CASE(
   qp.settings.eps_rel = 0;
   qp.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          true);
   qp.solve();
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1730,11 +2003,13 @@ DOCTEST_TEST_CASE(
             true); // rederive preconditioner with previous options, i.e., redo
                    // exact same derivations
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -1754,13 +2029,22 @@ DOCTEST_TEST_CASE(
   qp2.settings.eps_rel = 0;
   qp2.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
+           true);
   qp2.solve();
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   std::cout << "------using API solving qp with preconditioner derivation and "
@@ -1823,14 +2107,22 @@ TEST_CASE(
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -1846,11 +2138,13 @@ TEST_CASE(
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -1867,11 +2161,13 @@ TEST_CASE(
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -1888,11 +2184,13 @@ TEST_CASE(
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -1934,14 +2232,22 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -1957,11 +2263,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -1978,11 +2286,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -1999,11 +2309,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2047,14 +2359,22 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2072,11 +2392,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2093,11 +2415,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2114,11 +2438,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2162,14 +2488,22 @@ TEST_CASE(
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2187,11 +2521,13 @@ TEST_CASE(
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2208,11 +2544,13 @@ TEST_CASE(
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2229,11 +2567,13 @@ TEST_CASE(
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2278,14 +2618,22 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2303,11 +2651,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2324,11 +2674,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2345,11 +2697,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2391,14 +2745,22 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2415,11 +2777,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   qp.settings.initial_guess = InitialGuessStatus::WARM_START;
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve(qp.results.x, qp.results.y, qp.results.z);
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2436,11 +2800,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve(qp.results.x, qp.results.y, qp.results.z);
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2457,11 +2823,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve(qp.results.x, qp.results.y, qp.results.z);
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2503,14 +2871,22 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2525,17 +2901,25 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             << qp.results.info.solve_time << std::endl;
 
   dense::QP<T> qp2(dim, n_eq, n_in);
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
   qp2.settings.initial_guess = InitialGuessStatus::WARM_START;
   std::cout << "dirty workspace for qp2 : " << qp2.work.dirty << std::endl;
   qp2.solve(qp.results.x, qp.results.y, qp.results.z);
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2579,14 +2963,22 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2604,14 +2996,23 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   qp_random.H *= 2.;
   qp_random.g = utils::rand::vector_rand<T>(dim);
   bool update_preconditioner = true;
-  qp.update(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+  qp.update(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l,
+            update_preconditioner);
   std::cout << "dirty workspace after update : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2628,11 +3029,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2649,11 +3052,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2696,14 +3101,22 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2721,14 +3134,23 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   qp_random.H *= 2.;
   qp_random.g = utils::rand::vector_rand<T>(dim);
   bool update_preconditioner = true;
-  qp.update(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+  qp.update(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l,
+            update_preconditioner);
   std::cout << "dirty workspace after update : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2745,11 +3167,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2766,11 +3190,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2816,14 +3242,22 @@ TEST_CASE(
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2843,14 +3277,23 @@ TEST_CASE(
   qp_random.H *= 2.;
   qp_random.g = utils::rand::vector_rand<T>(dim);
   bool update_preconditioner = true;
-  qp.update(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+  qp.update(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l,
+            update_preconditioner);
   std::cout << "dirty workspace after update : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2867,11 +3310,13 @@ TEST_CASE(
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2888,11 +3333,13 @@ TEST_CASE(
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2936,14 +3383,22 @@ TEST_CASE(
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2963,13 +3418,22 @@ TEST_CASE(
   qp_random.H *= 2.;
   qp_random.g = utils::rand::vector_rand<T>(dim);
   bool update_preconditioner = true;
-  qp.update(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+  qp.update(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l,
+            update_preconditioner);
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -2986,11 +3450,13 @@ TEST_CASE(
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3007,11 +3473,13 @@ TEST_CASE(
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3056,14 +3524,22 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3092,11 +3568,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             update_preconditioner);
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3113,11 +3591,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3134,11 +3614,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3181,14 +3663,22 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3209,14 +3699,23 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   auto z_wm = qp.results.z;
   bool update_preconditioner = true;
   // test with a false update (the warm start should give the exact solution)
-  qp.update(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+  qp.update(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l,
+            update_preconditioner);
   std::cout << "dirty workspace after update: " << qp.work.dirty << std::endl;
   qp.solve(x_wm, y_wm, z_wm);
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   std::cout << "Second solve " << std::endl;
@@ -3236,14 +3735,23 @@ TEST_CASE("sparse random strongly convex qp with equality and "
   qp_random.H *= 2.;
   qp_random.g = utils::rand::vector_rand<T>(dim);
   // try now with a real update
-  qp.update(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+  qp.update(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l,
+            update_preconditioner);
   std::cout << "dirty workspace after update: " << qp.work.dirty << std::endl;
   qp.solve(x_wm, y_wm, z_wm);
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3260,11 +3768,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve(qp.results.x, qp.results.y, qp.results.z);
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3281,11 +3791,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
   std::cout << "dirty workspace : " << qp.work.dirty << std::endl;
   qp.solve(qp.results.x, qp.results.y, qp.results.z);
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3326,14 +3838,24 @@ TEST_CASE("Test initializaton with rho for different initial guess")
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          true,
+          T(1.E-7));
   qp.solve();
   CHECK(qp.results.info.rho == T(1.E-7));
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3352,14 +3874,24 @@ TEST_CASE("Test initializaton with rho for different initial guess")
   qp2.settings.eps_rel = 0;
   qp2.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
+           true,
+           T(1.E-7));
   qp2.solve();
   CHECK(qp2.results.info.rho == T(1.E-7));
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3378,14 +3910,24 @@ TEST_CASE("Test initializaton with rho for different initial guess")
   qp3.settings.eps_rel = 0;
   qp3.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  qp3.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
+           true,
+           T(1.E-7));
   qp3.solve();
   CHECK(qp3.results.info.rho == T(1.E-7));
-  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+             qp_random.A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3404,14 +3946,24 @@ TEST_CASE("Test initializaton with rho for different initial guess")
   qp4.settings.eps_rel = 0;
   qp4.settings.initial_guess =
     InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  qp4.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+  qp4.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
+           true,
+           T(1.E-7));
   qp4.solve();
   CHECK(qp4.results.info.rho == T(1.E-7));
-  pri_res = std::max((qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp4.results.x + qp_random.g + qp_random.A.transpose() * qp4.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp4.results.x + qp_random.g +
+             qp_random.A.transpose() * qp4.results.y +
              qp_random.C.transpose() * qp4.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3429,14 +3981,24 @@ TEST_CASE("Test initializaton with rho for different initial guess")
   qp5.settings.eps_abs = eps_abs;
   qp5.settings.eps_rel = 0;
   qp5.settings.initial_guess = InitialGuessStatus::WARM_START;
-  qp5.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+  qp5.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
+           true,
+           T(1.E-7));
   qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
   CHECK(qp5.results.info.rho == T(1.E-7));
-  pri_res = std::max((qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp5.results.x + qp_random.g + qp_random.A.transpose() * qp5.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp5.results.x + qp_random.g +
+             qp_random.A.transpose() * qp5.results.y +
              qp_random.C.transpose() * qp5.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3475,14 +4037,22 @@ TEST_CASE("Test g update for different initial guess")
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3497,11 +4067,13 @@ TEST_CASE("Test g update for different initial guess")
             std::nullopt,
             std::nullopt);
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK((qp.model.g - qp_random.g).lpNorm<Eigen::Infinity>() <= eps_abs);
@@ -3521,13 +4093,21 @@ TEST_CASE("Test g update for different initial guess")
   qp2.settings.eps_rel = 0;
   qp2.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  qp2.init(qp_random.H, old_g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           old_g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.solve();
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + old_g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + old_g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3540,11 +4120,13 @@ TEST_CASE("Test g update for different initial guess")
              std::nullopt,
              std::nullopt);
   qp2.solve();
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK((qp2.model.g - qp_random.g).lpNorm<Eigen::Infinity>() <= eps_abs);
@@ -3564,13 +4146,21 @@ TEST_CASE("Test g update for different initial guess")
   qp3.settings.eps_rel = 0;
   qp3.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  qp3.init(qp_random.H, old_g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp3.init(qp_random.H,
+           old_g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp3.solve();
-  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + old_g + qp_random.A.transpose() * qp3.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + old_g +
+             qp_random.A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3583,11 +4173,13 @@ TEST_CASE("Test g update for different initial guess")
              std::nullopt,
              std::nullopt);
   qp3.solve();
-  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+             qp_random.A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK((qp3.model.g - qp_random.g).lpNorm<Eigen::Infinity>() <= eps_abs);
@@ -3607,13 +4199,21 @@ TEST_CASE("Test g update for different initial guess")
   qp4.settings.eps_rel = 0;
   qp4.settings.initial_guess =
     InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  qp4.init(qp_random.H, old_g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp4.init(qp_random.H,
+           old_g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp4.solve();
-  pri_res = std::max((qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp4.results.x + old_g + qp_random.A.transpose() * qp4.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp4.results.x + old_g +
+             qp_random.A.transpose() * qp4.results.y +
              qp_random.C.transpose() * qp4.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3626,11 +4226,13 @@ TEST_CASE("Test g update for different initial guess")
              std::nullopt,
              std::nullopt);
   qp4.solve();
-  pri_res = std::max((qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp4.results.x + qp_random.g + qp_random.A.transpose() * qp4.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp4.results.x + qp_random.g +
+             qp_random.A.transpose() * qp4.results.y +
              qp_random.C.transpose() * qp4.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK((qp4.model.g - qp_random.g).lpNorm<Eigen::Infinity>() <= eps_abs);
@@ -3649,13 +4251,21 @@ TEST_CASE("Test g update for different initial guess")
   qp5.settings.eps_abs = eps_abs;
   qp5.settings.eps_rel = 0;
   qp5.settings.initial_guess = InitialGuessStatus::WARM_START;
-  qp5.init(qp_random.H, old_g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp5.init(qp_random.H,
+           old_g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
-  pri_res = std::max((qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp5.results.x + old_g + qp_random.A.transpose() * qp5.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp5.results.x + old_g +
+             qp_random.A.transpose() * qp5.results.y +
              qp_random.C.transpose() * qp5.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3668,11 +4278,13 @@ TEST_CASE("Test g update for different initial guess")
              std::nullopt,
              std::nullopt);
   qp5.solve();
-  pri_res = std::max((qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp5.results.x + qp_random.g + qp_random.A.transpose() * qp5.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp5.results.x + qp_random.g +
+             qp_random.A.transpose() * qp5.results.y +
              qp_random.C.transpose() * qp5.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK((qp5.model.g - qp_random.g).lpNorm<Eigen::Infinity>() <= eps_abs);
@@ -3712,14 +4324,22 @@ TEST_CASE("Test A update for different initial guess")
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3734,13 +4354,15 @@ TEST_CASE("Test A update for different initial guess")
             std::nullopt,
             std::nullopt);
   qp.solve();
-  pri_res = std::max((new_A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + new_A.transpose() * qp.results.y +
-             qp_random.C.transpose() * qp.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res =
+    std::max((new_A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp_random.H * qp.results.x + qp_random.g +
+     new_A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
+      .lpNorm<Eigen::Infinity>();
   CHECK((qp.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
@@ -3758,13 +4380,21 @@ TEST_CASE("Test A update for different initial guess")
   qp2.settings.eps_rel = 0;
   qp2.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.solve();
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3777,11 +4407,13 @@ TEST_CASE("Test A update for different initial guess")
              std::nullopt,
              std::nullopt);
   qp2.solve();
-  pri_res = std::max((new_A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + new_A.transpose() * qp2.results.y +
+  pri_res =
+    std::max((new_A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+              dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             new_A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK((qp2.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
@@ -3801,13 +4433,21 @@ TEST_CASE("Test A update for different initial guess")
   qp3.settings.eps_rel = 0;
   qp3.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  qp3.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp3.solve();
-  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+             qp_random.A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3820,11 +4460,13 @@ TEST_CASE("Test A update for different initial guess")
              std::nullopt,
              std::nullopt);
   qp3.solve();
-  pri_res = std::max((new_A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + qp_random.g + new_A.transpose() * qp3.results.y +
+  pri_res =
+    std::max((new_A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+              dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+             new_A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK((qp3.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
@@ -3844,13 +4486,21 @@ TEST_CASE("Test A update for different initial guess")
   qp4.settings.eps_rel = 0;
   qp4.settings.initial_guess =
     InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  qp4.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp4.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp4.solve();
-  pri_res = std::max((qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp4.results.x + qp_random.g + qp_random.A.transpose() * qp4.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp4.results.x + qp_random.g +
+             qp_random.A.transpose() * qp4.results.y +
              qp_random.C.transpose() * qp4.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3863,11 +4513,13 @@ TEST_CASE("Test A update for different initial guess")
              std::nullopt,
              std::nullopt);
   qp4.solve();
-  pri_res = std::max((new_A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp4.results.x + qp_random.g + new_A.transpose() * qp4.results.y +
+  pri_res =
+    std::max((new_A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+              dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp4.results.x + qp_random.g +
+             new_A.transpose() * qp4.results.y +
              qp_random.C.transpose() * qp4.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK((qp4.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
@@ -3886,13 +4538,21 @@ TEST_CASE("Test A update for different initial guess")
   qp5.settings.eps_abs = eps_abs;
   qp5.settings.eps_rel = 0;
   qp5.settings.initial_guess = InitialGuessStatus::WARM_START;
-  qp5.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp5.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
-  pri_res = std::max((qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp5.results.x + qp_random.g + qp_random.A.transpose() * qp5.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp5.results.x + qp_random.g +
+             qp_random.A.transpose() * qp5.results.y +
              qp_random.C.transpose() * qp5.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3905,11 +4565,13 @@ TEST_CASE("Test A update for different initial guess")
              std::nullopt,
              std::nullopt);
   qp5.solve();
-  pri_res = std::max((new_A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp5.results.x + qp_random.g + new_A.transpose() * qp5.results.y +
+  pri_res =
+    std::max((new_A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+              dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp5.results.x + qp_random.g +
+             new_A.transpose() * qp5.results.y +
              qp_random.C.transpose() * qp5.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK((qp5.model.A - new_A).lpNorm<Eigen::Infinity>() <= eps_abs);
@@ -3949,14 +4611,22 @@ TEST_CASE("Test rho update for different initial guess")
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -3971,11 +4641,13 @@ TEST_CASE("Test rho update for different initial guess")
             true,
             T(1.E-7));
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(qp.results.info.rho == T(1.E-7));
@@ -3995,13 +4667,21 @@ TEST_CASE("Test rho update for different initial guess")
   qp2.settings.eps_rel = 0;
   qp2.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.solve();
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -4016,11 +4696,13 @@ TEST_CASE("Test rho update for different initial guess")
              true,
              T(1.E-7));
   qp2.solve();
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(qp2.results.info.rho == T(1.e-7));
@@ -4040,13 +4722,21 @@ TEST_CASE("Test rho update for different initial guess")
   qp3.settings.eps_rel = 0;
   qp3.settings.initial_guess =
     InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  qp3.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp3.solve();
-  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+             qp_random.A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -4061,11 +4751,13 @@ TEST_CASE("Test rho update for different initial guess")
              true,
              T(1.E-7));
   qp3.solve();
-  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+             qp_random.A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(qp3.results.info.rho == T(1.e-7));
@@ -4085,13 +4777,21 @@ TEST_CASE("Test rho update for different initial guess")
   qp4.settings.eps_rel = 0;
   qp4.settings.initial_guess =
     InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  qp4.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp4.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp4.solve();
-  pri_res = std::max((qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp4.results.x + qp_random.g + qp_random.A.transpose() * qp4.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp4.results.x + qp_random.g +
+             qp_random.A.transpose() * qp4.results.y +
              qp_random.C.transpose() * qp4.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -4106,11 +4806,13 @@ TEST_CASE("Test rho update for different initial guess")
              true,
              T(1.E-7));
   qp4.solve();
-  pri_res = std::max((qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp4.results.x + qp_random.g + qp_random.A.transpose() * qp4.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp4.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp4.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp4.results.x + qp_random.g +
+             qp_random.A.transpose() * qp4.results.y +
              qp_random.C.transpose() * qp4.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(qp4.results.info.rho == T(1.e-7));
@@ -4129,13 +4831,21 @@ TEST_CASE("Test rho update for different initial guess")
   qp5.settings.eps_abs = eps_abs;
   qp5.settings.eps_rel = 0;
   qp5.settings.initial_guess = InitialGuessStatus::WARM_START;
-  qp5.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp5.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
-  pri_res = std::max((qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp5.results.x + qp_random.g + qp_random.A.transpose() * qp5.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp5.results.x + qp_random.g +
+             qp_random.A.transpose() * qp5.results.y +
              qp_random.C.transpose() * qp5.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -4150,11 +4860,13 @@ TEST_CASE("Test rho update for different initial guess")
              true,
              T(1.E-7));
   qp5.solve();
-  pri_res = std::max((qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp5.results.x + qp_random.g + qp_random.A.transpose() * qp5.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp5.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp5.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp5.results.x + qp_random.g +
+             qp_random.A.transpose() * qp5.results.y +
              qp_random.C.transpose() * qp5.results.z)
               .lpNorm<Eigen::Infinity>();
   CHECK(qp5.results.info.rho == T(1.e-7));
@@ -4195,14 +4907,22 @@ TEST_CASE("Test g update for different warm start with previous result option")
   std::cout << "dirty workspace before any solving: " << qp.work.dirty
             << std::endl;
 
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
@@ -4227,13 +4947,15 @@ TEST_CASE("Test g update for different warm start with previous result option")
             std::nullopt,
             std::nullopt);
   qp.solve();
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + g + qp_random.A.transpose() * qp.results.y +
-             qp_random.C.transpose() * qp.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp_random.H * qp.results.x + g + qp_random.A.transpose() * qp.results.y +
+     qp_random.C.transpose() * qp.results.z)
+      .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
@@ -4250,15 +4972,23 @@ TEST_CASE("Test g update for different warm start with previous result option")
   qp2.settings.eps_rel = 0;
   qp2.settings.initial_guess =
     InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  qp2.init(qp_random.H, g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp2.init(qp_random.H,
+           g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l);
   qp2.solve();
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + g + qp_random.A.transpose() * qp2.results.y +
-             qp_random.C.transpose() * qp2.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp_random.H * qp2.results.x + g + qp_random.A.transpose() * qp2.results.y +
+     qp_random.C.transpose() * qp2.results.z)
+      .lpNorm<Eigen::Infinity>();
   CHECK(dua_res <= eps_abs);
   CHECK(pri_res <= eps_abs);
   std::cout << "--n = " << dim << " n_eq " << n_eq << " n_in " << n_in
@@ -4299,19 +5029,28 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4332,11 +5071,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4365,11 +5106,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4403,11 +5146,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+             qp_random.A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4428,11 +5173,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
   qp3.solve();
-  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+             qp_random.A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4469,19 +5216,28 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4502,11 +5258,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4537,11 +5295,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4577,11 +5337,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+             qp_random.A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4602,11 +5364,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
   qp3.solve();
-  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+             qp_random.A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4643,19 +5407,28 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4676,11 +5449,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4711,11 +5486,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4751,11 +5528,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+             qp_random.A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4776,11 +5555,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
   qp3.solve();
-  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+             qp_random.A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4816,19 +5597,28 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4849,11 +5639,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
-  pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y +
              qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4883,11 +5675,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+             qp_random.A.transpose() * qp2.results.y +
              qp_random.C.transpose() * qp2.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4922,11 +5716,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+             qp_random.A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4947,11 +5743,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
   qp3.solve();
-  pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                      dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+             qp_random.A.transpose() * qp3.results.y +
              qp_random.C.transpose() * qp3.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -4986,19 +5784,28 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5008,11 +5815,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5032,11 +5841,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5078,11 +5889,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+               qp_random.A.transpose() * qp2.results.y +
                qp_random.C.transpose() * qp2.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5121,11 +5934,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+               qp_random.A.transpose() * qp3.results.y +
                qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5157,11 +5972,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+               qp_random.A.transpose() * qp3.results.y +
                qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5199,19 +6016,28 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5221,11 +6047,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5245,11 +6073,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5290,11 +6120,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+               qp_random.A.transpose() * qp2.results.y +
                qp_random.C.transpose() * qp2.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5332,11 +6164,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+               qp_random.A.transpose() * qp3.results.y +
                qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5365,11 +6199,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+               qp_random.A.transpose() * qp3.results.y +
                qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5408,19 +6244,28 @@ DOCTEST_TEST_CASE(
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5430,11 +6275,13 @@ DOCTEST_TEST_CASE(
     qp.solve();
     DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5454,11 +6301,13 @@ DOCTEST_TEST_CASE(
     qp.solve();
     DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5499,11 +6348,13 @@ DOCTEST_TEST_CASE(
     DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+               qp_random.A.transpose() * qp2.results.y +
                qp_random.C.transpose() * qp2.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5541,11 +6392,13 @@ DOCTEST_TEST_CASE(
     DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+               qp_random.A.transpose() * qp3.results.y +
                qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5574,11 +6427,13 @@ DOCTEST_TEST_CASE(
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+               qp_random.A.transpose() * qp3.results.y +
                qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5615,19 +6470,28 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5637,11 +6501,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5661,11 +6527,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
-    pri_res = std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5705,11 +6573,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp2.results.x + qp_random.g + qp_random.A.transpose() * qp2.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp2.results.x + qp_random.g +
+               qp_random.A.transpose() * qp2.results.y +
                qp_random.C.transpose() * qp2.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5746,11 +6616,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+               qp_random.A.transpose() * qp3.results.y +
                qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -5779,11 +6651,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res = std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-                       (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                        dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-                         .lpNorm<Eigen::Infinity>());
-    dua_res = (qp_random.H * qp3.results.x + qp_random.g + qp_random.A.transpose() * qp3.results.y +
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (dense::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+       dense::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H * qp3.results.x + qp_random.g +
+               qp_random.A.transpose() * qp3.results.y +
                qp_random.C.transpose() * qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);

--- a/test/src/dense_qp_wrapper.cpp
+++ b/test/src/dense_qp_wrapper.cpp
@@ -4271,12 +4271,13 @@ TEST_CASE("Test g update for different warm start with previous result option")
             << Qp2.results.info.solve_time << std::endl;
 }
 
-
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after updates using warm start with previous results")
+                  "inequality constraints: test changing default settings "
+                  "after updates using warm start with previous results")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after updates using warm start with previous results---"
+               "inequality constraints: test changing default settings after "
+               "updates using warm start with previous results---"
             << std::endl;
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
@@ -4294,15 +4295,17 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   bool compute_preconditioner = true;
 
   dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
   T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                        (dense::positive_part(qp.C * Qp.results.x - qp.u) +
@@ -4323,11 +4326,11 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
 
   pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp.results.x - qp.u) +
@@ -4340,17 +4343,27 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
@@ -4362,24 +4375,33 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
-
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
@@ -4391,20 +4413,20 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
   pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
@@ -4415,14 +4437,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after updates using cold start with previous results")
+                  "inequality constraints: test changing default settings "
+                  "after updates using cold start with previous results")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after updates using cold start with previous results---"
+               "inequality constraints: test changing default settings after "
+               "updates using cold start with previous results---"
             << std::endl;
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
@@ -4440,16 +4463,19 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   bool compute_preconditioner = true;
 
   dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp.settings.initial_guess =
+    proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
   T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                        (dense::positive_part(qp.C * Qp.results.x - qp.u) +
@@ -4470,11 +4496,11 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
 
   pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp.results.x - qp.u) +
@@ -4487,18 +4513,29 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp2.settings.initial_guess =
+    proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
@@ -4510,25 +4547,35 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
-
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
-  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp3.settings.initial_guess =
+    proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
@@ -4540,20 +4587,20 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
   pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
@@ -4564,14 +4611,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after updates using equality constrained initial guess")
+                  "inequality constraints: test changing default settings "
+                  "after updates using equality constrained initial guess")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after updates using equality constrained initial guess---"
+               "inequality constraints: test changing default settings after "
+               "updates using equality constrained initial guess---"
             << std::endl;
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
@@ -4589,16 +4637,19 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   bool compute_preconditioner = true;
 
   dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp.settings.initial_guess =
+    proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
   T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                        (dense::positive_part(qp.C * Qp.results.x - qp.u) +
@@ -4619,11 +4670,11 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
 
   pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp.results.x - qp.u) +
@@ -4636,18 +4687,29 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp2.settings.initial_guess =
+    proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
@@ -4659,25 +4721,35 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
-
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
-  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp3.settings.initial_guess =
+    proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
@@ -4689,20 +4761,20 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
   pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
@@ -4713,14 +4785,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after updates using no initial guess")
+                  "inequality constraints: test changing default settings "
+                  "after updates using no initial guess")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after updates using no initial guess---"
+               "inequality constraints: test changing default settings after "
+               "updates using no initial guess---"
             << std::endl;
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
@@ -4739,15 +4812,17 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
 
   dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
   Qp.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
   T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                        (dense::positive_part(qp.C * Qp.results.x - qp.u) +
@@ -4768,11 +4843,11 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
 
   pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp.results.x - qp.u) +
@@ -4786,17 +4861,27 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
   Qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
@@ -4808,25 +4893,34 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
-
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
   Qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
@@ -4838,20 +4932,20 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
   pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                      (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
@@ -4862,16 +4956,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-
 }
 
-
-
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after several solves using warm start with previous results")
+                  "inequality constraints: test changing default settings "
+                  "after several solves using warm start with previous results")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after several solves using warm start with previous results---"
+               "inequality constraints: test changing default settings after "
+               "several solves using warm start with previous results---"
             << std::endl;
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
@@ -4889,15 +4982,17 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   bool compute_preconditioner = true;
 
   dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
   T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                        (dense::positive_part(qp.C * Qp.results.x - qp.u) +
@@ -4908,22 +5003,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  
+
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
     pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
+               qp.C.transpose() * Qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
+
   Qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -4935,129 +5030,152 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
     pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
+               qp.C.transpose() * Qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    // warm start with previous result used, hence if the qp is small and simple, the parameters should not changed during first solve, and also after as we start at the solution
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    // warm start with previous result used, hence if the qp is small and
+    // simple, the parameters should not changed during first solve, and also
+    // after as we start at the solution
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
     Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
     pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp2.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-              qp.C.transpose() * Qp2.results.z)
+               qp.C.transpose() * Qp2.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    // warm start with previous result used, hence if the qp is small and simple, the parameters should not changed during first solve, and also after as we start at the solution
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    // warm start with previous result used, hence if the qp is small and
+    // simple, the parameters should not changed during first solve, and also
+    // after as we start at the solution
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
+               qp.C.transpose() * Qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
+
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    // warm start with previous result used, hence if the qp is small and simple, the parameters should not changed during first solve, and also after as we start at the solution
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    // warm start with previous result used, hence if the qp is small and
+    // simple, the parameters should not changed during first solve, and also
+    // after as we start at the solution
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
+               qp.C.transpose() * Qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 }
 
-
-
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after several solves using cold start with previous results")
+                  "inequality constraints: test changing default settings "
+                  "after several solves using cold start with previous results")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after several solves using cold start with previous results---"
+               "inequality constraints: test changing default settings after "
+               "several solves using cold start with previous results---"
             << std::endl;
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
@@ -5075,16 +5193,19 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   bool compute_preconditioner = true;
 
   dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp.settings.initial_guess =
+    proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
   T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                        (dense::positive_part(qp.C * Qp.results.x - qp.u) +
@@ -5095,22 +5216,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  
+
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
     pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
+               qp.C.transpose() * Qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
- 
+
   Qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -5122,126 +5243,148 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
     pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
+               qp.C.transpose() * Qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp2.settings.initial_guess =
+    proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
     Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
     pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp2.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-              qp.C.transpose() * Qp2.results.z)
+               qp.C.transpose() * Qp2.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
-  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp3.settings.initial_guess =
+    proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
+               qp.C.transpose() * Qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
+
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
+               qp.C.transpose() * Qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 }
 
-DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after several solves using equality constrained initial guess")
+DOCTEST_TEST_CASE(
+  "sparse random strongly convex qp with equality and "
+  "inequality constraints: test changing default settings after several solves "
+  "using equality constrained initial guess")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after several solves using equality constrained initial guess---"
+               "inequality constraints: test changing default settings after "
+               "several solves using equality constrained initial guess---"
             << std::endl;
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
@@ -5259,16 +5402,19 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   bool compute_preconditioner = true;
 
   dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp.settings.initial_guess =
+    proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
   T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                        (dense::positive_part(qp.C * Qp.results.x - qp.u) +
@@ -5279,22 +5425,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  
+
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
     pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
+               qp.C.transpose() * Qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
- 
+
   Qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -5306,126 +5452,147 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
     pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
+               qp.C.transpose() * Qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
-  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp2.settings.initial_guess =
+    proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
     Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
     pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp2.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-              qp.C.transpose() * Qp2.results.z)
+               qp.C.transpose() * Qp2.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
-  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp3.settings.initial_guess =
+    proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
+               qp.C.transpose() * Qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
+
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
+               qp.C.transpose() * Qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after several solves using no initial guess")
+                  "inequality constraints: test changing default settings "
+                  "after several solves using no initial guess")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after several solves using no initial guess---"
+               "inequality constraints: test changing default settings after "
+               "several solves using no initial guess---"
             << std::endl;
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
@@ -5444,15 +5611,17 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
 
   dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
   Qp.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
   T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
                        (dense::positive_part(qp.C * Qp.results.x - qp.u) +
@@ -5463,22 +5632,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  
+
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
     pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
+               qp.C.transpose() * Qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
- 
+
   Qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -5490,117 +5659,134 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
     pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
+               qp.C.transpose() * Qp.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp2{ dim, n_eq, n_in }; // creating QP object
   Qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
     Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
     pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp2.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp2.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp2.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-              qp.C.transpose() * Qp2.results.z)
+               qp.C.transpose() * Qp2.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  
   // conter factual check with another QP object starting at the updated model
   dense::QP<T> Qp3{ dim, n_eq, n_in }; // creating QP object
   Qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
+               qp.C.transpose() * Qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
+
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      dense::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
+                       (dense::positive_part(qp.C * Qp3.results.x - qp.u) +
+                        dense::negative_part(qp.C * Qp3.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
     dua_res = (qp.H * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
+               qp.C.transpose() * Qp3.results.z)
                 .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 }

--- a/test/src/dense_qp_wrapper.py
+++ b/test/src/dense_qp_wrapper.py
@@ -3894,6 +3894,563 @@ class DenseQpWrapper(unittest.TestCase):
             )
         )
 
+
+
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_no_initial_guess(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, no initial guess, multiple solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        for i in range(10):
+            Qp.solve()
+            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+            assert np.abs(rho - Qp.results.info.rho) <1.E-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            dua_res = normInf(
+                H @ Qp.results.x
+                + g
+                + A.transpose() @ Qp.results.y
+                + C.transpose() @ Qp.results.z
+            )
+            pri_res = max(
+                normInf(A @ Qp.results.x - b),
+                normInf(
+                    np.maximum(C @ Qp.results.x - u, 0)
+                    + np.minimum(C @ Qp.results.x - l, 0)
+                ),
+            )
+            assert dua_res <= 1e-9
+            assert pri_res <= 1e-9
+
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_EQUALITY_CONSTRAINED_INITIAL_GUESS(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, EQUALITY_CONSTRAINED_INITIAL_GUESS, multiple solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        for i in range(10):
+            Qp.solve()
+            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+            assert np.abs(rho - Qp.results.info.rho) <1.E-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            dua_res = normInf(
+                H @ Qp.results.x
+                + g
+                + A.transpose() @ Qp.results.y
+                + C.transpose() @ Qp.results.z
+            )
+            pri_res = max(
+                normInf(A @ Qp.results.x - b),
+                normInf(
+                    np.maximum(C @ Qp.results.x - u, 0)
+                    + np.minimum(C @ Qp.results.x - l, 0)
+                ),
+            )
+            assert dua_res <= 1e-9
+            assert pri_res <= 1e-9
+
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_COLD_START_WITH_PREVIOUS_RESULT(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, COLD_START_WITH_PREVIOUS_RESULT, multiple solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        for i in range(10):
+            Qp.solve()
+            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+            assert np.abs(rho - Qp.results.info.rho) <1.E-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            dua_res = normInf(
+                H @ Qp.results.x
+                + g
+                + A.transpose() @ Qp.results.y
+                + C.transpose() @ Qp.results.z
+            )
+            pri_res = max(
+                normInf(A @ Qp.results.x - b),
+                normInf(
+                    np.maximum(C @ Qp.results.x - u, 0)
+                    + np.minimum(C @ Qp.results.x - l, 0)
+                ),
+            )
+            assert dua_res <= 1e-9
+            assert pri_res <= 1e-9
+
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_WARM_START_WITH_PREVIOUS_RESULT(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, WARM_START_WITH_PREVIOUS_RESULT, multiple solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        for i in range(10):
+            Qp.solve()
+            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+            assert np.abs(rho - Qp.results.info.rho) <1.E-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            dua_res = normInf(
+                H @ Qp.results.x
+                + g
+                + A.transpose() @ Qp.results.y
+                + C.transpose() @ Qp.results.z
+            )
+            pri_res = max(
+                normInf(A @ Qp.results.x - b),
+                normInf(
+                    np.maximum(C @ Qp.results.x - u, 0)
+                    + np.minimum(C @ Qp.results.x - l, 0)
+                ),
+            )
+            assert dua_res <= 1e-9
+            assert pri_res <= 1e-9
+
+
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_WARM_START_WITH_PREVIOUS_RESULT(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, WARM_START_WITH_PREVIOUS_RESULT, update + solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
+        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
+        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
+        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_COLD_START_WITH_PREVIOUS_RESULT(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, COLD_START_WITH_PREVIOUS_RESULT, update + solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
+        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
+        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
+        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_EQUALITY_CONSTRAINED_INITIAL_GUESS(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, EQUALITY_CONSTRAINED_INITIAL_GUESS, update + solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
+        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
+        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
+        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_NO_INITIAL_GUESS(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, NO_INITIAL_GUESS, update + solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
+        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
+        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
+        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+
+
+
     def test_initializing_with_None(self):
         print("------------------------test initialization with Nones")
 

--- a/test/src/dense_qp_wrapper.py
+++ b/test/src/dense_qp_wrapper.py
@@ -44,7 +44,7 @@ def generate_mixed_qp(n, seed=1):
     return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
 
 
-class DenseQpWrapper(unittest.TestCase):
+class DenseqpWrapper(unittest.TestCase):
 
     # TESTS OF GENERAL METHODS OF THE API
 
@@ -57,10 +57,10 @@ class DenseQpWrapper(unittest.TestCase):
         n_eq = A.shape[0]
         n_in = C.shape[0]
 
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.init(
             H=H,
             g=np.asfortranarray(g),
             A=A,
@@ -70,28 +70,28 @@ class DenseQpWrapper(unittest.TestCase):
             l=np.asfortranarray(l),
             rho=1.0e-7,
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -106,10 +106,10 @@ class DenseQpWrapper(unittest.TestCase):
         n_eq = A.shape[0]
         n_in = C.shape[0]
 
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -120,29 +120,29 @@ class DenseQpWrapper(unittest.TestCase):
             mu_eq=1.0e-2,
             mu_in=1.0e-3,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -157,10 +157,10 @@ class DenseQpWrapper(unittest.TestCase):
         n_eq = A.shape[0]
         n_in = C.shape[0]
 
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -170,29 +170,29 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             False,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -207,10 +207,10 @@ class DenseQpWrapper(unittest.TestCase):
         n_eq = A.shape[0]
         n_in = C.shape[0]
 
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -220,29 +220,29 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -257,11 +257,11 @@ class DenseQpWrapper(unittest.TestCase):
         n_eq = A.shape[0]
         n_in = C.shape[0]
 
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -270,29 +270,29 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(u),
             np.asfortranarray(l),
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -307,11 +307,11 @@ class DenseQpWrapper(unittest.TestCase):
         n_eq = A.shape[0]
         n_in = C.shape[0]
 
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -321,34 +321,34 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
         g = np.random.randn(n)
         H *= 2.0  # too keep same sparsity structure
-        Qp.update(
+        qp.update(
             H,
             np.asfortranarray(g),
             A,
@@ -359,29 +359,29 @@ class DenseQpWrapper(unittest.TestCase):
             True,
         )
 
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -395,11 +395,11 @@ class DenseQpWrapper(unittest.TestCase):
         n_eq = A.shape[0]
         n_in = C.shape[0]
 
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -411,29 +411,29 @@ class DenseQpWrapper(unittest.TestCase):
         x_wm = np.random.randn(n)
         y_wm = np.random.randn(n_eq)
         z_wm = np.random.randn(n_in)
-        Qp.solve(x_wm, y_wm, z_wm)
+        qp.solve(x_wm, y_wm, z_wm)
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -447,13 +447,13 @@ class DenseQpWrapper(unittest.TestCase):
         n_eq = A.shape[0]
         n_in = C.shape[0]
 
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -462,36 +462,36 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(u),
             np.asfortranarray(l),
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert pri_res <= 1e-9
         assert dua_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
-        Qp2.init(
+        qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp2.init(
             H,
             np.asfortranarray(g),
             A,
@@ -501,65 +501,65 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
         )
 
-        x = Qp.results.x
-        y = Qp.results.y
-        z = Qp.results.z
-        Qp2.solve(x, y, z)
+        x = qp.results.x
+        y = qp.results.y
+        z = qp.results.z
+        qp2.solve(x, y, z)
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with Qp".format(
+            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with qp".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with Qp2".format(
+            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with qp2".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -573,13 +573,13 @@ class DenseQpWrapper(unittest.TestCase):
         n_eq = A.shape[0]
         n_in = C.shape[0]
 
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -588,39 +588,39 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(u),
             np.asfortranarray(l),
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with Qp".format(
+            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with qp".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
-        Qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
-        Qp2.init(
+        qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp2.init(
             H,
             np.asfortranarray(g),
             A,
@@ -629,65 +629,65 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(u),
             np.asfortranarray(l),
         )
-        x = Qp.results.x
-        y = Qp.results.y
-        z = Qp.results.z
-        Qp2.solve(x, y, z)
+        x = qp.results.x
+        y = qp.results.y
+        z = qp.results.z
+        qp2.solve(x, y, z)
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with Qp".format(
+            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with qp".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with Qp2".format(
+            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with qp2".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -702,13 +702,13 @@ class DenseQpWrapper(unittest.TestCase):
         n_eq = A.shape[0]
         n_in = C.shape[0]
 
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -718,41 +718,41 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with Qp".format(
+            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with qp".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
-        Qp2.init(
+        qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp2.init(
             H,
             np.asfortranarray(g),
             A,
@@ -762,32 +762,32 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             False,
         )
-        Qp2.solve()
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with Qp2".format(
+            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with qp2".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -801,13 +801,13 @@ class DenseQpWrapper(unittest.TestCase):
         n_eq = A.shape[0]
         n_in = C.shape[0]
 
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -817,81 +817,81 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
-        print("--n = {} ; n_eq = {} ; n_in = {} with Qp".format(n, n_eq, n_in))
+        print("--n = {} ; n_eq = {} ; n_in = {} with qp".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.update(update_preconditioner=True)
-        Qp.solve()
+        qp.update(update_preconditioner=True)
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} with Qp after update".format(
+            "--n = {} ; n_eq = {} ; n_in = {} with qp after update".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
-        Qp2.init(
+        qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp2.init(
             H,
             np.asfortranarray(g),
             A,
@@ -901,58 +901,58 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             False,
         )
-        Qp2.solve()
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
-        print("--n = {} ; n_eq = {} ; n_in = {} with Qp2".format(n, n_eq, n_in))
+        print("--n = {} ; n_eq = {} ; n_in = {} with qp2".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2.update(update_preconditioner=False)
-        Qp2.solve()
+        qp2.update(update_preconditioner=False)
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} with Qp2 after update".format(
+            "--n = {} ; n_eq = {} ; n_in = {} with qp2 after update".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -965,11 +965,11 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -979,29 +979,29 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve(np.random.randn(n), np.random.randn(n_eq), np.random.randn(n_in))
+        qp.solve(np.random.randn(n), np.random.randn(n_eq), np.random.randn(n_in))
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
-        print("--n = {} ; n_eq = {} ; n_in = {} with Qp".format(n, n_eq, n_in))
+        print("--n = {} ; n_eq = {} ; n_in = {} with qp".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -1016,11 +1016,11 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1030,44 +1030,44 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1075,25 +1075,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1101,25 +1101,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1127,10 +1127,10 @@ class DenseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -1143,13 +1143,13 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1159,44 +1159,44 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1204,25 +1204,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1230,25 +1230,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1256,10 +1256,10 @@ class DenseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -1274,13 +1274,13 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1290,48 +1290,48 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1339,25 +1339,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1365,25 +1365,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1391,10 +1391,10 @@ class DenseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -1407,11 +1407,11 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1421,48 +1421,48 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1470,25 +1470,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1496,25 +1496,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1522,10 +1522,10 @@ class DenseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -1538,11 +1538,11 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1552,48 +1552,48 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1601,25 +1601,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1627,25 +1627,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1653,10 +1653,10 @@ class DenseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -1669,11 +1669,11 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1683,49 +1683,49 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
-        Qp.init(H, g, A, b, C, u, l)
-        Qp.solve()
+        qp.init(H, g, A, b, C, u, l)
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
 
-        Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z)
+        qp.solve(qp.results.x, qp.results.y, qp.results.z)
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1733,25 +1733,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z)
+        qp.solve(qp.results.x, qp.results.y, qp.results.z)
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1759,25 +1759,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z)
+        qp.solve(qp.results.x, qp.results.y, qp.results.z)
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1785,10 +1785,10 @@ class DenseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -1801,11 +1801,11 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1815,51 +1815,51 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
-        Qp.init(H, g, A, b, C, u, l)
-        Qp.solve()
+        qp.init(H, g, A, b, C, u, l)
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp2.init(H, g, A, b, C, u, l)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
-        Qp2.solve(Qp.results.x, Qp.results.y, Qp.results.z)
+        qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp2.init(H, g, A, b, C, u, l)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp2.solve(qp.results.x, qp.results.y, qp.results.z)
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1867,10 +1867,10 @@ class DenseQpWrapper(unittest.TestCase):
         print("Second solve with new QP object")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp2.results.info.iter))
+        print("total number of iteration: {}".format(qp2.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp2.results.info.setup_time, Qp2.results.info.solve_time
+                qp2.results.info.setup_time, qp2.results.info.solve_time
             )
         )
 
@@ -1885,11 +1885,11 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1899,36 +1899,36 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
         H *= 2.0  # keep same sparsity structure
         g = np.random.randn(n)
         update_preconditioner = True
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1938,18 +1938,18 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             update_preconditioner,
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1957,25 +1957,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1983,25 +1983,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2009,10 +2009,10 @@ class DenseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -2027,13 +2027,13 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2043,36 +2043,36 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
         H *= 2.0  # keep same sparsity structure
         g = np.random.randn(n)
         update_preconditioner = True
-        Qp.update(
+        qp.update(
             H,
             np.asfortranarray(g),
             A,
@@ -2082,18 +2082,18 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             update_preconditioner,
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2101,25 +2101,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2127,25 +2127,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2153,10 +2153,10 @@ class DenseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -2171,13 +2171,13 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2187,40 +2187,40 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
 
         H *= 2.0  # keep same sparsity structure
         g = np.random.randn(n)
         update_preconditioner = True
-        Qp.update(
+        qp.update(
             H,
             np.asfortranarray(g),
             A,
@@ -2230,18 +2230,18 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             update_preconditioner,
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2249,25 +2249,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2275,25 +2275,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2301,10 +2301,10 @@ class DenseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -2319,11 +2319,11 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2333,40 +2333,40 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
 
         H *= 2.0  # keep same sparsity structure
         g = np.random.randn(n)
         update_preconditioner = True
-        Qp.update(
+        qp.update(
             H,
             np.asfortranarray(g),
             A,
@@ -2376,18 +2376,18 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             update_preconditioner,
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2395,25 +2395,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2421,25 +2421,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2447,10 +2447,10 @@ class DenseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -2465,11 +2465,11 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2479,76 +2479,76 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
 
         H *= 2  # keep same sparsity structure
         g = np.random.randn(n)
-        Qp.update(H=H, g=np.asfortranarray(g), update_preconditioner=True)
-        Qp.solve()
+        qp.update(H=H, g=np.asfortranarray(g), update_preconditioner=True)
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2556,25 +2556,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2582,10 +2582,10 @@ class DenseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -2598,11 +2598,11 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2612,38 +2612,38 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
 
         H *= 2.0  # keep same sparsity structure
         g = np.random.randn(n)
         update_preconditioner = True
-        Qp.update(
+        qp.update(
             H,
             np.asfortranarray(g),
             A,
@@ -2653,18 +2653,18 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             update_preconditioner,
         )
-        Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z)
+        qp.solve(qp.results.x, qp.results.y, qp.results.z)
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2672,25 +2672,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z)
+        qp.solve(qp.results.x, qp.results.y, qp.results.z)
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2698,25 +2698,25 @@ class DenseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z)
+        qp.solve(qp.results.x, qp.results.y, qp.results.z)
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2724,10 +2724,10 @@ class DenseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -2740,11 +2740,11 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2755,39 +2755,39 @@ class DenseQpWrapper(unittest.TestCase):
             True,
             rho=1.0e-7,
         )
-        Qp.solve()
-        assert Qp.results.info.rho == 1.0e-7
+        qp.solve()
+        assert qp.results.info.rho == 1.0e-7
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = (
+        qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
-        Qp2.init(
+        qp2.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2798,39 +2798,39 @@ class DenseQpWrapper(unittest.TestCase):
             True,
             rho=1.0e-7,
         )
-        Qp2.solve()
-        assert Qp2.results.info.rho == 1.0e-7
+        qp2.solve()
+        assert qp2.results.info.rho == 1.0e-7
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp2.results.info.iter))
+        print("total number of iteration: {}".format(qp2.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp2.results.info.setup_time, Qp2.results.info.solve_time
+                qp2.results.info.setup_time, qp2.results.info.solve_time
             )
         )
 
-        Qp3 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp3.settings.eps_abs = 1.0e-9
-        Qp3.settings.verbose = False
-        Qp3.settings.initial_guess = (
+        qp3 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp3.settings.eps_abs = 1.0e-9
+        qp3.settings.verbose = False
+        qp3.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp3.init(
+        qp3.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2841,39 +2841,39 @@ class DenseQpWrapper(unittest.TestCase):
             True,
             rho=1.0e-7,
         )
-        Qp3.solve()
-        assert Qp.results.info.rho == 1.0e-7
+        qp3.solve()
+        assert qp.results.info.rho == 1.0e-7
         dua_res = normInf(
-            H @ Qp3.results.x
+            H @ qp3.results.x
             + g
-            + A.transpose() @ Qp3.results.y
-            + C.transpose() @ Qp3.results.z
+            + A.transpose() @ qp3.results.y
+            + C.transpose() @ qp3.results.z
         )
         pri_res = max(
-            normInf(A @ Qp3.results.x - b),
+            normInf(A @ qp3.results.x - b),
             normInf(
-                np.maximum(C @ Qp3.results.x - u, 0)
-                + np.minimum(C @ Qp3.results.x - l, 0)
+                np.maximum(C @ qp3.results.x - u, 0)
+                + np.minimum(C @ qp3.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp3.results.info.iter))
+        print("total number of iteration: {}".format(qp3.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp3.results.info.setup_time, Qp3.results.info.solve_time
+                qp3.results.info.setup_time, qp3.results.info.solve_time
             )
         )
 
-        Qp4 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp4.settings.eps_abs = 1.0e-9
-        Qp4.settings.verbose = False
-        Qp4.settings.initial_guess = (
+        qp4 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp4.settings.eps_abs = 1.0e-9
+        qp4.settings.verbose = False
+        qp4.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
-        Qp4.init(
+        qp4.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2884,37 +2884,37 @@ class DenseQpWrapper(unittest.TestCase):
             True,
             rho=1.0e-7,
         )
-        Qp4.solve()
-        assert Qp4.results.info.rho == 1.0e-7
+        qp4.solve()
+        assert qp4.results.info.rho == 1.0e-7
         dua_res = normInf(
-            H @ Qp4.results.x
+            H @ qp4.results.x
             + g
-            + A.transpose() @ Qp4.results.y
-            + C.transpose() @ Qp4.results.z
+            + A.transpose() @ qp4.results.y
+            + C.transpose() @ qp4.results.z
         )
         pri_res = max(
-            normInf(A @ Qp4.results.x - b),
+            normInf(A @ qp4.results.x - b),
             normInf(
-                np.maximum(C @ Qp4.results.x - u, 0)
-                + np.minimum(C @ Qp4.results.x - l, 0)
+                np.maximum(C @ qp4.results.x - u, 0)
+                + np.minimum(C @ qp4.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp4.results.info.iter))
+        print("total number of iteration: {}".format(qp4.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp4.results.info.setup_time, Qp4.results.info.solve_time
+                qp4.results.info.setup_time, qp4.results.info.solve_time
             )
         )
 
-        Qp5 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp5.settings.eps_abs = 1.0e-9
-        Qp5.settings.verbose = False
-        Qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp5.init(
+        qp5 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp5.settings.eps_abs = 1.0e-9
+        qp5.settings.verbose = False
+        qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp5.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2925,29 +2925,29 @@ class DenseQpWrapper(unittest.TestCase):
             True,
             rho=1.0e-7,
         )
-        Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z)
-        assert Qp.results.info.rho == 1.0e-7
+        qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z)
+        assert qp.results.info.rho == 1.0e-7
         dua_res = normInf(
-            H @ Qp5.results.x
+            H @ qp5.results.x
             + g
-            + A.transpose() @ Qp5.results.y
-            + C.transpose() @ Qp5.results.z
+            + A.transpose() @ qp5.results.y
+            + C.transpose() @ qp5.results.z
         )
         pri_res = max(
-            normInf(A @ Qp5.results.x - b),
+            normInf(A @ qp5.results.x - b),
             normInf(
-                np.maximum(C @ Qp5.results.x - u, 0)
-                + np.minimum(C @ Qp5.results.x - l, 0)
+                np.maximum(C @ qp5.results.x - u, 0)
+                + np.minimum(C @ qp5.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp5.results.info.iter))
+        print("total number of iteration: {}".format(qp5.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp5.results.info.setup_time, Qp5.results.info.solve_time
+                qp5.results.info.setup_time, qp5.results.info.solve_time
             )
         )
 
@@ -2960,11 +2960,11 @@ class DenseQpWrapper(unittest.TestCase):
         H, g_old, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g_old),
             A,
@@ -2974,57 +2974,57 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
         g = np.random.randn(n)
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g_old
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(g=g)
-        assert normInf(Qp.model.g - g) <= 1.0e-9
-        Qp.solve()
+        qp.update(g=g)
+        assert normInf(qp.model.g - g) <= 1.0e-9
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = (
+        qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
-        Qp2.init(
+        qp2.init(
             H,
             np.asfortranarray(g_old),
             A,
@@ -3034,56 +3034,56 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp2.solve()
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g_old
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp2.update(g=g)
-        assert normInf(Qp.model.g - g) <= 1.0e-9
-        Qp2.solve()
+        qp2.update(g=g)
+        assert normInf(qp.model.g - g) <= 1.0e-9
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp2.results.info.iter))
+        print("total number of iteration: {}".format(qp2.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp2.results.info.setup_time, Qp2.results.info.solve_time
+                qp2.results.info.setup_time, qp2.results.info.solve_time
             )
         )
 
-        Qp3 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp3.settings.eps_abs = 1.0e-9
-        Qp3.settings.verbose = False
-        Qp3.settings.initial_guess = (
+        qp3 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp3.settings.eps_abs = 1.0e-9
+        qp3.settings.verbose = False
+        qp3.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp3.init(
+        qp3.init(
             H,
             np.asfortranarray(g_old),
             A,
@@ -3093,56 +3093,56 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp3.solve()
+        qp3.solve()
         dua_res = normInf(
-            H @ Qp3.results.x
+            H @ qp3.results.x
             + g_old
-            + A.transpose() @ Qp3.results.y
-            + C.transpose() @ Qp3.results.z
+            + A.transpose() @ qp3.results.y
+            + C.transpose() @ qp3.results.z
         )
         pri_res = max(
-            normInf(A @ Qp3.results.x - b),
+            normInf(A @ qp3.results.x - b),
             normInf(
-                np.maximum(C @ Qp3.results.x - u, 0)
-                + np.minimum(C @ Qp3.results.x - l, 0)
+                np.maximum(C @ qp3.results.x - u, 0)
+                + np.minimum(C @ qp3.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp3.update(g=g)
-        assert normInf(Qp.model.g - g) <= 1.0e-9
-        Qp3.solve()
+        qp3.update(g=g)
+        assert normInf(qp.model.g - g) <= 1.0e-9
+        qp3.solve()
         dua_res = normInf(
-            H @ Qp3.results.x
+            H @ qp3.results.x
             + g
-            + A.transpose() @ Qp3.results.y
-            + C.transpose() @ Qp3.results.z
+            + A.transpose() @ qp3.results.y
+            + C.transpose() @ qp3.results.z
         )
         pri_res = max(
-            normInf(A @ Qp3.results.x - b),
+            normInf(A @ qp3.results.x - b),
             normInf(
-                np.maximum(C @ Qp3.results.x - u, 0)
-                + np.minimum(C @ Qp3.results.x - l, 0)
+                np.maximum(C @ qp3.results.x - u, 0)
+                + np.minimum(C @ qp3.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp3.results.info.iter))
+        print("total number of iteration: {}".format(qp3.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp3.results.info.setup_time, Qp3.results.info.solve_time
+                qp3.results.info.setup_time, qp3.results.info.solve_time
             )
         )
 
-        Qp4 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp4.settings.eps_abs = 1.0e-9
-        Qp4.settings.verbose = False
-        Qp4.settings.initial_guess = (
+        qp4 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp4.settings.eps_abs = 1.0e-9
+        qp4.settings.verbose = False
+        qp4.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
-        Qp4.init(
+        qp4.init(
             H,
             np.asfortranarray(g_old),
             A,
@@ -3152,54 +3152,54 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp4.solve()
+        qp4.solve()
         dua_res = normInf(
-            H @ Qp4.results.x
+            H @ qp4.results.x
             + g_old
-            + A.transpose() @ Qp4.results.y
-            + C.transpose() @ Qp4.results.z
+            + A.transpose() @ qp4.results.y
+            + C.transpose() @ qp4.results.z
         )
         pri_res = max(
-            normInf(A @ Qp4.results.x - b),
+            normInf(A @ qp4.results.x - b),
             normInf(
-                np.maximum(C @ Qp4.results.x - u, 0)
-                + np.minimum(C @ Qp4.results.x - l, 0)
+                np.maximum(C @ qp4.results.x - u, 0)
+                + np.minimum(C @ qp4.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp4.update(g=g)
-        assert normInf(Qp.model.g - g) <= 1.0e-9
-        Qp4.solve()
+        qp4.update(g=g)
+        assert normInf(qp.model.g - g) <= 1.0e-9
+        qp4.solve()
         dua_res = normInf(
-            H @ Qp4.results.x
+            H @ qp4.results.x
             + g
-            + A.transpose() @ Qp4.results.y
-            + C.transpose() @ Qp4.results.z
+            + A.transpose() @ qp4.results.y
+            + C.transpose() @ qp4.results.z
         )
         pri_res = max(
-            normInf(A @ Qp4.results.x - b),
+            normInf(A @ qp4.results.x - b),
             normInf(
-                np.maximum(C @ Qp4.results.x - u, 0)
-                + np.minimum(C @ Qp4.results.x - l, 0)
+                np.maximum(C @ qp4.results.x - u, 0)
+                + np.minimum(C @ qp4.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp4.results.info.iter))
+        print("total number of iteration: {}".format(qp4.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp4.results.info.setup_time, Qp4.results.info.solve_time
+                qp4.results.info.setup_time, qp4.results.info.solve_time
             )
         )
 
-        Qp5 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp5.settings.eps_abs = 1.0e-9
-        Qp5.settings.verbose = False
-        Qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp5.init(
+        qp5 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp5.settings.eps_abs = 1.0e-9
+        qp5.settings.verbose = False
+        qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp5.init(
             H,
             np.asfortranarray(g_old),
             A,
@@ -3209,46 +3209,46 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z)
+        qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z)
         dua_res = normInf(
-            H @ Qp5.results.x
+            H @ qp5.results.x
             + g_old
-            + A.transpose() @ Qp5.results.y
-            + C.transpose() @ Qp5.results.z
+            + A.transpose() @ qp5.results.y
+            + C.transpose() @ qp5.results.z
         )
         pri_res = max(
-            normInf(A @ Qp5.results.x - b),
+            normInf(A @ qp5.results.x - b),
             normInf(
-                np.maximum(C @ Qp5.results.x - u, 0)
-                + np.minimum(C @ Qp5.results.x - l, 0)
+                np.maximum(C @ qp5.results.x - u, 0)
+                + np.minimum(C @ qp5.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp5.update(g=g)
-        assert normInf(Qp.model.g - g) <= 1.0e-9
-        Qp5.solve()
+        qp5.update(g=g)
+        assert normInf(qp.model.g - g) <= 1.0e-9
+        qp5.solve()
         dua_res = normInf(
-            H @ Qp5.results.x
+            H @ qp5.results.x
             + g
-            + A.transpose() @ Qp5.results.y
-            + C.transpose() @ Qp5.results.z
+            + A.transpose() @ qp5.results.y
+            + C.transpose() @ qp5.results.z
         )
         pri_res = max(
-            normInf(A @ Qp5.results.x - b),
+            normInf(A @ qp5.results.x - b),
             normInf(
-                np.maximum(C @ Qp5.results.x - u, 0)
-                + np.minimum(C @ Qp5.results.x - l, 0)
+                np.maximum(C @ qp5.results.x - u, 0)
+                + np.minimum(C @ qp5.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp5.results.info.iter))
+        print("total number of iteration: {}".format(qp5.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp5.results.info.setup_time, Qp5.results.info.solve_time
+                qp5.results.info.setup_time, qp5.results.info.solve_time
             )
         )
 
@@ -3261,11 +3261,11 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A_old, b, C, u, l = generate_mixed_qp(n)
         n_eq = A_old.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A_old,
@@ -3275,57 +3275,57 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
         A = spa.random(n_eq, n, density=0.15, data_rvs=np.random.randn, format="csc")
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A_old.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A_old.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A_old @ Qp.results.x - b),
+            normInf(A_old @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(A=A)
-        assert normInf(Qp.model.A - A) <= 1.0e-9
-        Qp.solve()
+        qp.update(A=A)
+        assert normInf(qp.model.A - A) <= 1.0e-9
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = (
+        qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
-        Qp2.init(
+        qp2.init(
             H,
             np.asfortranarray(g),
             A_old,
@@ -3335,56 +3335,56 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp2.solve()
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A_old.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A_old.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A_old @ Qp2.results.x - b),
+            normInf(A_old @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp2.update(A=A)
-        assert normInf(Qp.model.A - A) <= 1.0e-9
-        Qp2.solve()
+        qp2.update(A=A)
+        assert normInf(qp.model.A - A) <= 1.0e-9
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp2.results.info.iter))
+        print("total number of iteration: {}".format(qp2.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp2.results.info.setup_time, Qp2.results.info.solve_time
+                qp2.results.info.setup_time, qp2.results.info.solve_time
             )
         )
 
-        Qp3 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp3.settings.eps_abs = 1.0e-9
-        Qp3.settings.verbose = False
-        Qp3.settings.initial_guess = (
+        qp3 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp3.settings.eps_abs = 1.0e-9
+        qp3.settings.verbose = False
+        qp3.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp3.init(
+        qp3.init(
             H,
             np.asfortranarray(g),
             A_old,
@@ -3394,56 +3394,56 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp3.solve()
+        qp3.solve()
         dua_res = normInf(
-            H @ Qp3.results.x
+            H @ qp3.results.x
             + g
-            + A_old.transpose() @ Qp3.results.y
-            + C.transpose() @ Qp3.results.z
+            + A_old.transpose() @ qp3.results.y
+            + C.transpose() @ qp3.results.z
         )
         pri_res = max(
-            normInf(A_old @ Qp3.results.x - b),
+            normInf(A_old @ qp3.results.x - b),
             normInf(
-                np.maximum(C @ Qp3.results.x - u, 0)
-                + np.minimum(C @ Qp3.results.x - l, 0)
+                np.maximum(C @ qp3.results.x - u, 0)
+                + np.minimum(C @ qp3.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp3.update(A=A)
-        assert normInf(Qp.model.A - A) <= 1.0e-9
-        Qp3.solve()
+        qp3.update(A=A)
+        assert normInf(qp.model.A - A) <= 1.0e-9
+        qp3.solve()
         dua_res = normInf(
-            H @ Qp3.results.x
+            H @ qp3.results.x
             + g
-            + A.transpose() @ Qp3.results.y
-            + C.transpose() @ Qp3.results.z
+            + A.transpose() @ qp3.results.y
+            + C.transpose() @ qp3.results.z
         )
         pri_res = max(
-            normInf(A @ Qp3.results.x - b),
+            normInf(A @ qp3.results.x - b),
             normInf(
-                np.maximum(C @ Qp3.results.x - u, 0)
-                + np.minimum(C @ Qp3.results.x - l, 0)
+                np.maximum(C @ qp3.results.x - u, 0)
+                + np.minimum(C @ qp3.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp3.results.info.iter))
+        print("total number of iteration: {}".format(qp3.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp3.results.info.setup_time, Qp3.results.info.solve_time
+                qp3.results.info.setup_time, qp3.results.info.solve_time
             )
         )
 
-        Qp4 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp4.settings.eps_abs = 1.0e-9
-        Qp4.settings.verbose = False
-        Qp4.settings.initial_guess = (
+        qp4 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp4.settings.eps_abs = 1.0e-9
+        qp4.settings.verbose = False
+        qp4.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
-        Qp4.init(
+        qp4.init(
             H,
             np.asfortranarray(g),
             A_old,
@@ -3453,54 +3453,54 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp4.solve()
+        qp4.solve()
         dua_res = normInf(
-            H @ Qp4.results.x
+            H @ qp4.results.x
             + g
-            + A_old.transpose() @ Qp4.results.y
-            + C.transpose() @ Qp4.results.z
+            + A_old.transpose() @ qp4.results.y
+            + C.transpose() @ qp4.results.z
         )
         pri_res = max(
-            normInf(A_old @ Qp4.results.x - b),
+            normInf(A_old @ qp4.results.x - b),
             normInf(
-                np.maximum(C @ Qp4.results.x - u, 0)
-                + np.minimum(C @ Qp4.results.x - l, 0)
+                np.maximum(C @ qp4.results.x - u, 0)
+                + np.minimum(C @ qp4.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp4.update(A=A)
-        assert normInf(Qp.model.A - A) <= 1.0e-9
-        Qp4.solve()
+        qp4.update(A=A)
+        assert normInf(qp.model.A - A) <= 1.0e-9
+        qp4.solve()
         dua_res = normInf(
-            H @ Qp4.results.x
+            H @ qp4.results.x
             + g
-            + A.transpose() @ Qp4.results.y
-            + C.transpose() @ Qp4.results.z
+            + A.transpose() @ qp4.results.y
+            + C.transpose() @ qp4.results.z
         )
         pri_res = max(
-            normInf(A @ Qp4.results.x - b),
+            normInf(A @ qp4.results.x - b),
             normInf(
-                np.maximum(C @ Qp4.results.x - u, 0)
-                + np.minimum(C @ Qp4.results.x - l, 0)
+                np.maximum(C @ qp4.results.x - u, 0)
+                + np.minimum(C @ qp4.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp4.results.info.iter))
+        print("total number of iteration: {}".format(qp4.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp4.results.info.setup_time, Qp4.results.info.solve_time
+                qp4.results.info.setup_time, qp4.results.info.solve_time
             )
         )
 
-        Qp5 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp5.settings.eps_abs = 1.0e-9
-        Qp5.settings.verbose = False
-        Qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp5.init(
+        qp5 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp5.settings.eps_abs = 1.0e-9
+        qp5.settings.verbose = False
+        qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp5.init(
             H,
             np.asfortranarray(g),
             A_old,
@@ -3510,46 +3510,46 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z)
+        qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z)
         dua_res = normInf(
-            H @ Qp5.results.x
+            H @ qp5.results.x
             + g
-            + A_old.transpose() @ Qp5.results.y
-            + C.transpose() @ Qp5.results.z
+            + A_old.transpose() @ qp5.results.y
+            + C.transpose() @ qp5.results.z
         )
         pri_res = max(
-            normInf(A_old @ Qp5.results.x - b),
+            normInf(A_old @ qp5.results.x - b),
             normInf(
-                np.maximum(C @ Qp5.results.x - u, 0)
-                + np.minimum(C @ Qp5.results.x - l, 0)
+                np.maximum(C @ qp5.results.x - u, 0)
+                + np.minimum(C @ qp5.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp5.update(A=A)
-        assert normInf(Qp.model.A - A) <= 1.0e-9
-        Qp5.solve()
+        qp5.update(A=A)
+        assert normInf(qp.model.A - A) <= 1.0e-9
+        qp5.solve()
         dua_res = normInf(
-            H @ Qp5.results.x
+            H @ qp5.results.x
             + g
-            + A.transpose() @ Qp5.results.y
-            + C.transpose() @ Qp5.results.z
+            + A.transpose() @ qp5.results.y
+            + C.transpose() @ qp5.results.z
         )
         pri_res = max(
-            normInf(A @ Qp5.results.x - b),
+            normInf(A @ qp5.results.x - b),
             normInf(
-                np.maximum(C @ Qp5.results.x - u, 0)
-                + np.minimum(C @ Qp5.results.x - l, 0)
+                np.maximum(C @ qp5.results.x - u, 0)
+                + np.minimum(C @ qp5.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp5.results.info.iter))
+        print("total number of iteration: {}".format(qp5.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp5.results.info.setup_time, Qp5.results.info.solve_time
+                qp5.results.info.setup_time, qp5.results.info.solve_time
             )
         )
 
@@ -3562,11 +3562,11 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -3576,56 +3576,56 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(rho=1.0e-7)
-        assert Qp.results.info.rho == 1.0e-7
-        Qp.solve()
+        qp.update(rho=1.0e-7)
+        assert qp.results.info.rho == 1.0e-7
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = (
+        qp2 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
-        Qp2.init(
+        qp2.init(
             H,
             np.asfortranarray(g),
             A,
@@ -3635,56 +3635,56 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp2.solve()
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp2.update(rho=1.0e-7)
-        assert Qp2.results.info.rho == 1.0e-7
-        Qp2.solve()
+        qp2.update(rho=1.0e-7)
+        assert qp2.results.info.rho == 1.0e-7
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp2.results.info.iter))
+        print("total number of iteration: {}".format(qp2.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp2.results.info.setup_time, Qp2.results.info.solve_time
+                qp2.results.info.setup_time, qp2.results.info.solve_time
             )
         )
 
-        Qp3 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp3.settings.eps_abs = 1.0e-9
-        Qp3.settings.verbose = False
-        Qp3.settings.initial_guess = (
+        qp3 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp3.settings.eps_abs = 1.0e-9
+        qp3.settings.verbose = False
+        qp3.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp3.init(
+        qp3.init(
             H,
             np.asfortranarray(g),
             A,
@@ -3694,56 +3694,56 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp3.solve()
+        qp3.solve()
         dua_res = normInf(
-            H @ Qp3.results.x
+            H @ qp3.results.x
             + g
-            + A.transpose() @ Qp3.results.y
-            + C.transpose() @ Qp3.results.z
+            + A.transpose() @ qp3.results.y
+            + C.transpose() @ qp3.results.z
         )
         pri_res = max(
-            normInf(A @ Qp3.results.x - b),
+            normInf(A @ qp3.results.x - b),
             normInf(
-                np.maximum(C @ Qp3.results.x - u, 0)
-                + np.minimum(C @ Qp3.results.x - l, 0)
+                np.maximum(C @ qp3.results.x - u, 0)
+                + np.minimum(C @ qp3.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp3.update(rho=1.0e-7)
-        assert Qp3.results.info.rho == 1.0e-7
-        Qp3.solve()
+        qp3.update(rho=1.0e-7)
+        assert qp3.results.info.rho == 1.0e-7
+        qp3.solve()
         dua_res = normInf(
-            H @ Qp3.results.x
+            H @ qp3.results.x
             + g
-            + A.transpose() @ Qp3.results.y
-            + C.transpose() @ Qp3.results.z
+            + A.transpose() @ qp3.results.y
+            + C.transpose() @ qp3.results.z
         )
         pri_res = max(
-            normInf(A @ Qp3.results.x - b),
+            normInf(A @ qp3.results.x - b),
             normInf(
-                np.maximum(C @ Qp3.results.x - u, 0)
-                + np.minimum(C @ Qp3.results.x - l, 0)
+                np.maximum(C @ qp3.results.x - u, 0)
+                + np.minimum(C @ qp3.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp3.results.info.iter))
+        print("total number of iteration: {}".format(qp3.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp3.results.info.setup_time, Qp3.results.info.solve_time
+                qp3.results.info.setup_time, qp3.results.info.solve_time
             )
         )
 
-        Qp4 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp4.settings.eps_abs = 1.0e-9
-        Qp4.settings.verbose = False
-        Qp4.settings.initial_guess = (
+        qp4 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp4.settings.eps_abs = 1.0e-9
+        qp4.settings.verbose = False
+        qp4.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
-        Qp4.init(
+        qp4.init(
             H,
             np.asfortranarray(g),
             A,
@@ -3753,54 +3753,54 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp4.solve()
+        qp4.solve()
         dua_res = normInf(
-            H @ Qp4.results.x
+            H @ qp4.results.x
             + g
-            + A.transpose() @ Qp4.results.y
-            + C.transpose() @ Qp4.results.z
+            + A.transpose() @ qp4.results.y
+            + C.transpose() @ qp4.results.z
         )
         pri_res = max(
-            normInf(A @ Qp4.results.x - b),
+            normInf(A @ qp4.results.x - b),
             normInf(
-                np.maximum(C @ Qp4.results.x - u, 0)
-                + np.minimum(C @ Qp4.results.x - l, 0)
+                np.maximum(C @ qp4.results.x - u, 0)
+                + np.minimum(C @ qp4.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp4.update(rho=1.0e-7)
-        assert Qp4.results.info.rho == 1.0e-7
-        Qp4.solve()
+        qp4.update(rho=1.0e-7)
+        assert qp4.results.info.rho == 1.0e-7
+        qp4.solve()
         dua_res = normInf(
-            H @ Qp4.results.x
+            H @ qp4.results.x
             + g
-            + A.transpose() @ Qp4.results.y
-            + C.transpose() @ Qp4.results.z
+            + A.transpose() @ qp4.results.y
+            + C.transpose() @ qp4.results.z
         )
         pri_res = max(
-            normInf(A @ Qp4.results.x - b),
+            normInf(A @ qp4.results.x - b),
             normInf(
-                np.maximum(C @ Qp4.results.x - u, 0)
-                + np.minimum(C @ Qp4.results.x - l, 0)
+                np.maximum(C @ qp4.results.x - u, 0)
+                + np.minimum(C @ qp4.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp4.results.info.iter))
+        print("total number of iteration: {}".format(qp4.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp4.results.info.setup_time, Qp4.results.info.solve_time
+                qp4.results.info.setup_time, qp4.results.info.solve_time
             )
         )
 
-        Qp5 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp5.settings.eps_abs = 1.0e-9
-        Qp5.settings.verbose = False
-        Qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp5.init(
+        qp5 = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp5.settings.eps_abs = 1.0e-9
+        qp5.settings.verbose = False
+        qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp5.init(
             H,
             np.asfortranarray(g),
             A,
@@ -3810,46 +3810,46 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z)
+        qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z)
         dua_res = normInf(
-            H @ Qp5.results.x
+            H @ qp5.results.x
             + g
-            + A.transpose() @ Qp5.results.y
-            + C.transpose() @ Qp5.results.z
+            + A.transpose() @ qp5.results.y
+            + C.transpose() @ qp5.results.z
         )
         pri_res = max(
-            normInf(A @ Qp5.results.x - b),
+            normInf(A @ qp5.results.x - b),
             normInf(
-                np.maximum(C @ Qp5.results.x - u, 0)
-                + np.minimum(C @ Qp5.results.x - l, 0)
+                np.maximum(C @ qp5.results.x - u, 0)
+                + np.minimum(C @ qp5.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp5.update(rho=1.0e-7)
-        assert Qp5.results.info.rho == 1.0e-7
-        Qp5.solve()
+        qp5.update(rho=1.0e-7)
+        assert qp5.results.info.rho == 1.0e-7
+        qp5.solve()
         dua_res = normInf(
-            H @ Qp5.results.x
+            H @ qp5.results.x
             + g
-            + A.transpose() @ Qp5.results.y
-            + C.transpose() @ Qp5.results.z
+            + A.transpose() @ qp5.results.y
+            + C.transpose() @ qp5.results.z
         )
         pri_res = max(
-            normInf(A @ Qp5.results.x - b),
+            normInf(A @ qp5.results.x - b),
             normInf(
-                np.maximum(C @ Qp5.results.x - u, 0)
-                + np.minimum(C @ Qp5.results.x - l, 0)
+                np.maximum(C @ qp5.results.x - u, 0)
+                + np.minimum(C @ qp5.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp5.results.info.iter))
+        print("total number of iteration: {}".format(qp5.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp5.results.info.setup_time, Qp5.results.info.solve_time
+                qp5.results.info.setup_time, qp5.results.info.solve_time
             )
         )
 
@@ -3872,25 +3872,25 @@ class DenseQpWrapper(unittest.TestCase):
         l = 2.0 * np.ones((n,))
         u = np.full(l.shape, +np.infty)
 
-        Qp = proxsuite.proxqp.dense.QP(n, 0, n)
-        Qp.init(H, g, A, b, C, u, l)
-        Qp.solve()
+        qp = proxsuite.proxqp.dense.QP(n, 0, n)
+        qp.init(H, g, A, b, C, u, l)
+        qp.solve()
         x_theoretically_optimal = np.array([2.0] * 149 + [3.0])
 
-        dua_res = normInf(H @ Qp.results.x + g + C.transpose() @ Qp.results.z)
+        dua_res = normInf(H @ qp.results.x + g + C.transpose() @ qp.results.z)
         pri_res = normInf(
-            np.maximum(C @ Qp.results.x - u, 0) + np.minimum(C @ Qp.results.x - l, 0)
+            np.maximum(C @ qp.results.x - u, 0) + np.minimum(C @ qp.results.x - l, 0)
         )
 
         assert dua_res <= 1e-3  # default precision of the solver
         assert pri_res <= 1e-3
-        assert normInf(x_theoretically_optimal - Qp.results.x) <= 1e-3
+        assert normInf(x_theoretically_optimal - qp.results.x) <= 1e-3
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, 0, n))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -3906,11 +3906,11 @@ class DenseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -3922,44 +3922,44 @@ class DenseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         for i in range(10):
-            Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+            qp.solve()
+            assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
-                H @ Qp.results.x
+                H @ qp.results.x
                 + g
-                + A.transpose() @ Qp.results.y
-                + C.transpose() @ Qp.results.z
+                + A.transpose() @ qp.results.y
+                + C.transpose() @ qp.results.z
             )
             pri_res = max(
-                normInf(A @ Qp.results.x - b),
+                normInf(A @ qp.results.x - b),
                 normInf(
-                    np.maximum(C @ Qp.results.x - u, 0)
-                    + np.minimum(C @ Qp.results.x - l, 0)
+                    np.maximum(C @ qp.results.x - u, 0)
+                    + np.minimum(C @ qp.results.x - l, 0)
                 ),
             )
             assert dua_res <= 1e-9
@@ -3977,13 +3977,13 @@ class DenseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -3995,44 +3995,44 @@ class DenseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         for i in range(10):
-            Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+            qp.solve()
+            assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
-                H @ Qp.results.x
+                H @ qp.results.x
                 + g
-                + A.transpose() @ Qp.results.y
-                + C.transpose() @ Qp.results.z
+                + A.transpose() @ qp.results.y
+                + C.transpose() @ qp.results.z
             )
             pri_res = max(
-                normInf(A @ Qp.results.x - b),
+                normInf(A @ qp.results.x - b),
                 normInf(
-                    np.maximum(C @ Qp.results.x - u, 0)
-                    + np.minimum(C @ Qp.results.x - l, 0)
+                    np.maximum(C @ qp.results.x - u, 0)
+                    + np.minimum(C @ qp.results.x - l, 0)
                 ),
             )
             assert dua_res <= 1e-9
@@ -4050,13 +4050,13 @@ class DenseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -4068,44 +4068,44 @@ class DenseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         for i in range(10):
-            Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+            qp.solve()
+            assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
-                H @ Qp.results.x
+                H @ qp.results.x
                 + g
-                + A.transpose() @ Qp.results.y
-                + C.transpose() @ Qp.results.z
+                + A.transpose() @ qp.results.y
+                + C.transpose() @ qp.results.z
             )
             pri_res = max(
-                normInf(A @ Qp.results.x - b),
+                normInf(A @ qp.results.x - b),
                 normInf(
-                    np.maximum(C @ Qp.results.x - u, 0)
-                    + np.minimum(C @ Qp.results.x - l, 0)
+                    np.maximum(C @ qp.results.x - u, 0)
+                    + np.minimum(C @ qp.results.x - l, 0)
                 ),
             )
             assert dua_res <= 1e-9
@@ -4123,13 +4123,13 @@ class DenseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -4141,44 +4141,44 @@ class DenseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         for i in range(10):
-            Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+            qp.solve()
+            assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
-                H @ Qp.results.x
+                H @ qp.results.x
                 + g
-                + A.transpose() @ Qp.results.y
-                + C.transpose() @ Qp.results.z
+                + A.transpose() @ qp.results.y
+                + C.transpose() @ qp.results.z
             )
             pri_res = max(
-                normInf(A @ Qp.results.x - b),
+                normInf(A @ qp.results.x - b),
                 normInf(
-                    np.maximum(C @ Qp.results.x - u, 0)
-                    + np.minimum(C @ Qp.results.x - l, 0)
+                    np.maximum(C @ qp.results.x - u, 0)
+                    + np.minimum(C @ qp.results.x - l, 0)
                 ),
             )
             assert dua_res <= 1e-9
@@ -4196,13 +4196,13 @@ class DenseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -4214,44 +4214,44 @@ class DenseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
-        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
+        qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -4269,13 +4269,13 @@ class DenseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -4287,44 +4287,44 @@ class DenseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
-        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
+        qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -4342,13 +4342,13 @@ class DenseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -4360,44 +4360,44 @@ class DenseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
-        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
+        qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -4415,11 +4415,11 @@ class DenseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -4431,44 +4431,44 @@ class DenseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
-        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
+        qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -4485,20 +4485,20 @@ class DenseQpWrapper(unittest.TestCase):
         u = None
         l = None
 
-        Qp = proxsuite.proxqp.dense.QP(3, 0, 0)
-        Qp.init(H, g, A, b, C, u, l)
-        Qp.solve()
-        print("optimal x: {}".format(Qp.results.x))
+        qp = proxsuite.proxqp.dense.QP(3, 0, 0)
+        qp.init(H, g, A, b, C, u, l)
+        qp.solve()
+        print("optimal x: {}".format(qp.results.x))
 
-        dua_res = normInf(H @ Qp.results.x + g)
+        dua_res = normInf(H @ qp.results.x + g)
 
         assert dua_res <= 1e-3  # default precision of the solver
         print("--n = {} ; n_eq = {} ; n_in = {}".format(3, 0, 0))
         print("dual residual = {} ".format(dua_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 

--- a/test/src/dense_qp_wrapper.py
+++ b/test/src/dense_qp_wrapper.py
@@ -3894,9 +3894,9 @@ class DenseQpWrapper(unittest.TestCase):
             )
         )
 
-
-
-    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_no_initial_guess(self):
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_no_initial_guess(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, no initial guess, multiple solve and default rho and mu_eq"
         )
@@ -3904,8 +3904,8 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
@@ -3920,15 +3920,15 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -3946,9 +3946,9 @@ class DenseQpWrapper(unittest.TestCase):
         assert pri_res <= 1e-9
         for i in range(10):
             Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-            assert np.abs(rho - Qp.results.info.rho) <1.E-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
                 H @ Qp.results.x
                 + g
@@ -3965,7 +3965,9 @@ class DenseQpWrapper(unittest.TestCase):
             assert dua_res <= 1e-9
             assert pri_res <= 1e-9
 
-    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_EQUALITY_CONSTRAINED_INITIAL_GUESS(self):
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_EQUALITY_CONSTRAINED_INITIAL_GUESS(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, EQUALITY_CONSTRAINED_INITIAL_GUESS, multiple solve and default rho and mu_eq"
         )
@@ -3973,12 +3975,14 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
+        Qp.settings.initial_guess = (
+            proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
+        )
         Qp.init(
             H,
             np.asfortranarray(g),
@@ -3989,15 +3993,15 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -4015,9 +4019,9 @@ class DenseQpWrapper(unittest.TestCase):
         assert pri_res <= 1e-9
         for i in range(10):
             Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-            assert np.abs(rho - Qp.results.info.rho) <1.E-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
                 H @ Qp.results.x
                 + g
@@ -4034,7 +4038,9 @@ class DenseQpWrapper(unittest.TestCase):
             assert dua_res <= 1e-9
             assert pri_res <= 1e-9
 
-    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_COLD_START_WITH_PREVIOUS_RESULT(self):
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_COLD_START_WITH_PREVIOUS_RESULT(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, COLD_START_WITH_PREVIOUS_RESULT, multiple solve and default rho and mu_eq"
         )
@@ -4042,12 +4048,14 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
+        Qp.settings.initial_guess = (
+            proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
+        )
         Qp.init(
             H,
             np.asfortranarray(g),
@@ -4058,15 +4066,15 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -4084,9 +4092,9 @@ class DenseQpWrapper(unittest.TestCase):
         assert pri_res <= 1e-9
         for i in range(10):
             Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-            assert np.abs(rho - Qp.results.info.rho) <1.E-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
                 H @ Qp.results.x
                 + g
@@ -4103,7 +4111,9 @@ class DenseQpWrapper(unittest.TestCase):
             assert dua_res <= 1e-9
             assert pri_res <= 1e-9
 
-    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_WARM_START_WITH_PREVIOUS_RESULT(self):
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_WARM_START_WITH_PREVIOUS_RESULT(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, WARM_START_WITH_PREVIOUS_RESULT, multiple solve and default rho and mu_eq"
         )
@@ -4111,12 +4121,14 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
+        Qp.settings.initial_guess = (
+            proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
+        )
         Qp.init(
             H,
             np.asfortranarray(g),
@@ -4127,15 +4139,15 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -4153,9 +4165,9 @@ class DenseQpWrapper(unittest.TestCase):
         assert pri_res <= 1e-9
         for i in range(10):
             Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-            assert np.abs(rho - Qp.results.info.rho) <1.E-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
                 H @ Qp.results.x
                 + g
@@ -4172,8 +4184,9 @@ class DenseQpWrapper(unittest.TestCase):
             assert dua_res <= 1e-9
             assert pri_res <= 1e-9
 
-
-    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_WARM_START_WITH_PREVIOUS_RESULT(self):
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_WARM_START_WITH_PREVIOUS_RESULT(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, WARM_START_WITH_PREVIOUS_RESULT, update + solve and default rho and mu_eq"
         )
@@ -4181,12 +4194,14 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
+        Qp.settings.initial_guess = (
+            proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
+        )
         Qp.init(
             H,
             np.asfortranarray(g),
@@ -4197,15 +4212,15 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -4221,10 +4236,10 @@ class DenseQpWrapper(unittest.TestCase):
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
-        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
-        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
-        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
         dua_res = normInf(
             H @ Qp.results.x
@@ -4242,7 +4257,9 @@ class DenseQpWrapper(unittest.TestCase):
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
 
-    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_COLD_START_WITH_PREVIOUS_RESULT(self):
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_COLD_START_WITH_PREVIOUS_RESULT(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, COLD_START_WITH_PREVIOUS_RESULT, update + solve and default rho and mu_eq"
         )
@@ -4250,12 +4267,14 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
+        Qp.settings.initial_guess = (
+            proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
+        )
         Qp.init(
             H,
             np.asfortranarray(g),
@@ -4266,15 +4285,15 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -4290,10 +4309,10 @@ class DenseQpWrapper(unittest.TestCase):
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
-        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
-        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
-        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
         dua_res = normInf(
             H @ Qp.results.x
@@ -4311,7 +4330,9 @@ class DenseQpWrapper(unittest.TestCase):
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
 
-    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_EQUALITY_CONSTRAINED_INITIAL_GUESS(self):
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_EQUALITY_CONSTRAINED_INITIAL_GUESS(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, EQUALITY_CONSTRAINED_INITIAL_GUESS, update + solve and default rho and mu_eq"
         )
@@ -4319,12 +4340,14 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
+        Qp.settings.initial_guess = (
+            proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
+        )
         Qp.init(
             H,
             np.asfortranarray(g),
@@ -4335,15 +4358,15 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -4359,10 +4382,10 @@ class DenseQpWrapper(unittest.TestCase):
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
-        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
-        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
-        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
         dua_res = normInf(
             H @ Qp.results.x
@@ -4380,7 +4403,9 @@ class DenseQpWrapper(unittest.TestCase):
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
 
-    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_NO_INITIAL_GUESS(self):
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_NO_INITIAL_GUESS(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, NO_INITIAL_GUESS, update + solve and default rho and mu_eq"
         )
@@ -4388,8 +4413,8 @@ class DenseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.dense.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
@@ -4404,15 +4429,15 @@ class DenseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -4428,10 +4453,10 @@ class DenseQpWrapper(unittest.TestCase):
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
-        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
-        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
-        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
         dua_res = normInf(
             H @ Qp.results.x
@@ -4448,8 +4473,6 @@ class DenseQpWrapper(unittest.TestCase):
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-
-
 
     def test_initializing_with_None(self):
         print("------------------------test initialization with Nones")

--- a/test/src/dense_ruiz_equilibration.cpp
+++ b/test/src/dense_ruiz_equilibration.cpp
@@ -18,43 +18,43 @@ DOCTEST_TEST_CASE("ruiz preconditioner")
 
   Scalar sparsity_factor(0.15);
   Scalar strong_convexity_factor(0.01);
-  proxqp::dense::Model<Scalar> qp = proxqp::utils::dense_strongly_convex_qp(
+  proxqp::dense::Model<Scalar> qp_random = proxqp::utils::dense_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
   switch (sym) {
     case proxqp::Symmetry::upper: {
-      qp.H = qp.H.triangularView<Eigen::Upper>();
+      qp_random.H = qp_random.H.triangularView<Eigen::Upper>();
       break;
     }
     case proxqp::Symmetry::lower: {
-      qp.H = qp.H.triangularView<Eigen::Lower>();
+      qp_random.H = qp_random.H.triangularView<Eigen::Lower>();
       break;
     }
     default: {
     }
   }
 
-  proxqp::dense::QP<Scalar> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
+  proxqp::dense::QP<Scalar> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
 
   auto head = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>(
-    Qp.ruiz.delta.head(dim).asDiagonal());
+    qp.ruiz.delta.head(dim).asDiagonal());
   auto tail = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>(
-    Qp.ruiz.delta.tail(n_eq).asDiagonal());
-  auto c = Qp.ruiz.c;
+    qp.ruiz.delta.tail(n_eq).asDiagonal());
+  auto c = qp.ruiz.c;
 
-  auto const& H = qp.H;
-  auto const& g = qp.g;
-  auto const& A = qp.A;
-  auto const& b = qp.b;
+  auto const& H = qp_random.H;
+  auto const& g = qp_random.g;
+  auto const& A = qp_random.A;
+  auto const& b = qp_random.b;
 
   auto H_new = (c * head * H * head).eval();
   auto g_new = (c * head * g).eval();
   auto A_new = (tail * A * head).eval();
   auto b_new = (tail * b).eval();
 
-  DOCTEST_CHECK((H_new - Qp.work.H_scaled).norm() <= Scalar(1e-10));
-  DOCTEST_CHECK((g_new - Qp.work.g_scaled).norm() <= Scalar(1e-10));
-  DOCTEST_CHECK((A_new - Qp.work.A_scaled).norm() <= Scalar(1e-10));
-  DOCTEST_CHECK((b_new - Qp.work.b_scaled).norm() <= Scalar(1e-10));
+  DOCTEST_CHECK((H_new - qp.work.H_scaled).norm() <= Scalar(1e-10));
+  DOCTEST_CHECK((g_new - qp.work.g_scaled).norm() <= Scalar(1e-10));
+  DOCTEST_CHECK((A_new - qp.work.A_scaled).norm() <= Scalar(1e-10));
+  DOCTEST_CHECK((b_new - qp.work.b_scaled).norm() <= Scalar(1e-10));
 }

--- a/test/src/dense_ruiz_equilibration.cpp
+++ b/test/src/dense_ruiz_equilibration.cpp
@@ -18,8 +18,9 @@ DOCTEST_TEST_CASE("ruiz preconditioner")
 
   Scalar sparsity_factor(0.15);
   Scalar strong_convexity_factor(0.01);
-  proxqp::dense::Model<Scalar> qp_random = proxqp::utils::dense_strongly_convex_qp(
-    dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
+  proxqp::dense::Model<Scalar> qp_random =
+    proxqp::utils::dense_strongly_convex_qp(
+      dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
   switch (sym) {
     case proxqp::Symmetry::upper: {
@@ -35,7 +36,13 @@ DOCTEST_TEST_CASE("ruiz preconditioner")
   }
 
   proxqp::dense::QP<Scalar> qp{ dim, n_eq, n_in }; // creating QP object
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
 
   auto head = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>(
     qp.ruiz.delta.head(dim).asDiagonal());

--- a/test/src/dense_unconstrained_qp.cpp
+++ b/test/src/dense_unconstrained_qp.cpp
@@ -29,15 +29,22 @@ DOCTEST_TEST_CASE(
       dim, sparsity_factor, strong_convexity_factor);
     proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
     qp.settings.eps_abs = eps_abs;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
-    T pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    T pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+                 qp_random.A.transpose() * qp.results.y +
                  qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -70,19 +77,27 @@ DOCTEST_TEST_CASE("sparse random not strongly convex unconstrained qp and "
       dim, sparsity_factor, strong_convexity_factor);
     auto x_sol = proxqp::utils::rand::vector_rand<T>(dim);
     qp_random.g =
-      -qp_random.H * x_sol; // to be dually feasible g must be in the image space of H
+      -qp_random.H *
+      x_sol; // to be dually feasible g must be in the image space of H
 
     proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
     qp.settings.eps_abs = eps_abs;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
-    T pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+    T pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+                 qp_random.A.transpose() * qp.results.y +
                  qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
@@ -115,15 +130,22 @@ DOCTEST_TEST_CASE("unconstrained qp with H = Id and g random")
 
   proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
   qp.settings.eps_abs = eps_abs;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res =
-    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-              proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
@@ -156,15 +178,22 @@ DOCTEST_TEST_CASE("unconstrained qp with H = Id and g = 0")
 
   proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
   qp.settings.eps_abs = eps_abs;
-  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l);
   qp.solve();
 
-  T pri_res =
-    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-              proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+               qp_random.A.transpose() * qp.results.y +
                qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);

--- a/test/src/dense_unconstrained_qp.cpp
+++ b/test/src/dense_unconstrained_qp.cpp
@@ -25,20 +25,20 @@ DOCTEST_TEST_CASE(
     int n_eq(0);
     int n_in(0);
     T strong_convexity_factor(1.e-2);
-    proxqp::dense::Model<T> qp = proxqp::utils::dense_unconstrained_qp(
+    proxqp::dense::Model<T> qp_random = proxqp::utils::dense_unconstrained_qp(
       dim, sparsity_factor, strong_convexity_factor);
-    proxqp::dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-    Qp.settings.eps_abs = eps_abs;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+    qp.settings.eps_abs = eps_abs;
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                proxqp::dense::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-                 qp.C.transpose() * Qp.results.z)
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+                 qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
@@ -47,7 +47,7 @@ DOCTEST_TEST_CASE(
               << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
   }
 }
@@ -66,24 +66,24 @@ DOCTEST_TEST_CASE("sparse random not strongly convex unconstrained qp and "
     int n_eq(0);
     int n_in(0);
     T strong_convexity_factor(0);
-    proxqp::dense::Model<T> qp = proxqp::utils::dense_unconstrained_qp(
+    proxqp::dense::Model<T> qp_random = proxqp::utils::dense_unconstrained_qp(
       dim, sparsity_factor, strong_convexity_factor);
     auto x_sol = proxqp::utils::rand::vector_rand<T>(dim);
-    qp.g =
-      -qp.H * x_sol; // to be dually feasible g must be in the image space of H
+    qp_random.g =
+      -qp_random.H * x_sol; // to be dually feasible g must be in the image space of H
 
-    proxqp::dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-    Qp.settings.eps_abs = eps_abs;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+    qp.settings.eps_abs = eps_abs;
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (proxqp::dense::positive_part(qp.C * Qp.results.x - qp.u) +
-                proxqp::dense::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
-    T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-                 qp.C.transpose() * Qp.results.z)
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+                 qp_random.C.transpose() * qp.results.z)
                   .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
@@ -92,7 +92,7 @@ DOCTEST_TEST_CASE("sparse random not strongly convex unconstrained qp and "
               << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
   }
 }
@@ -108,23 +108,23 @@ DOCTEST_TEST_CASE("unconstrained qp with H = Id and g random")
   int n_eq(0);
   int n_in(0);
   T strong_convexity_factor(1.E-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_unconstrained_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_unconstrained_qp(
     dim, sparsity_factor, strong_convexity_factor);
-  qp.H.setZero();
-  qp.H.diagonal().array() += 1;
+  qp_random.H.setZero();
+  qp_random.H.diagonal().array() += 1;
 
-  proxqp::dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
   T pri_res =
-    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (proxqp::dense::positive_part(qp.C * Qp.results.x - qp.u) +
-              proxqp::dense::negative_part(qp.C * Qp.results.x - qp.l))
+    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -133,7 +133,7 @@ DOCTEST_TEST_CASE("unconstrained qp with H = Id and g random")
             << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
 }
 
@@ -148,24 +148,24 @@ DOCTEST_TEST_CASE("unconstrained qp with H = Id and g = 0")
   int n_eq(0);
   int n_in(0);
   T strong_convexity_factor(1.E-2);
-  proxqp::dense::Model<T> qp = proxqp::utils::dense_unconstrained_qp(
+  proxqp::dense::Model<T> qp_random = proxqp::utils::dense_unconstrained_qp(
     dim, sparsity_factor, strong_convexity_factor);
-  qp.H.setZero();
-  qp.H.diagonal().array() += 1;
-  qp.g.setZero();
+  qp_random.H.setZero();
+  qp_random.H.diagonal().array() += 1;
+  qp_random.g.setZero();
 
-  proxqp::dense::QP<T> Qp{ dim, n_eq, n_in }; // creating QP object
-  Qp.settings.eps_abs = eps_abs;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-  Qp.solve();
+  proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+  qp.settings.eps_abs = eps_abs;
+  qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+  qp.solve();
 
   T pri_res =
-    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (proxqp::dense::positive_part(qp.C * Qp.results.x - qp.u) +
-              proxqp::dense::negative_part(qp.C * Qp.results.x - qp.l))
+    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (proxqp::dense::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              proxqp::dense::negative_part(qp_random.C * qp.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
+  T dua_res = (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
                 .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -174,6 +174,6 @@ DOCTEST_TEST_CASE("unconstrained qp with H = Id and g = 0")
             << " nin: " << n_in << std::endl;
   std::cout << "primal residual: " << pri_res << std::endl;
   std::cout << "dual residual: " << dua_res << std::endl;
-  std::cout << "total number of iteration: " << Qp.results.info.iter
+  std::cout << "total number of iteration: " << qp.results.info.iter
             << std::endl;
 }

--- a/test/src/qp_eq_py.cpp
+++ b/test/src/qp_eq_py.cpp
@@ -54,20 +54,30 @@ DOCTEST_TEST_CASE("qp: test qp loading and solving")
 
     qp::dense::QP<Scalar> qp{ n, n_eq, 0 }; // creating QP object
     qp.settings.eps_abs = eps_abs;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
     std::cout << "-- iter           : " << qp.results.info.iter << std::endl;
-    std::cout << "-- primal residual: "
-              << (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>()
-              << std::endl;
+    std::cout
+      << "-- primal residual: "
+      << (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>()
+      << std::endl;
     std::cout << "-- dual residual  : "
-              << (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y)
+              << (qp_random.H * qp.results.x + qp_random.g +
+                  qp_random.A.transpose() * qp.results.y)
                    .lpNorm<Eigen::Infinity>()
               << std::endl;
 
-    DOCTEST_CHECK((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>() <=
-                  eps_abs);
-    DOCTEST_CHECK((qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y)
+    DOCTEST_CHECK(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>() <=
+      eps_abs);
+    DOCTEST_CHECK((qp_random.H * qp.results.x + qp_random.g +
+                   qp_random.A.transpose() * qp.results.y)
                     .lpNorm<Eigen::Infinity>() <= eps_abs);
   }
 }

--- a/test/src/qp_eq_py.cpp
+++ b/test/src/qp_eq_py.cpp
@@ -42,32 +42,32 @@ DOCTEST_TEST_CASE("qp: test qp loading and solving")
     isize n_in = 0;
     Scalar sparsity_factor = 0.15;
     Scalar strong_convexity_factor = 0.01;
-    proxqp::dense::Model<T> qp = proxqp::utils::dense_strongly_convex_qp(
+    proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
       dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
-    qp.H = cnpy::npy_load_mat<Scalar>(path + "/H.npy");
-    qp.g = cnpy::npy_load_vec<Scalar>(path + "/g.npy");
-    qp.A = cnpy::npy_load_mat<Scalar>(path + "/A.npy");
-    qp.b = cnpy::npy_load_vec<Scalar>(path + "/b.npy");
+    qp_random.H = cnpy::npy_load_mat<Scalar>(path + "/H.npy");
+    qp_random.g = cnpy::npy_load_vec<Scalar>(path + "/g.npy");
+    qp_random.A = cnpy::npy_load_mat<Scalar>(path + "/A.npy");
+    qp_random.b = cnpy::npy_load_vec<Scalar>(path + "/b.npy");
     std::cout << "-- problem_path   : " << path << std::endl;
     std::cout << "-- n   : " << n << std::endl;
     std::cout << "-- n_eq   : " << n_eq << std::endl;
 
-    qp::dense::QP<Scalar> Qp{ n, n_eq, 0 }; // creating QP object
-    Qp.settings.eps_abs = eps_abs;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
-    std::cout << "-- iter           : " << Qp.results.info.iter << std::endl;
+    qp::dense::QP<Scalar> qp{ n, n_eq, 0 }; // creating QP object
+    qp.settings.eps_abs = eps_abs;
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
+    std::cout << "-- iter           : " << qp.results.info.iter << std::endl;
     std::cout << "-- primal residual: "
-              << (qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>()
+              << (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>()
               << std::endl;
     std::cout << "-- dual residual  : "
-              << (qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y)
+              << (qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y)
                    .lpNorm<Eigen::Infinity>()
               << std::endl;
 
-    DOCTEST_CHECK((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>() <=
+    DOCTEST_CHECK((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>() <=
                   eps_abs);
-    DOCTEST_CHECK((qp.H * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y)
+    DOCTEST_CHECK((qp_random.H * qp.results.x + qp_random.g + qp_random.A.transpose() * qp.results.y)
                     .lpNorm<Eigen::Infinity>() <= eps_abs);
   }
 }

--- a/test/src/sparse_maros_meszaros.cpp
+++ b/test/src/sparse_maros_meszaros.cpp
@@ -112,72 +112,72 @@ TEST_CASE("sparse maros meszaros using the API")
       auto& l = preprocessed.l;
 
       isize n_in = CT.cols();
-      proxsuite::proxqp::sparse::QP<T, I> Qp(H.cast<bool>(),
+      proxsuite::proxqp::sparse::QP<T, I> qp(H.cast<bool>(),
                                              AT.transpose().cast<bool>(),
                                              CT.transpose().cast<bool>());
-      Qp.settings.max_iter = 1.E6;
-      Qp.settings.verbose = true;
+      qp.settings.max_iter = 1.E6;
+      qp.settings.verbose = true;
 
-      Qp.settings.eps_abs = 2e-8;
-      Qp.settings.eps_rel = 0;
-      auto& eps = Qp.settings.eps_abs;
-      Qp.init(H, g, AT.transpose(), b, CT.transpose(), u, l);
+      qp.settings.eps_abs = 2e-8;
+      qp.settings.eps_rel = 0;
+      auto& eps = qp.settings.eps_abs;
+      qp.init(H, g, AT.transpose(), b, CT.transpose(), u, l);
       T prim_eq(0);
       T prim_in(0);
 
       for (isize iter = 0; iter < 10; ++iter) {
-        Qp.solve();
+        qp.solve();
 
         CHECK(proxsuite::proxqp::dense::infty_norm(
-                H.selfadjointView<Eigen::Upper>() * Qp.results.x + g +
-                AT * Qp.results.y + CT * Qp.results.z) <= eps);
+                H.selfadjointView<Eigen::Upper>() * qp.results.x + g +
+                AT * qp.results.y + CT * qp.results.z) <= eps);
         CHECK(proxsuite::proxqp::dense::infty_norm(
-                AT.transpose() * Qp.results.x - b) <= eps);
+                AT.transpose() * qp.results.x - b) <= eps);
         if (n_in > 0) {
-          CHECK((CT.transpose() * Qp.results.x - l).minCoeff() > -eps);
-          CHECK((CT.transpose() * Qp.results.x - u).maxCoeff() < eps);
+          CHECK((CT.transpose() * qp.results.x - l).minCoeff() > -eps);
+          CHECK((CT.transpose() * qp.results.x - u).maxCoeff() < eps);
         }
         std::cout << "dual residual "
                   << proxsuite::proxqp::dense::infty_norm(
-                       H.selfadjointView<Eigen::Upper>() * Qp.results.x + g +
-                       AT * Qp.results.y + CT * Qp.results.z)
+                       H.selfadjointView<Eigen::Upper>() * qp.results.x + g +
+                       AT * qp.results.y + CT * qp.results.z)
                   << std::endl;
         T prim_eq = proxsuite::proxqp::dense::infty_norm(
-          AT.transpose() * Qp.results.x - b);
+          AT.transpose() * qp.results.x - b);
         T prim_in = std::max(
-          proxsuite::proxqp::dense::infty_norm(AT.transpose() * Qp.results.x -
+          proxsuite::proxqp::dense::infty_norm(AT.transpose() * qp.results.x -
                                                b),
           proxsuite::proxqp::dense::infty_norm(
-            sparse::detail::positive_part(CT.transpose() * Qp.results.x - u) +
-            sparse::detail::negative_part(CT.transpose() * Qp.results.x - l)));
+            sparse::detail::positive_part(CT.transpose() * qp.results.x - u) +
+            sparse::detail::negative_part(CT.transpose() * qp.results.x - l)));
         std::cout << "primal residual " << std::max(prim_eq, prim_in)
                   << std::endl;
       }
 
-      Qp.solve();
+      qp.solve();
 
       CHECK(proxsuite::proxqp::dense::infty_norm(
-              H.selfadjointView<Eigen::Upper>() * Qp.results.x + g +
-              AT * Qp.results.y + CT * Qp.results.z) <= eps);
-      CHECK(proxsuite::proxqp::dense::infty_norm(AT.transpose() * Qp.results.x -
+              H.selfadjointView<Eigen::Upper>() * qp.results.x + g +
+              AT * qp.results.y + CT * qp.results.z) <= eps);
+      CHECK(proxsuite::proxqp::dense::infty_norm(AT.transpose() * qp.results.x -
                                                  b) <= eps);
       if (n_in > 0) {
-        CHECK((CT.transpose() * Qp.results.x - l).minCoeff() > -eps);
-        CHECK((CT.transpose() * Qp.results.x - u).maxCoeff() < eps);
+        CHECK((CT.transpose() * qp.results.x - l).minCoeff() > -eps);
+        CHECK((CT.transpose() * qp.results.x - u).maxCoeff() < eps);
       }
       std::cout << "dual residual "
                 << proxsuite::proxqp::dense::infty_norm(
-                     H.selfadjointView<Eigen::Upper>() * Qp.results.x + g +
-                     AT * Qp.results.y + CT * Qp.results.z)
+                     H.selfadjointView<Eigen::Upper>() * qp.results.x + g +
+                     AT * qp.results.y + CT * qp.results.z)
                 << std::endl;
 
       prim_eq =
-        proxsuite::proxqp::dense::infty_norm(AT.transpose() * Qp.results.x - b);
+        proxsuite::proxqp::dense::infty_norm(AT.transpose() * qp.results.x - b);
       prim_in = std::max(
-        proxsuite::proxqp::dense::infty_norm(AT.transpose() * Qp.results.x - b),
+        proxsuite::proxqp::dense::infty_norm(AT.transpose() * qp.results.x - b),
         proxsuite::proxqp::dense::infty_norm(
-          sparse::detail::positive_part(CT.transpose() * Qp.results.x - u) +
-          sparse::detail::negative_part(CT.transpose() * Qp.results.x - l)));
+          sparse::detail::positive_part(CT.transpose() * qp.results.x - u) +
+          sparse::detail::negative_part(CT.transpose() * qp.results.x - l)));
       std::cout << "primal residual " << std::max(prim_eq, prim_in)
                 << std::endl;
     }

--- a/test/src/sparse_qp.cpp
+++ b/test/src/sparse_qp.cpp
@@ -35,7 +35,7 @@ proxqp::utils::rand::vector_rand<T>(n_in); auto u = (l.array() +
 1).matrix().eval();
 
                 {
-                        sparse::QpView<T, I> qp = {
+                        sparse::qpView<T, I> qp = {
                                         {linalg::sparse::from_eigen,
 H}, {linalg::sparse::from_eigen, g},
                                         {linalg::sparse::from_eigen,
@@ -102,17 +102,17 @@ proxqp::utils::rand::vector_rand<T>(n_in); auto u = (l.array() +
 
                 {
 
-                        proxqp::sparse::QP<T,I> Qp(n, n_eq, n_in);
-                        Qp.settings.eps_abs = 1.E-9;
-                        Qp.setup_sparse_matrices(H,g,A,b,C,u,l);
-                        Qp.solve();
+                        proxqp::sparse::QP<T,I> qp(n, n_eq, n_in);
+                        qp.settings.eps_abs = 1.E-9;
+                        qp.setup_sparse_matrices(H,g,A,b,C,u,l);
+                        qp.solve();
                         CHECK(
                                         proxqp::dense::infty_norm(
                                                         H.selfadjointView<Eigen::Upper>()
-* Qp.results.x + g + A.transpose() * Qp.results.y + C.transpose() *
-Qp.results.z) <= 1e-9); CHECK(proxqp::dense::infty_norm(A * Qp.results.x - b) <=
-1e-9); if (n_in > 0) { CHECK((C * Qp.results.x - l).minCoeff() > -1e-9);
-                                CHECK((C * Qp.results.x - u).maxCoeff() < 1e-9);
+* qp.results.x + g + A.transpose() * qp.results.y + C.transpose() *
+qp.results.z) <= 1e-9); CHECK(proxqp::dense::infty_norm(A * qp.results.x - b) <=
+1e-9); if (n_in > 0) { CHECK((C * qp.results.x - l).minCoeff() > -1e-9);
+                                CHECK((C * qp.results.x - u).maxCoeff() < 1e-9);
                         }
                 }
         }
@@ -141,7 +141,7 @@ proxqp::utils::rand::vector_rand<T>(n_in); auto u = (l.array() +
 1).matrix().eval();
 
                 {
-                        sparse::QpView<T, I> qp = {
+                        sparse::qpView<T, I> qp = {
                                         {linalg::sparse::from_eigen,
 H}, {linalg::sparse::from_eigen, g},
                                         {linalg::sparse::from_eigen,
@@ -205,20 +205,20 @@ TEST_CASE("random id using the API")
     auto u = (l.array() + 1).matrix().eval();
 
     {
-      proxqp::sparse::QP<T, I> Qp(n, n_eq, n_in);
-      Qp.settings.eps_abs = 1.E-9;
-      Qp.settings.verbose = true;
-      Qp.init(H, g, A, b, C, u, l);
-      Qp.solve();
+      proxqp::sparse::QP<T, I> qp(n, n_eq, n_in);
+      qp.settings.eps_abs = 1.E-9;
+      qp.settings.verbose = true;
+      qp.init(H, g, A, b, C, u, l);
+      qp.solve();
 
       CHECK(proxqp::dense::infty_norm(
-              H.selfadjointView<Eigen::Upper>() * Qp.results.x + g +
-              A.transpose() * Qp.results.y + C.transpose() * Qp.results.z) <=
+              H.selfadjointView<Eigen::Upper>() * qp.results.x + g +
+              A.transpose() * qp.results.y + C.transpose() * qp.results.z) <=
             1e-9);
-      CHECK(proxqp::dense::infty_norm(A * Qp.results.x - b) <= 1e-9);
+      CHECK(proxqp::dense::infty_norm(A * qp.results.x - b) <= 1e-9);
       if (n_in > 0) {
-        CHECK((C * Qp.results.x - l).minCoeff() > -1e-9);
-        CHECK((C * Qp.results.x - u).maxCoeff() < 1e-9);
+        CHECK((C * qp.results.x - l).minCoeff() > -1e-9);
+        CHECK((C * qp.results.x - u).maxCoeff() < 1e-9);
       }
     }
   }

--- a/test/src/sparse_qp_wrapper.cpp
+++ b/test/src/sparse_qp_wrapper.cpp
@@ -52,12 +52,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -112,12 +114,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -155,17 +159,26 @@ TEST_CASE(
 
     proxqp::sparse::QP<T, I> qp(n, n_eq, n_in);
     qp.settings.eps_abs = 1.E-9;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, false);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l,
+            false);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -203,17 +216,26 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
     proxqp::sparse::QP<T, I> qp(n, n_eq, n_in);
     qp.settings.eps_abs = 1.E-9;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l,
+            true);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -251,17 +273,25 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -300,16 +330,24 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -325,7 +363,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     std::cout << "H before update " << qp_random.H << std::endl;
     auto H_new = 2. * qp_random.H; // keep same sparsity structure
     std::cout << "H generated " << H_new << std::endl;
-    qp.update(H_new, g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, false);
+    qp.update(H_new,
+              g,
+              qp_random.A,
+              qp_random.b,
+              qp_random.C,
+              qp_random.u,
+              qp_random.l,
+              false);
     proxsuite::linalg::sparse::MatMut<T, I> kkt_unscaled =
       qp.model.kkt_mut_unscaled();
     auto kkt_top_n_rows =
@@ -340,12 +385,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -381,7 +428,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     auto x_wm = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     auto y_wm = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n_eq);
     auto z_wm = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n_in);
@@ -393,12 +446,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -441,17 +496,25 @@ DOCTEST_TEST_CASE(
     qp.settings.eps_abs = eps_abs;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
     std::cout << "------using API solving qp with dim with qp: " << n
@@ -467,7 +530,14 @@ DOCTEST_TEST_CASE(
     qp2.settings.eps_abs = 1.E-9;
     qp2.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+    qp2.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l,
+             true);
 
     auto x = qp.results.x;
     auto y = qp.results.y;
@@ -476,15 +546,15 @@ DOCTEST_TEST_CASE(
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
     qp.solve();
-    pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
     std::cout << "------using API solving qp with dim with qp after warm start "
                  "with previous result: "
               << n << " neq: " << n_eq << " nin: " << n_in << std::endl;
@@ -494,15 +564,16 @@ DOCTEST_TEST_CASE(
               << std::endl;
     std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
               << qp.results.info.solve_time << std::endl;
-    pri_res =
-      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp2.results.x -
+                                     qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+               qp_random.g + qp_random.A.transpose() * qp2.results.y +
+               qp_random.C.transpose() * qp2.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
     std::cout << "------using API solving qp with dim with qp2: " << n
@@ -543,18 +614,24 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.settings.eps_abs = eps_abs;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
-    T pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    T dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-        .lpNorm<Eigen::Infinity>();
+    T pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    T dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+                 qp_random.g + qp_random.A.transpose() * qp.results.y +
+                 qp_random.C.transpose() * qp.results.z)
+                  .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
     std::cout << "------using API solving qp with dim with qp: " << n
@@ -570,7 +647,13 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp2.settings.eps_abs = 1.E-9;
     qp2.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp2.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
 
     auto x = qp.results.x;
     auto y = qp.results.y;
@@ -587,15 +670,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
     qp.solve();
-    pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
     std::cout << "------using API solving qp with dim with qp after warm start "
                  "with cold start option: "
               << n << " neq: " << n_eq << " nin: " << n_in << std::endl;
@@ -605,15 +688,16 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
               << qp.results.info.solve_time << std::endl;
-    pri_res =
-      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp2.results.x -
+                                     qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+               qp_random.g + qp_random.A.transpose() * qp2.results.y +
+               qp_random.C.transpose() * qp2.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
     std::cout << "------using API solving qp with dim with cold start option: "
@@ -654,18 +738,25 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.settings.eps_abs = eps_abs;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l,
+            true);
     qp.solve();
 
-    T pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    T dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-        .lpNorm<Eigen::Infinity>();
+    T pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    T dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+                 qp_random.g + qp_random.A.transpose() * qp.results.y +
+                 qp_random.C.transpose() * qp.results.z)
+                  .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
     std::cout << "------using API solving qp with dim with qp: " << n
@@ -679,17 +770,25 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
 
     proxqp::sparse::QP<T, I> qp2(n, n_eq, n_in); // creating QP object
     qp2.settings.eps_abs = 1.E-9;
-    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, false);
+    qp2.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l,
+             false);
     qp2.solve();
-    pri_res =
-      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp2.results.x -
+                                     qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+               qp_random.g + qp_random.A.transpose() * qp2.results.y +
+               qp_random.C.transpose() * qp2.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
     std::cout << "------using API solving qp with dim with qp2: " << n
@@ -730,17 +829,24 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.settings.eps_abs = eps_abs;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l,
+            true);
     qp.solve();
-    T pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    T dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-        .lpNorm<Eigen::Infinity>();
+    T pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    T dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+                 qp_random.g + qp_random.A.transpose() * qp.results.y +
+                 qp_random.C.transpose() * qp.results.z)
+                  .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
     std::cout << "------using API solving qp with dim with qp: " << n
@@ -753,15 +859,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
               << qp.results.info.solve_time << std::endl;
     qp.solve();
 
-    pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
     std::cout << "------using API solving qp with dim with qp: " << n
@@ -775,18 +881,26 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
 
     proxqp::sparse::QP<T, I> qp2(n, n_eq, n_in); // creating QP object
     qp2.settings.eps_abs = 1.E-9;
-    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, false);
+    qp2.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l,
+             false);
 
     qp2.solve();
-    pri_res =
-      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp2.results.x -
+                                     qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+               qp_random.g + qp_random.A.transpose() * qp2.results.y +
+               qp_random.C.transpose() * qp2.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
     std::cout << "------using API solving qp with dim with qp2: " << n
@@ -807,15 +921,16 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                std::nullopt,
                false);
     qp2.solve();
-    pri_res =
-      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp2.results.x -
+                                     qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+               qp_random.g + qp_random.A.transpose() * qp2.results.y +
+               qp_random.C.transpose() * qp2.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
     std::cout << "------using API solving qp with dim with qp2: " << n
@@ -851,7 +966,13 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     auto x_wm = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     auto y_wm = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n_eq);
     auto z_wm = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n_in);
@@ -863,12 +984,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -900,21 +1023,30 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = 1.E-9;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -929,17 +1061,25 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     proxqp::sparse::QP<T, I> qp2(n, n_eq, n_in);
     qp2.settings.eps_abs = 1.E-9;
 
-    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp2.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
     qp2.solve();
 
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+      qp_random.g + qp_random.A.transpose() * qp2.results.y +
+      qp_random.C.transpose() * qp2.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp2.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp2.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -974,8 +1114,9 @@ TEST_CASE(
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
@@ -984,17 +1125,25 @@ TEST_CASE(
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -1010,12 +1159,14 @@ TEST_CASE(
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1032,12 +1183,14 @@ TEST_CASE(
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1054,12 +1207,14 @@ TEST_CASE(
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -1094,8 +1249,9 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
@@ -1104,17 +1260,25 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -1130,12 +1294,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1152,12 +1318,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1174,12 +1342,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -1214,8 +1384,9 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
@@ -1226,17 +1397,25 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -1254,12 +1433,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1276,12 +1457,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1298,12 +1481,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -1338,8 +1523,9 @@ TEST_CASE(
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
@@ -1350,17 +1536,25 @@ TEST_CASE(
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -1378,12 +1572,14 @@ TEST_CASE(
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1400,12 +1596,14 @@ TEST_CASE(
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1422,12 +1620,14 @@ TEST_CASE(
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -1462,8 +1662,9 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
@@ -1474,17 +1675,25 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -1502,12 +1711,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1524,12 +1735,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1546,12 +1759,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -1585,8 +1800,9 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
@@ -1596,17 +1812,25 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -1624,12 +1848,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve(qp.results.x, qp.results.y, qp.results.z);
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1646,12 +1872,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve(qp.results.x, qp.results.y, qp.results.z);
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1668,12 +1896,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve(qp.results.x, qp.results.y, qp.results.z);
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -1707,8 +1937,9 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
@@ -1718,17 +1949,25 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -1740,9 +1979,16 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
               << qp.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> qp2(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
-    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    proxqp::sparse::QP<T, I> qp2(qp_random.H.cast<bool>(),
+                                 qp_random.A.cast<bool>(),
+                                 qp_random.C.cast<bool>());
+    qp2.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
     qp2.settings.eps_abs = 1.E-9;
     qp2.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
@@ -1750,13 +1996,15 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     qp2.solve(qp.results.x, qp.results.y, qp.results.z);
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+      qp_random.g + qp_random.A.transpose() * qp2.results.y +
+      qp_random.C.transpose() * qp2.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp2.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp2.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve with new QP object" << std::endl;
@@ -1793,8 +2041,9 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
@@ -1803,17 +2052,25 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -1829,19 +2086,27 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     auto H_new = 2. * qp_random.H; // keep same sparsity structure
     auto g_new = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     bool update_preconditioner = true;
-    qp.update(
-      H_new, g_new, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+    qp.update(H_new,
+              g_new,
+              qp_random.A,
+              qp_random.b,
+              qp_random.C,
+              qp_random.u,
+              qp_random.l,
+              update_preconditioner);
     std::cout << "dirty workspace after update : " << qp.work.internal.dirty
               << std::endl;
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1858,12 +2123,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1880,12 +2147,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -1920,8 +2189,9 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
@@ -1930,17 +2200,25 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -1956,19 +2234,27 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     auto H_new = 2. * qp_random.H; // keep same sparsity structure
     auto g_new = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     bool update_preconditioner = true;
-    qp.update(
-      H_new, g_new, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+    qp.update(H_new,
+              g_new,
+              qp_random.A,
+              qp_random.b,
+              qp_random.C,
+              qp_random.u,
+              qp_random.l,
+              update_preconditioner);
     std::cout << "dirty workspace after update : " << qp.work.internal.dirty
               << std::endl;
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1985,12 +2271,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -2007,12 +2295,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -2048,8 +2338,9 @@ TEST_CASE(
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
@@ -2060,17 +2351,25 @@ TEST_CASE(
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -2088,19 +2387,27 @@ TEST_CASE(
     auto H_new = 2. * qp_random.H; // keep same sparsity structure
     auto g_new = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     bool update_preconditioner = true;
-    qp.update(
-      H_new, g_new, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+    qp.update(H_new,
+              g_new,
+              qp_random.A,
+              qp_random.b,
+              qp_random.C,
+              qp_random.u,
+              qp_random.l,
+              update_preconditioner);
     std::cout << "dirty workspace after update : " << qp.work.internal.dirty
               << std::endl;
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -2117,12 +2424,14 @@ TEST_CASE(
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -2139,12 +2448,14 @@ TEST_CASE(
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -2179,8 +2490,9 @@ TEST_CASE(
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
@@ -2191,17 +2503,25 @@ TEST_CASE(
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -2219,17 +2539,25 @@ TEST_CASE(
     auto H_new = 2. * qp_random.H; // keep same sparsity structure
     auto g_new = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     bool update_preconditioner = true;
-    qp.update(
-      H_new, g_new, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+    qp.update(H_new,
+              g_new,
+              qp_random.A,
+              qp_random.b,
+              qp_random.C,
+              qp_random.u,
+              qp_random.l,
+              update_preconditioner);
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -2246,12 +2574,14 @@ TEST_CASE(
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -2268,12 +2598,14 @@ TEST_CASE(
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -2308,8 +2640,9 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
@@ -2320,17 +2653,25 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -2359,12 +2700,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -2381,12 +2724,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -2403,12 +2748,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -2443,8 +2790,9 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = 1.E-9;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
@@ -2454,17 +2802,25 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -2484,18 +2840,27 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     auto z_wm = qp.results.z;
     // try with a false update, the warm start should give the exact solution
     bool update_preconditioner = true;
-    qp.update(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+    qp.update(qp_random.H,
+              qp_random.g,
+              qp_random.A,
+              qp_random.b,
+              qp_random.C,
+              qp_random.u,
+              qp_random.l,
+              update_preconditioner);
     std::cout << "dirty workspace after update: " << qp.work.internal.dirty
               << std::endl;
     qp.solve(x_wm, y_wm, z_wm);
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -2515,19 +2880,27 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     auto H_new = 2. * qp_random.H; // keep same sparsity structure
     auto g_new = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     update_preconditioner = true;
-    qp.update(
-      H_new, g_new, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+    qp.update(H_new,
+              g_new,
+              qp_random.A,
+              qp_random.b,
+              qp_random.C,
+              qp_random.u,
+              qp_random.l,
+              update_preconditioner);
     std::cout << "dirty workspace after update: " << qp.work.internal.dirty
               << std::endl;
     qp.solve(x_wm, y_wm, z_wm);
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -2544,12 +2917,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve(qp.results.x, qp.results.y, qp.results.z);
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -2566,12 +2941,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve(qp.results.x, qp.results.y, qp.results.z);
     dua_res = proxqp::dense::infty_norm(
       H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fifth solve " << std::endl;
@@ -2606,8 +2983,9 @@ TEST_CASE("Test initializaton with rho for different initial guess")
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = eps_abs;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
@@ -2617,17 +2995,27 @@ TEST_CASE("Test initializaton with rho for different initial guess")
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l,
+            true,
+            T(1.E-7));
     qp.solve();
     CHECK(qp.results.info.rho == T(1.E-7));
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -2643,17 +3031,27 @@ TEST_CASE("Test initializaton with rho for different initial guess")
     qp2.settings.eps_abs = eps_abs;
     qp2.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+    qp2.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l,
+             true,
+             T(1.E-7));
     qp2.solve();
     CHECK(qp2.results.info.rho == T(1.E-7));
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+      qp_random.g + qp_random.A.transpose() * qp2.results.y +
+      qp_random.C.transpose() * qp2.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp2.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp2.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -2669,17 +3067,27 @@ TEST_CASE("Test initializaton with rho for different initial guess")
     qp3.settings.eps_abs = eps_abs;
     qp3.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    qp3.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+    qp3.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l,
+             true,
+             T(1.E-7));
     qp3.solve();
     CHECK(qp3.results.info.rho == T(1.E-7));
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-      qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+      qp_random.g + qp_random.A.transpose() * qp3.results.y +
+      qp_random.C.transpose() * qp3.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp3.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp3.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -2695,17 +3103,27 @@ TEST_CASE("Test initializaton with rho for different initial guess")
     qp4.settings.eps_abs = eps_abs;
     qp4.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-    qp4.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+    qp4.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l,
+             true,
+             T(1.E-7));
     qp4.solve();
     CHECK(qp4.results.info.rho == T(1.E-7));
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x + qp_random.g +
-      qp_random.A.transpose() * qp4.results.y + qp_random.C.transpose() * qp4.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp4.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x +
+      qp_random.g + qp_random.A.transpose() * qp4.results.y +
+      qp_random.C.transpose() * qp4.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp4.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp4.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -2721,17 +3139,27 @@ TEST_CASE("Test initializaton with rho for different initial guess")
     qp5.settings.eps_abs = eps_abs;
     qp5.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    qp5.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+    qp5.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l,
+             true,
+             T(1.E-7));
     qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
     CHECK(qp5.results.info.rho == T(1.E-7));
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x + qp_random.g +
-      qp_random.A.transpose() * qp5.results.y + qp_random.C.transpose() * qp5.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp5.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x +
+      qp_random.g + qp_random.A.transpose() * qp5.results.y +
+      qp_random.C.transpose() * qp5.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp5.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp5.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -2765,8 +3193,9 @@ TEST_CASE("Test g update for different initial guess")
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     qp.settings.eps_abs = eps_abs;
     qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
@@ -2775,16 +3204,24 @@ TEST_CASE("Test g update for different initial guess")
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     auto g = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
@@ -2798,12 +3235,14 @@ TEST_CASE("Test g update for different initial guess")
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK((qp.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
@@ -2820,16 +3259,24 @@ TEST_CASE("Test g update for different initial guess")
     qp2.settings.eps_abs = eps_abs;
     qp2.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp2.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
     qp2.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+      qp_random.g + qp_random.A.transpose() * qp2.results.y +
+      qp_random.C.transpose() * qp2.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp2.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp2.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     qp2.update(std::nullopt,
@@ -2842,12 +3289,14 @@ TEST_CASE("Test g update for different initial guess")
     qp2.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + g +
-      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp2.results.y +
+      qp_random.C.transpose() * qp2.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp2.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp2.results.x - qp_random.l)));
     CHECK((qp2.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
@@ -2864,16 +3313,24 @@ TEST_CASE("Test g update for different initial guess")
     qp3.settings.eps_abs = eps_abs;
     qp3.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    qp3.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp3.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
     qp3.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-      qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+      qp_random.g + qp_random.A.transpose() * qp3.results.y +
+      qp_random.C.transpose() * qp3.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp3.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp3.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     qp3.update(std::nullopt,
@@ -2886,12 +3343,14 @@ TEST_CASE("Test g update for different initial guess")
     qp3.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + g +
-      qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp3.results.y +
+      qp_random.C.transpose() * qp3.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp3.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp3.results.x - qp_random.l)));
     CHECK((qp3.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
@@ -2908,16 +3367,24 @@ TEST_CASE("Test g update for different initial guess")
     qp4.settings.eps_abs = eps_abs;
     qp4.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-    qp4.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp4.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
     qp4.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x + qp_random.g +
-      qp_random.A.transpose() * qp4.results.y + qp_random.C.transpose() * qp4.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp4.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x +
+      qp_random.g + qp_random.A.transpose() * qp4.results.y +
+      qp_random.C.transpose() * qp4.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp4.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp4.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     qp4.update(std::nullopt,
@@ -2930,12 +3397,14 @@ TEST_CASE("Test g update for different initial guess")
     qp4.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x + g +
-      qp_random.A.transpose() * qp4.results.y + qp_random.C.transpose() * qp4.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp4.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp4.results.y +
+      qp_random.C.transpose() * qp4.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp4.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp4.results.x - qp_random.l)));
     CHECK((qp4.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
@@ -2952,16 +3421,24 @@ TEST_CASE("Test g update for different initial guess")
     qp5.settings.eps_abs = eps_abs;
     qp5.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    qp5.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp5.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
     qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x + qp_random.g +
-      qp_random.A.transpose() * qp5.results.y + qp_random.C.transpose() * qp5.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp5.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x +
+      qp_random.g + qp_random.A.transpose() * qp5.results.y +
+      qp_random.C.transpose() * qp5.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp5.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp5.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     qp5.update(std::nullopt,
@@ -2974,12 +3451,14 @@ TEST_CASE("Test g update for different initial guess")
     qp5.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x + g +
-      qp_random.A.transpose() * qp5.results.y + qp_random.C.transpose() * qp5.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp5.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp5.results.y +
+      qp_random.C.transpose() * qp5.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp5.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp5.results.x - qp_random.l)));
     CHECK((qp5.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
@@ -3014,8 +3493,9 @@ TEST_CASE("Test A update for different initial guess")
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     // proxqp::sparse::QP<T,I> qp(n,n_eq,n_in);
     qp.settings.eps_abs = eps_abs;
     qp.settings.initial_guess =
@@ -3025,16 +3505,24 @@ TEST_CASE("Test A update for different initial guess")
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     SparseMat<T> A = 2 * qp_random.A; // keep same sparsity structure
@@ -3050,11 +3538,12 @@ TEST_CASE("Test A update for different initial guess")
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
       A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+    pri_res = std::max(
+      proxqp::dense::infty_norm(A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -3084,16 +3573,24 @@ TEST_CASE("Test A update for different initial guess")
     qp2.settings.eps_abs = eps_abs;
     qp2.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp2.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
     qp2.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+      qp_random.g + qp_random.A.transpose() * qp2.results.y +
+      qp_random.C.transpose() * qp2.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp2.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp2.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     qp2.update(std::nullopt,
@@ -3105,13 +3602,15 @@ TEST_CASE("Test A update for different initial guess")
                std::nullopt);
     qp2.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-      A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(A * qp2.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+      qp_random.g + A.transpose() * qp2.results.y +
+      qp_random.C.transpose() * qp2.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(A * qp2.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp2.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp2.results.x - qp_random.l)));
     // get stored A from KKT matrix
     kkt_unscaled = qp2.model.kkt_mut_unscaled();
     kkt_top_n_rows = proxsuite::proxqp::sparse::detail::top_rows_mut_unchecked(
@@ -3139,16 +3638,24 @@ TEST_CASE("Test A update for different initial guess")
     qp3.settings.eps_abs = eps_abs;
     qp3.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    qp3.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp3.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
     qp3.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-      qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+      qp_random.g + qp_random.A.transpose() * qp3.results.y +
+      qp_random.C.transpose() * qp3.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp3.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp3.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     qp3.update(std::nullopt,
@@ -3160,13 +3667,15 @@ TEST_CASE("Test A update for different initial guess")
                std::nullopt);
     qp3.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-      A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(A * qp3.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+      qp_random.g + A.transpose() * qp3.results.y +
+      qp_random.C.transpose() * qp3.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(A * qp3.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp3.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp3.results.x - qp_random.l)));
     // get stored A from KKT matrix
     kkt_unscaled = qp3.model.kkt_mut_unscaled();
     kkt_top_n_rows = proxsuite::proxqp::sparse::detail::top_rows_mut_unchecked(
@@ -3194,16 +3703,24 @@ TEST_CASE("Test A update for different initial guess")
     qp4.settings.eps_abs = eps_abs;
     qp4.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-    qp4.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp4.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
     qp4.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x + qp_random.g +
-      qp_random.A.transpose() * qp4.results.y + qp_random.C.transpose() * qp4.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp4.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x +
+      qp_random.g + qp_random.A.transpose() * qp4.results.y +
+      qp_random.C.transpose() * qp4.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp4.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp4.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     qp4.update(std::nullopt,
@@ -3215,13 +3732,15 @@ TEST_CASE("Test A update for different initial guess")
                std::nullopt);
     qp4.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x + qp_random.g +
-      A.transpose() * qp4.results.y + qp_random.C.transpose() * qp4.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(A * qp4.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp4.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x +
+      qp_random.g + A.transpose() * qp4.results.y +
+      qp_random.C.transpose() * qp4.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(A * qp4.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp4.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp4.results.x - qp_random.l)));
     // get stored A from KKT matrix
     kkt_unscaled = qp4.model.kkt_mut_unscaled();
     kkt_top_n_rows = proxsuite::proxqp::sparse::detail::top_rows_mut_unchecked(
@@ -3249,16 +3768,24 @@ TEST_CASE("Test A update for different initial guess")
     qp5.settings.eps_abs = eps_abs;
     qp5.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    qp5.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp5.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
     qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x + qp_random.g +
-      qp_random.A.transpose() * qp5.results.y + qp_random.C.transpose() * qp5.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp5.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x +
+      qp_random.g + qp_random.A.transpose() * qp5.results.y +
+      qp_random.C.transpose() * qp5.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp5.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp5.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     qp5.update(std::nullopt,
@@ -3270,13 +3797,15 @@ TEST_CASE("Test A update for different initial guess")
                std::nullopt);
     qp5.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x + qp_random.g +
-      A.transpose() * qp5.results.y + qp_random.C.transpose() * qp5.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(A * qp5.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp5.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x +
+      qp_random.g + A.transpose() * qp5.results.y +
+      qp_random.C.transpose() * qp5.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(A * qp5.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp5.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp5.results.x - qp_random.l)));
     // get stored A from KKT matrix
     kkt_unscaled = qp5.model.kkt_mut_unscaled();
     kkt_top_n_rows = proxsuite::proxqp::sparse::detail::top_rows_mut_unchecked(
@@ -3322,8 +3851,9 @@ TEST_CASE("Test rho update for different initial guess")
     proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> qp(
-      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                                qp_random.A.cast<bool>(),
+                                qp_random.C.cast<bool>());
     // proxqp::sparse::QP<T,I> qp(n,n_eq,n_in);
     qp.settings.eps_abs = eps_abs;
     qp.settings.initial_guess =
@@ -3333,16 +3863,24 @@ TEST_CASE("Test rho update for different initial guess")
     std::cout << "dirty workspace before any solving: "
               << qp.work.internal.dirty << std::endl;
 
-    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l);
     qp.solve();
     T dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    T pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    T pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     qp.update(std::nullopt,
@@ -3358,12 +3896,14 @@ TEST_CASE("Test rho update for different initial guess")
     qp.solve();
     dua_res = proxqp::dense::infty_norm(
       qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+      qp_random.A.transpose() * qp.results.y +
+      qp_random.C.transpose() * qp.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
@@ -3380,16 +3920,24 @@ TEST_CASE("Test rho update for different initial guess")
     qp2.settings.eps_abs = eps_abs;
     qp2.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp2.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
     qp2.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+      qp_random.g + qp_random.A.transpose() * qp2.results.y +
+      qp_random.C.transpose() * qp2.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp2.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp2.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     qp2.update(std::nullopt,
@@ -3403,13 +3951,15 @@ TEST_CASE("Test rho update for different initial guess")
                T(1.E-7));
     qp2.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+      qp_random.g + qp_random.A.transpose() * qp2.results.y +
+      qp_random.C.transpose() * qp2.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp2.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp2.results.x - qp_random.l)));
     CHECK(qp2.results.info.rho == T(1.E-7));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
@@ -3426,16 +3976,24 @@ TEST_CASE("Test rho update for different initial guess")
     qp3.settings.eps_abs = eps_abs;
     qp3.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    qp3.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp3.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
     qp3.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-      qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+      qp_random.g + qp_random.A.transpose() * qp3.results.y +
+      qp_random.C.transpose() * qp3.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp3.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp3.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     qp3.update(std::nullopt,
@@ -3449,13 +4007,15 @@ TEST_CASE("Test rho update for different initial guess")
                T(1.E-7));
     qp3.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-      qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+      qp_random.g + qp_random.A.transpose() * qp3.results.y +
+      qp_random.C.transpose() * qp3.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp3.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp3.results.x - qp_random.l)));
     CHECK(qp3.results.info.rho == T(1.E-7));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
@@ -3472,16 +4032,24 @@ TEST_CASE("Test rho update for different initial guess")
     qp4.settings.eps_abs = eps_abs;
     qp4.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-    qp4.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp4.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
     qp4.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x + qp_random.g +
-      qp_random.A.transpose() * qp4.results.y + qp_random.C.transpose() * qp4.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp4.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x +
+      qp_random.g + qp_random.A.transpose() * qp4.results.y +
+      qp_random.C.transpose() * qp4.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp4.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp4.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     qp4.update(std::nullopt,
@@ -3495,13 +4063,15 @@ TEST_CASE("Test rho update for different initial guess")
                T(1.E-7));
     qp4.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x + qp_random.g +
-      qp_random.A.transpose() * qp4.results.y + qp_random.C.transpose() * qp4.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp4.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x +
+      qp_random.g + qp_random.A.transpose() * qp4.results.y +
+      qp_random.C.transpose() * qp4.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp4.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp4.results.x - qp_random.l)));
     CHECK(qp4.results.info.rho == T(1.E-7));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
@@ -3518,16 +4088,24 @@ TEST_CASE("Test rho update for different initial guess")
     qp5.settings.eps_abs = eps_abs;
     qp5.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    qp5.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp5.init(qp_random.H,
+             qp_random.g,
+             qp_random.A,
+             qp_random.b,
+             qp_random.C,
+             qp_random.u,
+             qp_random.l);
     qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x + qp_random.g +
-      qp_random.A.transpose() * qp5.results.y + qp_random.C.transpose() * qp5.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp5.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x +
+      qp_random.g + qp_random.A.transpose() * qp5.results.y +
+      qp_random.C.transpose() * qp5.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp5.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp5.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     qp5.update(std::nullopt,
@@ -3541,13 +4119,15 @@ TEST_CASE("Test rho update for different initial guess")
                T(1.E-7));
     qp5.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x + qp_random.g +
-      qp_random.A.transpose() * qp5.results.y + qp_random.C.transpose() * qp5.results.z);
-    pri_res =
-      std::max(proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
-               proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
-                 sparse::detail::negative_part(qp_random.C * qp5.results.x - qp_random.l)));
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x +
+      qp_random.g + qp_random.A.transpose() * qp5.results.y +
+      qp_random.C.transpose() * qp5.results.z);
+    pri_res = std::max(
+      proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
+      proxqp::dense::infty_norm(sparse::detail::positive_part(
+                                  qp_random.C * qp5.results.x - qp_random.u) +
+                                sparse::detail::negative_part(
+                                  qp_random.C * qp5.results.x - qp_random.l)));
     CHECK(qp5.results.info.rho == T(1.E-7));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
@@ -3582,8 +4162,9 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> qp(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                              qp_random.A.cast<bool>(),
+                              qp_random.C.cast<bool>());
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
@@ -3594,23 +4175,30 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res =
-    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  T dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-      .lpNorm<Eigen::Infinity>();
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
@@ -3629,19 +4217,21 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
-  pri_res =
-    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-             qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+             qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp2(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp2(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
   DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
@@ -3666,21 +4256,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res =
-    std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-     qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
-      .lpNorm<Eigen::Infinity>();
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+             qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
+              .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp3(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp3(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
   DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
@@ -3708,15 +4299,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res =
-    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-      .lpNorm<Eigen::Infinity>();
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+             qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   qp3.update(std::nullopt,
@@ -3735,15 +4326,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
   qp3.solve();
-  pri_res =
-    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-      .lpNorm<Eigen::Infinity>();
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+             qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 }
@@ -3768,8 +4359,9 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> qp(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                              qp_random.A.cast<bool>(),
+                              qp_random.C.cast<bool>());
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
@@ -3781,23 +4373,30 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res =
-    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  T dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-      .lpNorm<Eigen::Infinity>();
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
@@ -3816,19 +4415,21 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
-  pri_res =
-    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-             qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+             qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp2(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp2(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
   DOCTEST_CHECK(qp2.settings.initial_guess ==
@@ -3854,21 +4455,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res =
-    std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-     qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
-      .lpNorm<Eigen::Infinity>();
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+             qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
+              .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp3(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp3(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
   DOCTEST_CHECK(qp3.settings.initial_guess ==
@@ -3897,15 +4499,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res =
-    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-      .lpNorm<Eigen::Infinity>();
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+             qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   qp3.update(std::nullopt,
@@ -3924,15 +4526,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
   qp3.solve();
-  pri_res =
-    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-      .lpNorm<Eigen::Infinity>();
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+             qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 }
@@ -3957,8 +4559,9 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> qp(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                              qp_random.A.cast<bool>(),
+                              qp_random.C.cast<bool>());
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
@@ -3970,23 +4573,30 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res =
-    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  T dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-      .lpNorm<Eigen::Infinity>();
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
@@ -4005,19 +4615,21 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
-  pri_res =
-    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-             qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+             qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp2(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp2(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
   DOCTEST_CHECK(qp2.settings.initial_guess ==
@@ -4043,21 +4655,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res =
-    std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-     qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
-      .lpNorm<Eigen::Infinity>();
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+             qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
+              .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp3(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp3(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
   DOCTEST_CHECK(qp3.settings.initial_guess ==
@@ -4086,15 +4699,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res =
-    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-      .lpNorm<Eigen::Infinity>();
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+             qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   qp3.update(std::nullopt,
@@ -4113,15 +4726,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
   qp3.solve();
-  pri_res =
-    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-      .lpNorm<Eigen::Infinity>();
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+             qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 }
@@ -4146,8 +4759,9 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> qp(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                              qp_random.A.cast<bool>(),
+                              qp_random.C.cast<bool>());
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
@@ -4159,23 +4773,30 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res =
-    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  T dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-      .lpNorm<Eigen::Infinity>();
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
@@ -4194,19 +4815,21 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
-  pri_res =
-    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-             qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
+  pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+             qp_random.g + qp_random.A.transpose() * qp.results.y +
+             qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp2(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp2(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
   DOCTEST_CHECK(qp2.settings.initial_guess ==
@@ -4232,21 +4855,22 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res =
-    std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-     qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
-      .lpNorm<Eigen::Infinity>();
+  pri_res = std::max(
+    (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+             qp_random.g + qp_random.A.transpose() * qp2.results.y +
+             qp_random.C.transpose() * qp2.results.z)
+              .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp3(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp3(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
   DOCTEST_CHECK(qp3.settings.initial_guess ==
@@ -4275,15 +4899,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res =
-    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-      .lpNorm<Eigen::Infinity>();
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+             qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   qp3.update(std::nullopt,
@@ -4302,15 +4926,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
   DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
   qp3.solve();
-  pri_res =
-    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-      .lpNorm<Eigen::Infinity>();
+  pri_res = std::max(
+    (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+             qp_random.g + qp_random.A.transpose() * qp3.results.y +
+             qp_random.C.transpose() * qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 }
@@ -4336,8 +4960,9 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> qp(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                              qp_random.A.cast<bool>(),
+                              qp_random.C.cast<bool>());
   // proxqp::sparse::QP<T,I> qp(n,n_eq,n_in);
   qp.settings.eps_abs = eps_abs;
 
@@ -4355,23 +4980,30 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
   // qp.settings.verbose = true;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res =
-    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  T dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-      .lpNorm<Eigen::Infinity>();
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
@@ -4379,15 +5011,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
-    pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
@@ -4405,22 +5037,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
-    pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp2(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp2(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
   DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
@@ -4452,22 +5085,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res =
-      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+               qp_random.g + qp_random.A.transpose() * qp2.results.y +
+               qp_random.C.transpose() * qp2.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp3(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp3(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
   DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
@@ -4496,15 +5130,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res =
-      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+               qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
@@ -4531,15 +5165,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res =
-      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+               qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
@@ -4567,8 +5201,9 @@ DOCTEST_TEST_CASE(
   proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> qp(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                              qp_random.A.cast<bool>(),
+                              qp_random.C.cast<bool>());
   // proxqp::sparse::QP<T,I> qp(n,n_eq,n_in);
   qp.settings.eps_abs = eps_abs;
 
@@ -4587,23 +5222,30 @@ DOCTEST_TEST_CASE(
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
   // qp.settings.verbose = true;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res =
-    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  T dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-      .lpNorm<Eigen::Infinity>();
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
@@ -4611,15 +5253,15 @@ DOCTEST_TEST_CASE(
     qp.solve();
     DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
-    pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
@@ -4637,22 +5279,23 @@ DOCTEST_TEST_CASE(
     qp.solve();
     DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
-    pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp2(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp2(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
   DOCTEST_CHECK(qp2.settings.initial_guess ==
@@ -4685,22 +5328,23 @@ DOCTEST_TEST_CASE(
     DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res =
-      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+               qp_random.g + qp_random.A.transpose() * qp2.results.y +
+               qp_random.C.transpose() * qp2.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp3(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp3(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
   DOCTEST_CHECK(qp3.settings.initial_guess ==
@@ -4730,15 +5374,15 @@ DOCTEST_TEST_CASE(
     DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res =
-      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+               qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
@@ -4765,15 +5409,15 @@ DOCTEST_TEST_CASE(
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res =
-      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+               qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
@@ -4800,8 +5444,9 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> qp(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                              qp_random.A.cast<bool>(),
+                              qp_random.C.cast<bool>());
   // proxqp::sparse::QP<T,I> qp(n,n_eq,n_in);
   qp.settings.eps_abs = eps_abs;
 
@@ -4820,23 +5465,30 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
   // qp.settings.verbose = true;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res =
-    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  T dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-      .lpNorm<Eigen::Infinity>();
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
@@ -4844,15 +5496,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
-    pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
@@ -4870,22 +5522,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
-    pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp2(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp2(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
   DOCTEST_CHECK(qp2.settings.initial_guess ==
@@ -4918,22 +5571,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res =
-      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+               qp_random.g + qp_random.A.transpose() * qp2.results.y +
+               qp_random.C.transpose() * qp2.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp3(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp3(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
   DOCTEST_CHECK(qp3.settings.initial_guess ==
@@ -4963,15 +5617,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res =
-      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+               qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
@@ -4998,15 +5652,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res =
-      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+               qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
@@ -5033,8 +5687,9 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> qp(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp(qp_random.H.cast<bool>(),
+                              qp_random.A.cast<bool>(),
+                              qp_random.C.cast<bool>());
   // proxqp::sparse::QP<T,I> qp(n,n_eq,n_in);
   qp.settings.eps_abs = eps_abs;
 
@@ -5053,23 +5708,30 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
   // qp.settings.verbose = true;
-  qp.init(
-    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.u,
+          qp_random.l,
+          compute_preconditioner,
+          rho);
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
   qp.solve();
   DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
   DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
-  T pri_res =
-    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-               .lpNorm<Eigen::Infinity>());
-  T dua_res =
-    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-      .lpNorm<Eigen::Infinity>();
+  T pri_res = std::max(
+    (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+    (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+     sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+      .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
@@ -5077,15 +5739,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
-    pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
@@ -5103,22 +5765,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     qp.solve();
     DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
     DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
-    pri_res =
-      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
-       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x +
+               qp_random.g + qp_random.A.transpose() * qp.results.y +
+               qp_random.C.transpose() * qp.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp2(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp2(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
   DOCTEST_CHECK(qp2.settings.initial_guess ==
@@ -5151,22 +5814,23 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res =
-      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
-       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x +
+               qp_random.g + qp_random.A.transpose() * qp2.results.y +
+               qp_random.C.transpose() * qp2.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> qp3(
-    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp3(qp_random.H.cast<bool>(),
+                               qp_random.A.cast<bool>(),
+                               qp_random.C.cast<bool>());
   qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
   DOCTEST_CHECK(qp3.settings.initial_guess ==
@@ -5196,15 +5860,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res =
-      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+               qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
@@ -5231,15 +5895,15 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
     DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
-    pri_res =
-      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
-                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
-                 .lpNorm<Eigen::Infinity>());
-    dua_res =
-      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
-       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
-        .lpNorm<Eigen::Infinity>();
+    pri_res = std::max(
+      (qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x +
+               qp_random.g + qp_random.A.transpose() * qp3.results.y +
+               qp_random.C.transpose() * qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }

--- a/test/src/sparse_qp_wrapper.cpp
+++ b/test/src/sparse_qp_wrapper.cpp
@@ -3561,3 +3561,1421 @@ TEST_CASE("Test rho update for different initial guess")
               << " solve time " << Qp5.results.info.solve_time << std::endl;
   }
 }
+
+
+DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
+                  "inequality constraints: test changing default settings after updates using no initial guess")
+{
+  std::cout << "---testing sparse random strongly convex qp with equality and "
+               "inequality constraints: test changing default settings after updates using no initial guess---"
+            << std::endl;
+  double sparsity_factor = 0.15;
+  T eps_abs = T(1e-9);
+  utils::rand::set_seed(1);
+  dense::isize dim = 10;
+
+  dense::isize n_eq(dim / 4);
+  dense::isize n_in(dim / 4);
+  T strong_convexity_factor(1.e-2);
+  ::proxsuite::proxqp::utils::rand::set_seed(1);
+  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
+
+  proxqp::sparse::QP<T, I> Qp(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+
+  T rho(1.e-7);
+  T mu_eq(1.e-4);
+  bool compute_preconditioner = true;
+
+  Qp.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  Qp.settings.eps_abs = eps_abs;
+  Qp.settings.eps_rel = 0;
+  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.solve();
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+
+  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                        sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+               qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+
+  Qp.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  Qp.solve();
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+
+  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>()  * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+             qp.C.transpose() * Qp.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp2(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  Qp2.settings.eps_abs = eps_abs;
+  Qp2.settings.eps_rel = 0;
+
+  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+
+  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
+             qp.C.transpose() * Qp2.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+
+
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp3(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  Qp3.settings.eps_abs = eps_abs;
+  Qp3.settings.eps_rel = 0;
+  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.solve();
+  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+
+  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+             qp.C.transpose() * Qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+  Qp3.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6,
+            1.e-3);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.solve();
+  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+             qp.C.transpose() * Qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+
+}
+
+
+DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
+                  "inequality constraints: test changing default settings after updates using EQUALITY_CONSTRAINED_INITIAL_GUESS")
+{
+  std::cout << "---testing sparse random strongly convex qp with equality and "
+               "inequality constraints: test changing default settings after updates using EQUALITY_CONSTRAINED_INITIAL_GUESS---"
+            << std::endl;
+  double sparsity_factor = 0.15;
+  T eps_abs = T(1e-9);
+  utils::rand::set_seed(1);
+  dense::isize dim = 10;
+
+  dense::isize n_eq(dim / 4);
+  dense::isize n_in(dim / 4);
+  T strong_convexity_factor(1.e-2);
+  ::proxsuite::proxqp::utils::rand::set_seed(1);
+  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
+
+  proxqp::sparse::QP<T, I> Qp(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+
+  T rho(1.e-7);
+  T mu_eq(1.e-4);
+  bool compute_preconditioner = true;
+
+  Qp.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp.settings.eps_abs = eps_abs;
+  Qp.settings.eps_rel = 0;
+  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.solve();
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+
+  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                        sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+               qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+
+  Qp.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  Qp.solve();
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+
+  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>()  * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+             qp.C.transpose() * Qp.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp2(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp2.settings.eps_abs = eps_abs;
+  Qp2.settings.eps_rel = 0;
+
+  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+
+  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
+             qp.C.transpose() * Qp2.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+
+
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp3(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp3.settings.eps_abs = eps_abs;
+  Qp3.settings.eps_rel = 0;
+  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.solve();
+  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+
+  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+             qp.C.transpose() * Qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+  Qp3.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6,
+            1.e-3);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.solve();
+  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+             qp.C.transpose() * Qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+
+}
+
+
+DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
+                  "inequality constraints: test changing default settings after updates using COLD_START_WITH_PREVIOUS_RESULT")
+{
+  std::cout << "---testing sparse random strongly convex qp with equality and "
+               "inequality constraints: test changing default settings after updates using COLD_START_WITH_PREVIOUS_RESULT---"
+            << std::endl;
+  double sparsity_factor = 0.15;
+  T eps_abs = T(1e-9);
+  utils::rand::set_seed(1);
+  dense::isize dim = 10;
+
+  dense::isize n_eq(dim / 4);
+  dense::isize n_in(dim / 4);
+  T strong_convexity_factor(1.e-2);
+  ::proxsuite::proxqp::utils::rand::set_seed(1);
+  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
+
+  proxqp::sparse::QP<T, I> Qp(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+
+  T rho(1.e-7);
+  T mu_eq(1.e-4);
+  bool compute_preconditioner = true;
+
+  Qp.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp.settings.eps_abs = eps_abs;
+  Qp.settings.eps_rel = 0;
+  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.solve();
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+
+  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                        sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+               qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+
+  Qp.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  Qp.solve();
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+
+  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>()  * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+             qp.C.transpose() * Qp.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp2(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp2.settings.eps_abs = eps_abs;
+  Qp2.settings.eps_rel = 0;
+
+  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+
+  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
+             qp.C.transpose() * Qp2.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+
+
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp3(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp3.settings.eps_abs = eps_abs;
+  Qp3.settings.eps_rel = 0;
+  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.solve();
+  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+
+  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+             qp.C.transpose() * Qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+  Qp3.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6,
+            1.e-3);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.solve();
+  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+             qp.C.transpose() * Qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+
+}
+
+DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
+                  "inequality constraints: test changing default settings after updates using WARM_START_WITH_PREVIOUS_RESULT")
+{
+  std::cout << "---testing sparse random strongly convex qp with equality and "
+               "inequality constraints: test changing default settings after updates using WARM_START_WITH_PREVIOUS_RESULT---"
+            << std::endl;
+  double sparsity_factor = 0.15;
+  T eps_abs = T(1e-9);
+  utils::rand::set_seed(1);
+  dense::isize dim = 10;
+
+  dense::isize n_eq(dim / 4);
+  dense::isize n_in(dim / 4);
+  T strong_convexity_factor(1.e-2);
+  ::proxsuite::proxqp::utils::rand::set_seed(1);
+  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
+
+  proxqp::sparse::QP<T, I> Qp(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+
+  T rho(1.e-7);
+  T mu_eq(1.e-4);
+  bool compute_preconditioner = true;
+
+  Qp.settings.initial_guess = proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  Qp.settings.eps_abs = eps_abs;
+  Qp.settings.eps_rel = 0;
+  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.solve();
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+
+  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                        sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+               qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+
+  Qp.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  Qp.solve();
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+
+  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>()  * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+             qp.C.transpose() * Qp.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp2(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  Qp2.settings.eps_abs = eps_abs;
+  Qp2.settings.eps_rel = 0;
+
+  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+
+  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
+             qp.C.transpose() * Qp2.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+
+
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp3(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  Qp3.settings.eps_abs = eps_abs;
+  Qp3.settings.eps_rel = 0;
+  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.solve();
+  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+
+  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+             qp.C.transpose() * Qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+  Qp3.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6,
+            1.e-3);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.solve();
+  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+             qp.C.transpose() * Qp3.results.z)
+              .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+
+}
+
+
+
+DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
+                  "inequality constraints: test changing default settings after several solves using no initial guess")
+{
+  std::cout << "---testing sparse random strongly convex qp with equality and "
+               "inequality constraints: test changing default settings after several solves using no initial guess---"
+            << std::endl;
+
+  
+  double sparsity_factor = 0.15;
+  T eps_abs = T(1e-9);
+  utils::rand::set_seed(1);
+  dense::isize dim = 10;
+
+  dense::isize n_eq(dim / 4);
+  dense::isize n_in(dim / 4);
+  T strong_convexity_factor(1.e-2);
+  ::proxsuite::proxqp::utils::rand::set_seed(1);
+  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
+
+  proxqp::sparse::QP<T, I> Qp(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  // proxqp::sparse::QP<T,I> Qp(n,n_eq,n_in);
+  Qp.settings.eps_abs = eps_abs;
+
+  std::cout << "Test rho update for different initial guess" << std::endl;
+  std::cout << "dirty workspace before any solving: "
+            << Qp.work.internal.dirty << std::endl;  
+
+  T rho(1.e-7);
+  T mu_eq(1.e-4);
+  bool compute_preconditioner = true;
+
+  Qp.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  Qp.settings.eps_abs = eps_abs;
+  Qp.settings.eps_rel = 0;
+  //Qp.settings.verbose = true;
+  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.solve();
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+
+  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+               qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+  
+  for (isize iter = 0; iter < 10; ++iter) {
+    Qp.solve();
+    DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<1.e-9);
+    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+              qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+ 
+  Qp.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6);
+  for (isize iter = 0; iter < 10; ++iter) {
+    Qp.solve();
+    DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<1.e-9);
+    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+              qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+  
+
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp2(
+  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  Qp2.settings.eps_abs = eps_abs;
+  Qp2.settings.eps_rel = 0;
+  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+
+  for (isize iter = 0; iter < 10; ++iter) {
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    Qp2.solve();
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
+              qp.C.transpose() * Qp2.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+
+  
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp3(
+  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  Qp3.settings.eps_abs = eps_abs;
+  Qp3.settings.eps_rel = 0;
+  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+
+  for (isize iter = 0; iter < 10; ++iter) {
+    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    Qp3.solve();
+    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+              qp.C.transpose() * Qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+  
+  Qp3.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6,
+            1.e-3);
+  for (isize iter = 0; iter < 10; ++iter) {
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    Qp3.solve();
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+              qp.C.transpose() * Qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+  
+}
+
+DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
+                  "inequality constraints: test changing default settings after several solves using equality constrained initial guess")
+{
+  std::cout << "---testing sparse random strongly convex qp with equality and "
+               "inequality constraints: test changing default settings after several solves using equality constrained initial guess---"
+            << std::endl;
+
+  
+  double sparsity_factor = 0.15;
+  T eps_abs = T(1e-9);
+  utils::rand::set_seed(1);
+  dense::isize dim = 10;
+
+  dense::isize n_eq(dim / 4);
+  dense::isize n_in(dim / 4);
+  T strong_convexity_factor(1.e-2);
+  ::proxsuite::proxqp::utils::rand::set_seed(1);
+  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
+
+  proxqp::sparse::QP<T, I> Qp(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  // proxqp::sparse::QP<T,I> Qp(n,n_eq,n_in);
+  Qp.settings.eps_abs = eps_abs;
+
+  std::cout << "Test rho update for different initial guess" << std::endl;
+  std::cout << "dirty workspace before any solving: "
+            << Qp.work.internal.dirty << std::endl;  
+
+  T rho(1.e-7);
+  T mu_eq(1.e-4);
+  bool compute_preconditioner = true;
+
+  Qp.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp.settings.eps_abs = eps_abs;
+  Qp.settings.eps_rel = 0;
+  //Qp.settings.verbose = true;
+  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.solve();
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+
+  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+               qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+  
+  for (isize iter = 0; iter < 10; ++iter) {
+    Qp.solve();
+    DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<1.e-9);
+    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+              qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+ 
+  Qp.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6);
+  for (isize iter = 0; iter < 10; ++iter) {
+    Qp.solve();
+    DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<1.e-9);
+    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+              qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+  
+
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp2(
+  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp2.settings.eps_abs = eps_abs;
+  Qp2.settings.eps_rel = 0;
+  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+
+  for (isize iter = 0; iter < 10; ++iter) {
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    Qp2.solve();
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
+              qp.C.transpose() * Qp2.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+
+  
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp3(
+  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp3.settings.eps_abs = eps_abs;
+  Qp3.settings.eps_rel = 0;
+  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+
+  for (isize iter = 0; iter < 10; ++iter) {
+    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    Qp3.solve();
+    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+              qp.C.transpose() * Qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+  
+  Qp3.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6,
+            1.e-3);
+  for (isize iter = 0; iter < 10; ++iter) {
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    Qp3.solve();
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+              qp.C.transpose() * Qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+  
+}
+
+DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
+                  "inequality constraints: test changing default settings after several solves using cold start with previous result")
+{
+  std::cout << "---testing sparse random strongly convex qp with equality and "
+               "inequality constraints: test changing default settings after several solves using cold start with previous result---"
+            << std::endl;
+
+  
+  double sparsity_factor = 0.15;
+  T eps_abs = T(1e-9);
+  utils::rand::set_seed(1);
+  dense::isize dim = 10;
+
+  dense::isize n_eq(dim / 4);
+  dense::isize n_in(dim / 4);
+  T strong_convexity_factor(1.e-2);
+  ::proxsuite::proxqp::utils::rand::set_seed(1);
+  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
+
+  proxqp::sparse::QP<T, I> Qp(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  // proxqp::sparse::QP<T,I> Qp(n,n_eq,n_in);
+  Qp.settings.eps_abs = eps_abs;
+
+  std::cout << "Test rho update for different initial guess" << std::endl;
+  std::cout << "dirty workspace before any solving: "
+            << Qp.work.internal.dirty << std::endl;  
+
+  T rho(1.e-7);
+  T mu_eq(1.e-4);
+  bool compute_preconditioner = true;
+
+  Qp.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp.settings.eps_abs = eps_abs;
+  Qp.settings.eps_rel = 0;
+  //Qp.settings.verbose = true;
+  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.solve();
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+
+  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+               qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+  
+  for (isize iter = 0; iter < 10; ++iter) {
+    Qp.solve();
+    DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<1.e-9);
+    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+              qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+ 
+  Qp.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6);
+  for (isize iter = 0; iter < 10; ++iter) {
+    Qp.solve();
+    DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<1.e-9);
+    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+              qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+  
+
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp2(
+  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp2.settings.eps_abs = eps_abs;
+  Qp2.settings.eps_rel = 0;
+  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+
+  for (isize iter = 0; iter < 10; ++iter) {
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    Qp2.solve();
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
+              qp.C.transpose() * Qp2.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+
+  
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp3(
+  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp3.settings.eps_abs = eps_abs;
+  Qp3.settings.eps_rel = 0;
+  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+
+  for (isize iter = 0; iter < 10; ++iter) {
+    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    Qp3.solve();
+    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+              qp.C.transpose() * Qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+  
+  Qp3.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6,
+            1.e-3);
+  for (isize iter = 0; iter < 10; ++iter) {
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    Qp3.solve();
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+              qp.C.transpose() * Qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+  
+}
+
+
+DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
+                  "inequality constraints: test changing default settings after several solves using warm start with previous result")
+{
+  std::cout << "---testing sparse random strongly convex qp with equality and "
+               "inequality constraints: test changing default settings after several solves using warm start with previous result---"
+            << std::endl;
+
+  
+  double sparsity_factor = 0.15;
+  T eps_abs = T(1e-9);
+  utils::rand::set_seed(1);
+  dense::isize dim = 10;
+
+  dense::isize n_eq(dim / 4);
+  dense::isize n_in(dim / 4);
+  T strong_convexity_factor(1.e-2);
+  ::proxsuite::proxqp::utils::rand::set_seed(1);
+  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
+
+  proxqp::sparse::QP<T, I> Qp(
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  // proxqp::sparse::QP<T,I> Qp(n,n_eq,n_in);
+  Qp.settings.eps_abs = eps_abs;
+
+  std::cout << "Test rho update for different initial guess" << std::endl;
+  std::cout << "dirty workspace before any solving: "
+            << Qp.work.internal.dirty << std::endl;  
+
+  T rho(1.e-7);
+  T mu_eq(1.e-4);
+  bool compute_preconditioner = true;
+
+  Qp.settings.initial_guess = proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  Qp.settings.eps_abs = eps_abs;
+  Qp.settings.eps_rel = 0;
+  //Qp.settings.verbose = true;
+  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.solve();
+  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+
+  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                         .lpNorm<Eigen::Infinity>());
+  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+               qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+  DOCTEST_CHECK(pri_res <= eps_abs);
+  DOCTEST_CHECK(dua_res <= eps_abs);
+  
+  for (isize iter = 0; iter < 10; ++iter) {
+    Qp.solve();
+    DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<1.e-9);
+    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+              qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+ 
+  Qp.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6);
+  for (isize iter = 0; iter < 10; ++iter) {
+    Qp.solve();
+    DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<1.e-9);
+    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
+              qp.C.transpose() * Qp.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+  
+
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp2(
+  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  Qp2.settings.eps_abs = eps_abs;
+  Qp2.settings.eps_rel = 0;
+  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+
+  for (isize iter = 0; iter < 10; ++iter) {
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    Qp2.solve();
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
+              qp.C.transpose() * Qp2.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+
+  
+  // conter factual check with another QP object starting at the updated model
+  proxqp::sparse::QP<T, I> Qp3(
+  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  Qp3.settings.eps_abs = eps_abs;
+  Qp3.settings.eps_rel = 0;
+  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+
+  for (isize iter = 0; iter < 10; ++iter) {
+    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    Qp3.solve();
+    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+              qp.C.transpose() * Qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+  
+  Qp3.update(std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            compute_preconditioner,
+            1.e-6,
+            1.e-3);
+  for (isize iter = 0; iter < 10; ++iter) {
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    Qp3.solve();
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                       .lpNorm<Eigen::Infinity>());
+    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
+              qp.C.transpose() * Qp3.results.z)
+                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+  }
+  
+}

--- a/test/src/sparse_qp_wrapper.cpp
+++ b/test/src/sparse_qp_wrapper.cpp
@@ -30,44 +30,44 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(n, n_eq, n_in);
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.verbose = false;
-    Qp.init(qp.H,
-            qp.g,
-            qp.A,
-            qp.b,
-            qp.C,
-            qp.u,
-            qp.l,
+    proxqp::sparse::QP<T, I> qp(n, n_eq, n_in);
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.verbose = false;
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l,
             true,
             T(1.e-7),
             std::nullopt,
             std::nullopt);
     std::cout << "after upating" << std::endl;
-    std::cout << "rho :  " << Qp.results.info.rho << std::endl;
-    Qp.solve();
+    std::cout << "rho :  " << qp.results.info.rho << std::endl;
+    qp.solve();
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -89,45 +89,45 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(n, n_eq, n_in);
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.init(qp.H,
-            qp.g,
-            qp.A,
-            qp.b,
-            qp.C,
-            qp.u,
-            qp.l,
+    proxqp::sparse::QP<T, I> qp(n, n_eq, n_in);
+    qp.settings.eps_abs = 1.E-9;
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.u,
+            qp_random.l,
             true,
             std::nullopt,
             T(1.E-2),
             T(1.E-3));
     std::cout << "after upating" << std::endl;
-    std::cout << "mu_eq :  " << Qp.results.info.mu_eq << std::endl;
-    std::cout << "mu_in :  " << Qp.results.info.mu_in << std::endl;
-    Qp.solve();
+    std::cout << "mu_eq :  " << qp.results.info.mu_eq << std::endl;
+    std::cout << "mu_in :  " << qp.results.info.mu_in << std::endl;
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 TEST_CASE(
@@ -150,32 +150,32 @@ TEST_CASE(
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(n, n_eq, n_in);
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, false);
-    Qp.solve();
+    proxqp::sparse::QP<T, I> qp(n, n_eq, n_in);
+    qp.settings.eps_abs = 1.E-9;
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, false);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -198,32 +198,32 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(n, n_eq, n_in);
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true);
-    Qp.solve();
+    proxqp::sparse::QP<T, I> qp(n, n_eq, n_in);
+    qp.settings.eps_abs = 1.E-9;
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 TEST_CASE("sparse random strongly convex qp with equality and "
@@ -244,34 +244,34 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(n, n_eq, n_in);
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(n, n_eq, n_in);
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -293,69 +293,69 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(n, n_eq, n_in);
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(n, n_eq, n_in);
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
     auto g = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
-    std::cout << "H before update " << qp.H << std::endl;
-    auto H_new = 2. * qp.H; // keep same sparsity structure
+    std::cout << "H before update " << qp_random.H << std::endl;
+    auto H_new = 2. * qp_random.H; // keep same sparsity structure
     std::cout << "H generated " << H_new << std::endl;
-    Qp.update(H_new, g, qp.A, qp.b, qp.C, qp.u, qp.l, false);
+    qp.update(H_new, g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, false);
     proxsuite::linalg::sparse::MatMut<T, I> kkt_unscaled =
-      Qp.model.kkt_mut_unscaled();
+      qp.model.kkt_mut_unscaled();
     auto kkt_top_n_rows =
       proxsuite::proxqp::sparse::detail::top_rows_mut_unchecked(
         proxsuite::linalg::veg::unsafe, kkt_unscaled, n);
 
     proxsuite::linalg::sparse::MatMut<T, I> H_unscaled =
       proxsuite::proxqp::sparse::detail::middle_cols_mut(
-        kkt_top_n_rows, 0, n, Qp.model.H_nnz);
+        kkt_top_n_rows, 0, n, qp.model.H_nnz);
     std::cout << " H_unscaled " << H_unscaled.to_eigen() << std::endl;
-    Qp.solve();
+    qp.solve();
 
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -374,14 +374,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(n, n_eq, n_in);
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(n, n_eq, n_in);
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
     auto x_wm = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     auto y_wm = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n_eq);
     auto z_wm = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n_in);
@@ -389,26 +389,26 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     std::cout << "x_wm :  " << x_wm << std::endl;
     std::cout << "y_wm :  " << y_wm << std::endl;
     std::cout << "z_wm :  " << z_wm << std::endl;
-    Qp.solve(x_wm, y_wm, z_wm);
+    qp.solve(x_wm, y_wm, z_wm);
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -433,86 +433,86 @@ DOCTEST_TEST_CASE(
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
     T eps_abs = 1.E-9;
 
-    proxqp::sparse::QP<T, I> Qp(n, n_eq, n_in); // creating QP object
-    Qp.settings.eps_abs = eps_abs;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(n, n_eq, n_in); // creating QP object
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
-    std::cout << "------using API solving qp with dim with Qp: " << n
+    std::cout << "------using API solving qp with dim with qp: " << n
               << " neq: " << n_eq << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp2(n, n_eq, n_in); // creating QP object
-    Qp2.settings.eps_abs = 1.E-9;
-    Qp2.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp2(n, n_eq, n_in); // creating QP object
+    qp2.settings.eps_abs = 1.E-9;
+    qp2.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true);
+    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
 
-    auto x = Qp.results.x;
-    auto y = Qp.results.y;
-    auto z = Qp.results.z;
-    Qp2.solve(x, y, z);
-    Qp.settings.initial_guess =
+    auto x = qp.results.x;
+    auto y = qp.results.y;
+    auto z = qp.results.z;
+    qp2.solve(x, y, z);
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-    Qp.solve();
+    qp.solve();
     pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
         .lpNorm<Eigen::Infinity>();
-    std::cout << "------using API solving qp with dim with Qp after warm start "
+    std::cout << "------using API solving qp with dim with qp after warm start "
                  "with previous result: "
               << n << " neq: " << n_eq << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
     pri_res =
-      std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-       qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
-    std::cout << "------using API solving qp with dim with Qp2: " << n
+    std::cout << "------using API solving qp with dim with qp2: " << n
               << " neq: " << n_eq << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp2.results.info.iter
+    std::cout << "total number of iteration: " << qp2.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp2.results.info.setup_time
-              << " solve time " << Qp2.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp2.results.info.setup_time
+              << " solve time " << qp2.results.info.solve_time << std::endl;
   }
 }
 
@@ -535,84 +535,84 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
     T eps_abs = 1.E-9;
-    proxqp::sparse::QP<T, I> Qp(n, n_eq, n_in); // creating QP object
-    Qp.settings.eps_abs = eps_abs;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(n, n_eq, n_in); // creating QP object
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     T dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
-    std::cout << "------using API solving qp with dim with Qp: " << n
+    std::cout << "------using API solving qp with dim with qp: " << n
               << " neq: " << n_eq << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp2(n, n_eq, n_in); // creating QP object
-    Qp2.settings.eps_abs = 1.E-9;
-    Qp2.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp2(n, n_eq, n_in); // creating QP object
+    qp2.settings.eps_abs = 1.E-9;
+    qp2.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
+    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
 
-    auto x = Qp.results.x;
-    auto y = Qp.results.y;
-    auto z = Qp.results.z;
-    // std::cout << "after scaling x " << x <<  " Qp.results.x " << Qp.results.x
+    auto x = qp.results.x;
+    auto y = qp.results.y;
+    auto z = qp.results.z;
+    // std::cout << "after scaling x " << x <<  " qp.results.x " << qp.results.x
     // << std::endl;
-    Qp2.ruiz.scale_primal_in_place({ proxsuite::proxqp::from_eigen, x });
-    Qp2.ruiz.scale_dual_in_place_eq({ proxsuite::proxqp::from_eigen, y });
-    Qp2.ruiz.scale_dual_in_place_in({ proxsuite::proxqp::from_eigen, z });
-    // std::cout << "after scaling x " << x <<  " Qp.results.x " << Qp.results.x
+    qp2.ruiz.scale_primal_in_place({ proxsuite::proxqp::from_eigen, x });
+    qp2.ruiz.scale_dual_in_place_eq({ proxsuite::proxqp::from_eigen, y });
+    qp2.ruiz.scale_dual_in_place_in({ proxsuite::proxqp::from_eigen, z });
+    // std::cout << "after scaling x " << x <<  " qp.results.x " << qp.results.x
     // << std::endl;
-    Qp2.solve(x, y, z);
+    qp2.solve(x, y, z);
 
-    Qp.settings.initial_guess =
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-    Qp.solve();
+    qp.solve();
     pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
         .lpNorm<Eigen::Infinity>();
-    std::cout << "------using API solving qp with dim with Qp after warm start "
+    std::cout << "------using API solving qp with dim with qp after warm start "
                  "with cold start option: "
               << n << " neq: " << n_eq << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
     pri_res =
-      std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-       qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
@@ -620,10 +620,10 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
               << n << " neq: " << n_eq << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp2.results.info.iter
+    std::cout << "total number of iteration: " << qp2.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp2.results.info.setup_time
-              << " solve time " << Qp2.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp2.results.info.setup_time
+              << " solve time " << qp2.results.info.solve_time << std::endl;
   }
 }
 
@@ -646,60 +646,60 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
     T eps_abs = 1.E-9;
-    proxqp::sparse::QP<T, I> Qp(n, n_eq, n_in); // creating QP object
-    Qp.settings.eps_abs = eps_abs;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(n, n_eq, n_in); // creating QP object
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+    qp.solve();
 
     T pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     T dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
-    std::cout << "------using API solving qp with dim with Qp: " << n
+    std::cout << "------using API solving qp with dim with qp: " << n
               << " neq: " << n_eq << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp2(n, n_eq, n_in); // creating QP object
-    Qp2.settings.eps_abs = 1.E-9;
-    Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, false);
-    Qp2.solve();
+    proxqp::sparse::QP<T, I> qp2(n, n_eq, n_in); // creating QP object
+    qp2.settings.eps_abs = 1.E-9;
+    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, false);
+    qp2.solve();
     pri_res =
-      std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-       qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
-    std::cout << "------using API solving qp with dim with Qp2: " << n
+    std::cout << "------using API solving qp with dim with qp2: " << n
               << " neq: " << n_eq << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp2.results.info.iter
+    std::cout << "total number of iteration: " << qp2.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp2.results.info.setup_time
-              << " solve time " << Qp2.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp2.results.info.setup_time
+              << " solve time " << qp2.results.info.solve_time << std::endl;
   }
 }
 
@@ -722,83 +722,83 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
     T eps_abs = 1.E-9;
-    proxqp::sparse::QP<T, I> Qp(n, n_eq, n_in); // creating QP object
-    Qp.settings.eps_abs = eps_abs;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(n, n_eq, n_in); // creating QP object
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true);
+    qp.solve();
     T pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     T dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
-    std::cout << "------using API solving qp with dim with Qp: " << n
+    std::cout << "------using API solving qp with dim with qp: " << n
               << " neq: " << n_eq << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
-    Qp.solve();
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
+    qp.solve();
 
     pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
-    std::cout << "------using API solving qp with dim with Qp: " << n
+    std::cout << "------using API solving qp with dim with qp: " << n
               << " neq: " << n_eq << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp2(n, n_eq, n_in); // creating QP object
-    Qp2.settings.eps_abs = 1.E-9;
-    Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, false);
+    proxqp::sparse::QP<T, I> qp2(n, n_eq, n_in); // creating QP object
+    qp2.settings.eps_abs = 1.E-9;
+    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, false);
 
-    Qp2.solve();
+    qp2.solve();
     pri_res =
-      std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-       qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
-    std::cout << "------using API solving qp with dim with Qp2: " << n
+    std::cout << "------using API solving qp with dim with qp2: " << n
               << " neq: " << n_eq << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp2.results.info.iter
+    std::cout << "total number of iteration: " << qp2.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp2.results.info.setup_time
-              << " solve time " << Qp2.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp2.results.info.setup_time
+              << " solve time " << qp2.results.info.solve_time << std::endl;
 
-    Qp2.update(std::nullopt,
+    qp2.update(std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt,
@@ -806,26 +806,26 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
                std::nullopt,
                std::nullopt,
                false);
-    Qp2.solve();
+    qp2.solve();
     pri_res =
-      std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-       qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
-    std::cout << "------using API solving qp with dim with Qp2: " << n
+    std::cout << "------using API solving qp with dim with qp2: " << n
               << " neq: " << n_eq << " nin: " << n_in << std::endl;
     std::cout << "primal residual: " << pri_res << std::endl;
     std::cout << "dual residual: " << dua_res << std::endl;
-    std::cout << "total number of iteration: " << Qp2.results.info.iter
+    std::cout << "total number of iteration: " << qp2.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp2.results.info.setup_time
-              << " solve time " << Qp2.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp2.results.info.setup_time
+              << " solve time " << qp2.results.info.solve_time << std::endl;
   }
 }
 
@@ -844,14 +844,14 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(n, n_eq, n_in);
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(n, n_eq, n_in);
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
     auto x_wm = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     auto y_wm = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n_eq);
     auto z_wm = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n_in);
@@ -859,26 +859,26 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     std::cout << "x_wm :  " << x_wm << std::endl;
     std::cout << "y_wm :  " << y_wm << std::endl;
     std::cout << "z_wm :  " << z_wm << std::endl;
-    Qp.solve(x_wm, y_wm, z_wm);
+    qp.solve(x_wm, y_wm, z_wm);
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -897,59 +897,59 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = 1.E-9;
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = 1.E-9;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp2(n, n_eq, n_in);
-    Qp2.settings.eps_abs = 1.E-9;
+    proxqp::sparse::QP<T, I> qp2(n, n_eq, n_in);
+    qp2.settings.eps_abs = 1.E-9;
 
-    Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp2.solve();
+    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp2.solve();
 
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-      qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp2.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp2.results.info.iter
+    std::cout << "total number of iteration: " << qp2.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp2.results.info.setup_time
-              << " solve time " << Qp2.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp2.results.info.setup_time
+              << " solve time " << qp2.results.info.solve_time << std::endl;
   }
 }
 
@@ -971,51 +971,51 @@ TEST_CASE(
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
 
     std::cout << "Test with no initial guess" << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1023,21 +1023,21 @@ TEST_CASE(
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1045,21 +1045,21 @@ TEST_CASE(
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -1067,10 +1067,10 @@ TEST_CASE(
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -1091,51 +1091,51 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
 
     std::cout << "Test with equality constrained initial guess" << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1143,21 +1143,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1165,21 +1165,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -1187,10 +1187,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -1211,55 +1211,55 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
 
     std::cout << "Test with warm start with previous result and first solve "
                  "with equality constrained initial guess"
               << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    Qp.settings.initial_guess =
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1267,21 +1267,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1289,21 +1289,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -1311,10 +1311,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -1335,55 +1335,55 @@ TEST_CASE(
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
 
     std::cout << "Test with warm start with previous result and first solve "
                  "with no initial guess"
               << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    Qp.settings.initial_guess =
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1391,21 +1391,21 @@ TEST_CASE(
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1413,21 +1413,21 @@ TEST_CASE(
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -1435,10 +1435,10 @@ TEST_CASE(
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -1459,55 +1459,55 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
 
     std::cout << "Test with cold start with previous result and first solve "
                  "with equality constrained initial guess"
               << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    Qp.settings.initial_guess =
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1515,21 +1515,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1537,21 +1537,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -1559,10 +1559,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -1582,54 +1582,54 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
 
     std::cout << "Test with warm start and first solve with no initial guess"
               << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    Qp.settings.initial_guess =
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z);
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve(qp.results.x, qp.results.y, qp.results.z);
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1637,21 +1637,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z);
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve(qp.results.x, qp.results.y, qp.results.z);
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1659,21 +1659,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z);
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve(qp.results.x, qp.results.y, qp.results.z);
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -1681,10 +1681,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -1704,59 +1704,59 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
 
     std::cout << "Test with warm start and first solve with no initial guess"
               << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp2(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp2.settings.eps_abs = 1.E-9;
-    Qp2.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp2(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp2.settings.eps_abs = 1.E-9;
+    qp2.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    std::cout << "dirty workspace for Qp2 : " << Qp2.work.internal.dirty
+    std::cout << "dirty workspace for qp2 : " << qp2.work.internal.dirty
               << std::endl;
-    Qp2.solve(Qp.results.x, Qp.results.y, Qp.results.z);
+    qp2.solve(qp.results.x, qp.results.y, qp.results.z);
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-      qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp2.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve with new QP object" << std::endl;
@@ -1764,10 +1764,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp2.results.info.iter
+    std::cout << "total number of iteration: " << qp2.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp2.results.info.setup_time
-              << " solve time " << Qp2.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp2.results.info.setup_time
+              << " solve time " << qp2.results.info.solve_time << std::endl;
   }
 }
 
@@ -1790,58 +1790,58 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
 
     std::cout << "Test with no initial guess" << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    auto H_new = 2. * qp.H; // keep same sparsity structure
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    auto H_new = 2. * qp_random.H; // keep same sparsity structure
     auto g_new = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     bool update_preconditioner = true;
-    Qp.update(
-      H_new, g_new, qp.A, qp.b, qp.C, qp.u, qp.l, update_preconditioner);
-    std::cout << "dirty workspace after update : " << Qp.work.internal.dirty
+    qp.update(
+      H_new, g_new, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+    std::cout << "dirty workspace after update : " << qp.work.internal.dirty
               << std::endl;
-    Qp.solve();
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1849,21 +1849,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1871,21 +1871,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -1893,10 +1893,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -1917,58 +1917,58 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
 
     std::cout << "Test with equality constrained initial guess" << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    auto H_new = 2. * qp.H; // keep same sparsity structure
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    auto H_new = 2. * qp_random.H; // keep same sparsity structure
     auto g_new = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     bool update_preconditioner = true;
-    Qp.update(
-      H_new, g_new, qp.A, qp.b, qp.C, qp.u, qp.l, update_preconditioner);
-    std::cout << "dirty workspace after update : " << Qp.work.internal.dirty
+    qp.update(
+      H_new, g_new, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+    std::cout << "dirty workspace after update : " << qp.work.internal.dirty
               << std::endl;
-    Qp.solve();
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -1976,21 +1976,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -1998,21 +1998,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -2020,10 +2020,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -2045,62 +2045,62 @@ TEST_CASE(
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
 
     std::cout << "Test with warm start with previous result and first solve "
                  "with equality constrained initial guess"
               << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    Qp.settings.initial_guess =
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    auto H_new = 2. * qp.H; // keep same sparsity structure
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    auto H_new = 2. * qp_random.H; // keep same sparsity structure
     auto g_new = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     bool update_preconditioner = true;
-    Qp.update(
-      H_new, g_new, qp.A, qp.b, qp.C, qp.u, qp.l, update_preconditioner);
-    std::cout << "dirty workspace after update : " << Qp.work.internal.dirty
+    qp.update(
+      H_new, g_new, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+    std::cout << "dirty workspace after update : " << qp.work.internal.dirty
               << std::endl;
-    Qp.solve();
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -2108,21 +2108,21 @@ TEST_CASE(
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -2130,21 +2130,21 @@ TEST_CASE(
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -2152,10 +2152,10 @@ TEST_CASE(
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -2176,60 +2176,60 @@ TEST_CASE(
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
 
     std::cout << "Test with warm start with previous result and first solve "
                  "with no initial guess"
               << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    Qp.settings.initial_guess =
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    auto H_new = 2. * qp.H; // keep same sparsity structure
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    auto H_new = 2. * qp_random.H; // keep same sparsity structure
     auto g_new = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     bool update_preconditioner = true;
-    Qp.update(
-      H_new, g_new, qp.A, qp.b, qp.C, qp.u, qp.l, update_preconditioner);
-    Qp.solve();
+    qp.update(
+      H_new, g_new, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -2237,21 +2237,21 @@ TEST_CASE(
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -2259,21 +2259,21 @@ TEST_CASE(
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -2281,10 +2281,10 @@ TEST_CASE(
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -2305,50 +2305,50 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
 
     std::cout << "Test with cold start with previous result and first solve "
                  "with equality constrained initial guess"
               << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    Qp.settings.initial_guess =
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    auto H_new = 2. * qp.H; // keep same sparsity structure
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    auto H_new = 2. * qp_random.H; // keep same sparsity structure
     auto g_new = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     bool update_preconditioner = true;
-    Qp.update(H_new,
+    qp.update(H_new,
               g_new,
               std::nullopt,
               std::nullopt,
@@ -2356,15 +2356,15 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               std::nullopt,
               std::nullopt,
               update_preconditioner);
-    Qp.solve();
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -2372,21 +2372,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -2394,21 +2394,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve();
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -2416,10 +2416,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -2440,62 +2440,62 @@ TEST_CASE("sparse random strongly convex qp with equality and "
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = 1.E-9;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = 1.E-9;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
 
     std::cout << "Test with warm start and first solve with no initial guess"
               << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
 
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    Qp.settings.initial_guess =
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    auto x_wm = Qp.results.x; // keep previous result
-    auto y_wm = Qp.results.y;
-    auto z_wm = Qp.results.z;
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    auto x_wm = qp.results.x; // keep previous result
+    auto y_wm = qp.results.y;
+    auto z_wm = qp.results.z;
     // try with a false update, the warm start should give the exact solution
     bool update_preconditioner = true;
-    Qp.update(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, update_preconditioner);
-    std::cout << "dirty workspace after update: " << Qp.work.internal.dirty
+    qp.update(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+    std::cout << "dirty workspace after update: " << qp.work.internal.dirty
               << std::endl;
-    Qp.solve(x_wm, y_wm, z_wm);
+    qp.solve(x_wm, y_wm, z_wm);
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Second solve " << std::endl;
@@ -2503,31 +2503,31 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    x_wm = Qp.results.x; // keep previous result
-    y_wm = Qp.results.y;
-    z_wm = Qp.results.z;
-    auto H_new = 2. * qp.H; // keep same sparsity structure
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    x_wm = qp.results.x; // keep previous result
+    y_wm = qp.results.y;
+    z_wm = qp.results.z;
+    auto H_new = 2. * qp_random.H; // keep same sparsity structure
     auto g_new = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
     update_preconditioner = true;
-    Qp.update(
-      H_new, g_new, qp.A, qp.b, qp.C, qp.u, qp.l, update_preconditioner);
-    std::cout << "dirty workspace after update: " << Qp.work.internal.dirty
+    qp.update(
+      H_new, g_new, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, update_preconditioner);
+    std::cout << "dirty workspace after update: " << qp.work.internal.dirty
               << std::endl;
-    Qp.solve(x_wm, y_wm, z_wm);
+    qp.solve(x_wm, y_wm, z_wm);
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Third solve " << std::endl;
@@ -2535,21 +2535,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z);
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve(qp.results.x, qp.results.y, qp.results.z);
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fourth solve " << std::endl;
@@ -2557,21 +2557,21 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    std::cout << "dirty workspace : " << Qp.work.internal.dirty << std::endl;
-    Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z);
+    std::cout << "dirty workspace : " << qp.work.internal.dirty << std::endl;
+    qp.solve(qp.results.x, qp.results.y, qp.results.z);
     dua_res = proxqp::dense::infty_norm(
-      H_new.selfadjointView<Eigen::Upper>() * Qp.results.x + g_new +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      H_new.selfadjointView<Eigen::Upper>() * qp.results.x + g_new +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= 1e-9);
     CHECK(pri_res <= 1E-9);
     std::cout << "Fifth solve " << std::endl;
@@ -2579,10 +2579,10 @@ TEST_CASE("sparse random strongly convex qp with equality and "
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
   }
 }
 
@@ -2603,145 +2603,145 @@ TEST_CASE("Test initializaton with rho for different initial guess")
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = eps_abs;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
 
     std::cout << "Test initializaton with rho for different initial guess"
               << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true, T(1.E-7));
-    Qp.solve();
-    CHECK(Qp.results.info.rho == T(1.E-7));
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+    qp.solve();
+    CHECK(qp.results.info.rho == T(1.E-7));
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp2(n, n_eq, n_in);
-    Qp2.settings.eps_abs = eps_abs;
-    Qp2.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp2(n, n_eq, n_in);
+    qp2.settings.eps_abs = eps_abs;
+    qp2.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-    Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true, T(1.E-7));
-    Qp2.solve();
-    CHECK(Qp2.results.info.rho == T(1.E-7));
+    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+    qp2.solve();
+    CHECK(qp2.results.info.rho == T(1.E-7));
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-      qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp2.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp2.results.info.iter
+    std::cout << "total number of iteration: " << qp2.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp2.results.info.setup_time
-              << " solve time " << Qp2.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp2.results.info.setup_time
+              << " solve time " << qp2.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp3(n, n_eq, n_in);
-    Qp3.settings.eps_abs = eps_abs;
-    Qp3.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp3(n, n_eq, n_in);
+    qp3.settings.eps_abs = eps_abs;
+    qp3.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true, T(1.E-7));
-    Qp3.solve();
-    CHECK(Qp3.results.info.rho == T(1.E-7));
+    qp3.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+    qp3.solve();
+    CHECK(qp3.results.info.rho == T(1.E-7));
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-      qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+      qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp3.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp3.results.info.iter
+    std::cout << "total number of iteration: " << qp3.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp3.results.info.setup_time
-              << " solve time " << Qp3.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp3.results.info.setup_time
+              << " solve time " << qp3.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp4(n, n_eq, n_in);
-    Qp4.settings.eps_abs = eps_abs;
-    Qp4.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp4(n, n_eq, n_in);
+    qp4.settings.eps_abs = eps_abs;
+    qp4.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-    Qp4.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true, T(1.E-7));
-    Qp4.solve();
-    CHECK(Qp4.results.info.rho == T(1.E-7));
+    qp4.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+    qp4.solve();
+    CHECK(qp4.results.info.rho == T(1.E-7));
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp4.results.x + qp.g +
-      qp.A.transpose() * Qp4.results.y + qp.C.transpose() * Qp4.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x + qp_random.g +
+      qp_random.A.transpose() * qp4.results.y + qp_random.C.transpose() * qp4.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp4.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp4.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp4.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp4.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp4.results.info.iter
+    std::cout << "total number of iteration: " << qp4.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp4.results.info.setup_time
-              << " solve time " << Qp4.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp4.results.info.setup_time
+              << " solve time " << qp4.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp5(n, n_eq, n_in);
-    Qp5.settings.eps_abs = eps_abs;
-    Qp5.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp5(n, n_eq, n_in);
+    qp5.settings.eps_abs = eps_abs;
+    qp5.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    Qp5.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, true, T(1.E-7));
-    Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z);
-    CHECK(Qp5.results.info.rho == T(1.E-7));
+    qp5.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, true, T(1.E-7));
+    qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
+    CHECK(qp5.results.info.rho == T(1.E-7));
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp5.results.x + qp.g +
-      qp.A.transpose() * Qp5.results.y + qp.C.transpose() * Qp5.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x + qp_random.g +
+      qp_random.A.transpose() * qp5.results.y + qp_random.C.transpose() * qp5.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp5.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp5.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp5.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp5.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp5.results.info.iter
+    std::cout << "total number of iteration: " << qp5.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp5.results.info.setup_time
-              << " solve time " << Qp5.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp5.results.info.setup_time
+              << " solve time " << qp5.results.info.solve_time << std::endl;
   }
 }
 
@@ -2762,235 +2762,235 @@ TEST_CASE("Test g update for different initial guess")
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    Qp.settings.eps_abs = eps_abs;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
 
     std::cout << "Test g update for different initial guess" << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     auto g = ::proxsuite::proxqp::utils::rand::vector_rand<T>(n);
-    Qp.update(std::nullopt,
+    qp.update(std::nullopt,
               g,
               std::nullopt,
               std::nullopt,
               std::nullopt,
               std::nullopt,
               std::nullopt);
-    Qp.solve();
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
-    CHECK((Qp.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
+    CHECK((qp.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp2(n, n_eq, n_in);
-    Qp2.settings.eps_abs = eps_abs;
-    Qp2.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp2(n, n_eq, n_in);
+    qp2.settings.eps_abs = eps_abs;
+    qp2.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-    Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp2.solve();
+    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp2.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-      qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp2.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
-    Qp2.update(std::nullopt,
+    qp2.update(std::nullopt,
                g,
                std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt);
-    Qp2.solve();
+    qp2.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + g +
-      qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + g +
+      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp2.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l)));
-    CHECK((Qp2.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
+                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
+    CHECK((qp2.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp2.results.info.iter
+    std::cout << "total number of iteration: " << qp2.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp2.results.info.setup_time
-              << " solve time " << Qp2.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp2.results.info.setup_time
+              << " solve time " << qp2.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp3(n, n_eq, n_in);
-    Qp3.settings.eps_abs = eps_abs;
-    Qp3.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp3(n, n_eq, n_in);
+    qp3.settings.eps_abs = eps_abs;
+    qp3.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp3.solve();
+    qp3.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp3.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-      qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+      qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp3.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
-    Qp3.update(std::nullopt,
+    qp3.update(std::nullopt,
                g,
                std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt);
-    Qp3.solve();
+    qp3.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + g +
-      qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + g +
+      qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp3.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l)));
-    CHECK((Qp3.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
+                 sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l)));
+    CHECK((qp3.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp3.results.info.iter
+    std::cout << "total number of iteration: " << qp3.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp3.results.info.setup_time
-              << " solve time " << Qp3.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp3.results.info.setup_time
+              << " solve time " << qp3.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp4(n, n_eq, n_in);
-    Qp4.settings.eps_abs = eps_abs;
-    Qp4.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp4(n, n_eq, n_in);
+    qp4.settings.eps_abs = eps_abs;
+    qp4.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-    Qp4.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp4.solve();
+    qp4.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp4.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp4.results.x + qp.g +
-      qp.A.transpose() * Qp4.results.y + qp.C.transpose() * Qp4.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x + qp_random.g +
+      qp_random.A.transpose() * qp4.results.y + qp_random.C.transpose() * qp4.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp4.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp4.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp4.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp4.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
-    Qp4.update(std::nullopt,
+    qp4.update(std::nullopt,
                g,
                std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt);
-    Qp4.solve();
+    qp4.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp4.results.x + g +
-      qp.A.transpose() * Qp4.results.y + qp.C.transpose() * Qp4.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x + g +
+      qp_random.A.transpose() * qp4.results.y + qp_random.C.transpose() * qp4.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp4.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp4.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp4.results.x - qp.l)));
-    CHECK((Qp4.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
+                 sparse::detail::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp4.results.x - qp_random.l)));
+    CHECK((qp4.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp4.results.info.iter
+    std::cout << "total number of iteration: " << qp4.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp4.results.info.setup_time
-              << " solve time " << Qp4.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp4.results.info.setup_time
+              << " solve time " << qp4.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp5(n, n_eq, n_in);
-    Qp5.settings.eps_abs = eps_abs;
-    Qp5.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp5(n, n_eq, n_in);
+    qp5.settings.eps_abs = eps_abs;
+    qp5.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    Qp5.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z);
+    qp5.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp5.results.x + qp.g +
-      qp.A.transpose() * Qp5.results.y + qp.C.transpose() * Qp5.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x + qp_random.g +
+      qp_random.A.transpose() * qp5.results.y + qp_random.C.transpose() * qp5.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp5.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp5.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp5.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp5.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
-    Qp5.update(std::nullopt,
+    qp5.update(std::nullopt,
                g,
                std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt);
-    Qp5.solve();
+    qp5.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp5.results.x + g +
-      qp.A.transpose() * Qp5.results.y + qp.C.transpose() * Qp5.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x + g +
+      qp_random.A.transpose() * qp5.results.y + qp_random.C.transpose() * qp5.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp5.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp5.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp5.results.x - qp.l)));
-    CHECK((Qp5.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
+                 sparse::detail::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp5.results.x - qp_random.l)));
+    CHECK((qp5.model.g - g).lpNorm<Eigen::Infinity>() <= eps_abs);
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp5.results.info.iter
+    std::cout << "total number of iteration: " << qp5.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp5.results.info.setup_time
-              << " solve time " << Qp5.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp5.results.info.setup_time
+              << " solve time " << qp5.results.info.solve_time << std::endl;
   }
 }
 
@@ -3011,68 +3011,68 @@ TEST_CASE("Test A update for different initial guess")
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    // proxqp::sparse::QP<T,I> Qp(n,n_eq,n_in);
-    Qp.settings.eps_abs = eps_abs;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    // proxqp::sparse::QP<T,I> qp(n,n_eq,n_in);
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
 
     std::cout << "Test A update for different initial guess" << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
-    SparseMat<T> A = 2 * qp.A; // keep same sparsity structure
-    Qp.update(std::nullopt,
+    SparseMat<T> A = 2 * qp_random.A; // keep same sparsity structure
+    qp.update(std::nullopt,
               std::nullopt,
               A,
               std::nullopt,
               std::nullopt,
               std::nullopt,
               std::nullopt);
-    Qp.settings.verbose = false;
-    Qp.solve();
+    qp.settings.verbose = false;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
     // get stored A from KKT matrix
-    auto kkt_unscaled = Qp.model.kkt_mut_unscaled();
+    auto kkt_unscaled = qp.model.kkt_mut_unscaled();
     auto kkt_top_n_rows =
       proxsuite::proxqp::sparse::detail::top_rows_mut_unchecked(
         proxsuite::linalg::veg::unsafe, kkt_unscaled, n);
     SparseMat<T> A_unscaled =
       proxsuite::proxqp::sparse::detail::middle_cols_mut(
-        kkt_top_n_rows, n, n_eq, Qp.model.A_nnz)
+        kkt_top_n_rows, n, n_eq, qp.model.A_nnz)
         .to_eigen()
         .transpose();
     SparseMat<T> diff_mat = A_unscaled - A;
@@ -3080,44 +3080,44 @@ TEST_CASE("Test A update for different initial guess")
                       std::abs(diff_mat.coeffs().minCoeff()));
     CHECK(diff <= eps_abs);
 
-    proxqp::sparse::QP<T, I> Qp2(n, n_eq, n_in);
-    Qp2.settings.eps_abs = eps_abs;
-    Qp2.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp2(n, n_eq, n_in);
+    qp2.settings.eps_abs = eps_abs;
+    qp2.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-    Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp2.solve();
+    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp2.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-      qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp2.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
-    Qp2.update(std::nullopt,
+    qp2.update(std::nullopt,
                std::nullopt,
                A,
                std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt);
-    Qp2.solve();
+    qp2.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-      A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+      A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(A * Qp2.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(A * qp2.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
     // get stored A from KKT matrix
-    kkt_unscaled = Qp2.model.kkt_mut_unscaled();
+    kkt_unscaled = qp2.model.kkt_mut_unscaled();
     kkt_top_n_rows = proxsuite::proxqp::sparse::detail::top_rows_mut_unchecked(
       proxsuite::linalg::veg::unsafe, kkt_unscaled, n);
     A_unscaled = proxsuite::proxqp::sparse::detail::middle_cols_mut(
-                   kkt_top_n_rows, n, n_eq, Qp2.model.A_nnz)
+                   kkt_top_n_rows, n, n_eq, qp2.model.A_nnz)
                    .to_eigen()
                    .transpose();
     diff_mat = A_unscaled - A;
@@ -3130,49 +3130,49 @@ TEST_CASE("Test A update for different initial guess")
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp2.results.info.iter
+    std::cout << "total number of iteration: " << qp2.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp2.results.info.setup_time
-              << " solve time " << Qp2.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp2.results.info.setup_time
+              << " solve time " << qp2.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp3(n, n_eq, n_in);
-    Qp3.settings.eps_abs = eps_abs;
-    Qp3.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp3(n, n_eq, n_in);
+    qp3.settings.eps_abs = eps_abs;
+    qp3.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp3.solve();
+    qp3.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp3.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-      qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+      qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp3.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
-    Qp3.update(std::nullopt,
+    qp3.update(std::nullopt,
                std::nullopt,
                A,
                std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt);
-    Qp3.solve();
+    qp3.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-      A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+      A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(A * Qp3.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(A * qp3.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l)));
     // get stored A from KKT matrix
-    kkt_unscaled = Qp3.model.kkt_mut_unscaled();
+    kkt_unscaled = qp3.model.kkt_mut_unscaled();
     kkt_top_n_rows = proxsuite::proxqp::sparse::detail::top_rows_mut_unchecked(
       proxsuite::linalg::veg::unsafe, kkt_unscaled, n);
     A_unscaled = proxsuite::proxqp::sparse::detail::middle_cols_mut(
-                   kkt_top_n_rows, n, n_eq, Qp3.model.A_nnz)
+                   kkt_top_n_rows, n, n_eq, qp3.model.A_nnz)
                    .to_eigen()
                    .transpose();
     diff_mat = A_unscaled - A;
@@ -3185,49 +3185,49 @@ TEST_CASE("Test A update for different initial guess")
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp3.results.info.iter
+    std::cout << "total number of iteration: " << qp3.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp3.results.info.setup_time
-              << " solve time " << Qp3.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp3.results.info.setup_time
+              << " solve time " << qp3.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp4(n, n_eq, n_in);
-    Qp4.settings.eps_abs = eps_abs;
-    Qp4.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp4(n, n_eq, n_in);
+    qp4.settings.eps_abs = eps_abs;
+    qp4.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-    Qp4.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp4.solve();
+    qp4.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp4.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp4.results.x + qp.g +
-      qp.A.transpose() * Qp4.results.y + qp.C.transpose() * Qp4.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x + qp_random.g +
+      qp_random.A.transpose() * qp4.results.y + qp_random.C.transpose() * qp4.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp4.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp4.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp4.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp4.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
-    Qp4.update(std::nullopt,
+    qp4.update(std::nullopt,
                std::nullopt,
                A,
                std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt);
-    Qp4.solve();
+    qp4.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp4.results.x + qp.g +
-      A.transpose() * Qp4.results.y + qp.C.transpose() * Qp4.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x + qp_random.g +
+      A.transpose() * qp4.results.y + qp_random.C.transpose() * qp4.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(A * Qp4.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(A * qp4.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp4.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp4.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp4.results.x - qp_random.l)));
     // get stored A from KKT matrix
-    kkt_unscaled = Qp4.model.kkt_mut_unscaled();
+    kkt_unscaled = qp4.model.kkt_mut_unscaled();
     kkt_top_n_rows = proxsuite::proxqp::sparse::detail::top_rows_mut_unchecked(
       proxsuite::linalg::veg::unsafe, kkt_unscaled, n);
     A_unscaled = proxsuite::proxqp::sparse::detail::middle_cols_mut(
-                   kkt_top_n_rows, n, n_eq, Qp4.model.A_nnz)
+                   kkt_top_n_rows, n, n_eq, qp4.model.A_nnz)
                    .to_eigen()
                    .transpose();
     diff_mat = A_unscaled - A;
@@ -3240,49 +3240,49 @@ TEST_CASE("Test A update for different initial guess")
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp4.results.info.iter
+    std::cout << "total number of iteration: " << qp4.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp4.results.info.setup_time
-              << " solve time " << Qp4.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp4.results.info.setup_time
+              << " solve time " << qp4.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp5(n, n_eq, n_in);
-    Qp5.settings.eps_abs = eps_abs;
-    Qp5.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp5(n, n_eq, n_in);
+    qp5.settings.eps_abs = eps_abs;
+    qp5.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    Qp5.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z);
+    qp5.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp5.results.x + qp.g +
-      qp.A.transpose() * Qp5.results.y + qp.C.transpose() * Qp5.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x + qp_random.g +
+      qp_random.A.transpose() * qp5.results.y + qp_random.C.transpose() * qp5.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp5.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp5.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp5.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp5.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
-    Qp5.update(std::nullopt,
+    qp5.update(std::nullopt,
                std::nullopt,
                A,
                std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt);
-    Qp5.solve();
+    qp5.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp5.results.x + qp.g +
-      A.transpose() * Qp5.results.y + qp.C.transpose() * Qp5.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x + qp_random.g +
+      A.transpose() * qp5.results.y + qp_random.C.transpose() * qp5.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(A * Qp5.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(A * qp5.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp5.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp5.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp5.results.x - qp_random.l)));
     // get stored A from KKT matrix
-    kkt_unscaled = Qp5.model.kkt_mut_unscaled();
+    kkt_unscaled = qp5.model.kkt_mut_unscaled();
     kkt_top_n_rows = proxsuite::proxqp::sparse::detail::top_rows_mut_unchecked(
       proxsuite::linalg::veg::unsafe, kkt_unscaled, n);
     A_unscaled = proxsuite::proxqp::sparse::detail::middle_cols_mut(
-                   kkt_top_n_rows, n, n_eq, Qp5.model.A_nnz)
+                   kkt_top_n_rows, n, n_eq, qp5.model.A_nnz)
                    .to_eigen()
                    .transpose();
     diff_mat = A_unscaled - A;
@@ -3295,10 +3295,10 @@ TEST_CASE("Test A update for different initial guess")
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp5.results.info.iter
+    std::cout << "total number of iteration: " << qp5.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp5.results.info.setup_time
-              << " solve time " << Qp5.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp5.results.info.setup_time
+              << " solve time " << qp5.results.info.solve_time << std::endl;
   }
 }
 
@@ -3319,33 +3319,33 @@ TEST_CASE("Test rho update for different initial guess")
     T sparsity_factor = 0.15;
     T strong_convexity_factor = 0.01;
     ::proxsuite::proxqp::utils::rand::set_seed(1);
-    proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+    proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
       n, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-    proxqp::sparse::QP<T, I> Qp(
-      qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-    // proxqp::sparse::QP<T,I> Qp(n,n_eq,n_in);
-    Qp.settings.eps_abs = eps_abs;
-    Qp.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp(
+      qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+    // proxqp::sparse::QP<T,I> qp(n,n_eq,n_in);
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
 
     std::cout << "Test rho update for different initial guess" << std::endl;
     std::cout << "dirty workspace before any solving: "
-              << Qp.work.internal.dirty << std::endl;
+              << qp.work.internal.dirty << std::endl;
 
-    Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp.solve();
+    qp.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp.solve();
     T dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     T pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
-    Qp.update(std::nullopt,
+    qp.update(std::nullopt,
               std::nullopt,
               std::nullopt,
               std::nullopt,
@@ -3354,45 +3354,45 @@ TEST_CASE("Test rho update for different initial guess")
               std::nullopt,
               true,
               T(1.E-7));
-    Qp.settings.verbose = false;
-    Qp.solve();
+    qp.settings.verbose = false;
+    qp.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-      qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+      qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp.results.info.iter
+    std::cout << "total number of iteration: " << qp.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp.results.info.setup_time << " solve time "
-              << Qp.results.info.solve_time << std::endl;
-    CHECK(Qp.results.info.rho == T(1.E-7));
+    std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+              << qp.results.info.solve_time << std::endl;
+    CHECK(qp.results.info.rho == T(1.E-7));
 
-    proxqp::sparse::QP<T, I> Qp2(n, n_eq, n_in);
-    Qp2.settings.eps_abs = eps_abs;
-    Qp2.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp2(n, n_eq, n_in);
+    qp2.settings.eps_abs = eps_abs;
+    qp2.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-    Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp2.solve();
+    qp2.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp2.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-      qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp2.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
-    Qp2.update(std::nullopt,
+    qp2.update(std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt,
@@ -3401,44 +3401,44 @@ TEST_CASE("Test rho update for different initial guess")
                std::nullopt,
                true,
                T(1.E-7));
-    Qp2.solve();
+    qp2.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-      qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+      qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp2.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp2.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l)));
-    CHECK(Qp2.results.info.rho == T(1.E-7));
+                 sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l)));
+    CHECK(qp2.results.info.rho == T(1.E-7));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp2.results.info.iter
+    std::cout << "total number of iteration: " << qp2.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp2.results.info.setup_time
-              << " solve time " << Qp2.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp2.results.info.setup_time
+              << " solve time " << qp2.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp3(n, n_eq, n_in);
-    Qp3.settings.eps_abs = eps_abs;
-    Qp3.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp3(n, n_eq, n_in);
+    qp3.settings.eps_abs = eps_abs;
+    qp3.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-    Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp3.solve();
+    qp3.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp3.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-      qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+      qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp3.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
-    Qp3.update(std::nullopt,
+    qp3.update(std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt,
@@ -3447,44 +3447,44 @@ TEST_CASE("Test rho update for different initial guess")
                std::nullopt,
                true,
                T(1.E-7));
-    Qp3.solve();
+    qp3.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-      qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+      qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp3.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp3.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l)));
-    CHECK(Qp3.results.info.rho == T(1.E-7));
+                 sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l)));
+    CHECK(qp3.results.info.rho == T(1.E-7));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp3.results.info.iter
+    std::cout << "total number of iteration: " << qp3.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp3.results.info.setup_time
-              << " solve time " << Qp3.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp3.results.info.setup_time
+              << " solve time " << qp3.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp4(n, n_eq, n_in);
-    Qp4.settings.eps_abs = eps_abs;
-    Qp4.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp4(n, n_eq, n_in);
+    qp4.settings.eps_abs = eps_abs;
+    qp4.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-    Qp4.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp4.solve();
+    qp4.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp4.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp4.results.x + qp.g +
-      qp.A.transpose() * Qp4.results.y + qp.C.transpose() * Qp4.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x + qp_random.g +
+      qp_random.A.transpose() * qp4.results.y + qp_random.C.transpose() * qp4.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp4.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp4.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp4.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp4.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
-    Qp4.update(std::nullopt,
+    qp4.update(std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt,
@@ -3493,44 +3493,44 @@ TEST_CASE("Test rho update for different initial guess")
                std::nullopt,
                true,
                T(1.E-7));
-    Qp4.solve();
+    qp4.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp4.results.x + qp.g +
-      qp.A.transpose() * Qp4.results.y + qp.C.transpose() * Qp4.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp4.results.x + qp_random.g +
+      qp_random.A.transpose() * qp4.results.y + qp_random.C.transpose() * qp4.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp4.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp4.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp4.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp4.results.x - qp.l)));
-    CHECK(Qp4.results.info.rho == T(1.E-7));
+                 sparse::detail::positive_part(qp_random.C * qp4.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp4.results.x - qp_random.l)));
+    CHECK(qp4.results.info.rho == T(1.E-7));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp4.results.info.iter
+    std::cout << "total number of iteration: " << qp4.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp4.results.info.setup_time
-              << " solve time " << Qp4.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp4.results.info.setup_time
+              << " solve time " << qp4.results.info.solve_time << std::endl;
 
-    proxqp::sparse::QP<T, I> Qp5(n, n_eq, n_in);
-    Qp5.settings.eps_abs = eps_abs;
-    Qp5.settings.initial_guess =
+    proxqp::sparse::QP<T, I> qp5(n, n_eq, n_in);
+    qp5.settings.eps_abs = eps_abs;
+    qp5.settings.initial_guess =
       proxsuite::proxqp::InitialGuessStatus::WARM_START;
-    Qp5.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l);
-    Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z);
+    qp5.init(qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l);
+    qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z);
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp5.results.x + qp.g +
-      qp.A.transpose() * Qp5.results.y + qp.C.transpose() * Qp5.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x + qp_random.g +
+      qp_random.A.transpose() * qp5.results.y + qp_random.C.transpose() * qp5.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp5.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp5.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp5.results.x - qp.l)));
+                 sparse::detail::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp5.results.x - qp_random.l)));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
-    Qp5.update(std::nullopt,
+    qp5.update(std::nullopt,
                std::nullopt,
                std::nullopt,
                std::nullopt,
@@ -3539,26 +3539,26 @@ TEST_CASE("Test rho update for different initial guess")
                std::nullopt,
                true,
                T(1.E-7));
-    Qp5.solve();
+    qp5.solve();
     dua_res = proxqp::dense::infty_norm(
-      qp.H.selfadjointView<Eigen::Upper>() * Qp5.results.x + qp.g +
-      qp.A.transpose() * Qp5.results.y + qp.C.transpose() * Qp5.results.z);
+      qp_random.H.selfadjointView<Eigen::Upper>() * qp5.results.x + qp_random.g +
+      qp_random.A.transpose() * qp5.results.y + qp_random.C.transpose() * qp5.results.z);
     pri_res =
-      std::max(proxqp::dense::infty_norm(qp.A * Qp5.results.x - qp.b),
+      std::max(proxqp::dense::infty_norm(qp_random.A * qp5.results.x - qp_random.b),
                proxqp::dense::infty_norm(
-                 sparse::detail::positive_part(qp.C * Qp5.results.x - qp.u) +
-                 sparse::detail::negative_part(qp.C * Qp5.results.x - qp.l)));
-    CHECK(Qp5.results.info.rho == T(1.E-7));
+                 sparse::detail::positive_part(qp_random.C * qp5.results.x - qp_random.u) +
+                 sparse::detail::negative_part(qp_random.C * qp5.results.x - qp_random.l)));
+    CHECK(qp5.results.info.rho == T(1.E-7));
     CHECK(dua_res <= eps_abs);
     CHECK(pri_res <= eps_abs);
     std::cout << "--n = " << n << " n_eq " << n_eq << " n_in " << n_in
               << std::endl;
     std::cout << "; dual residual " << dua_res << "; primal residual "
               << pri_res << std::endl;
-    std::cout << "total number of iteration: " << Qp5.results.info.iter
+    std::cout << "total number of iteration: " << qp5.results.info.iter
               << std::endl;
-    std::cout << "setup timing " << Qp5.results.info.setup_time
-              << " solve time " << Qp5.results.info.solve_time << std::endl;
+    std::cout << "setup timing " << qp5.results.info.setup_time
+              << " solve time " << qp5.results.info.solve_time << std::endl;
   }
 }
 
@@ -3579,42 +3579,42 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
   ::proxsuite::proxqp::utils::rand::set_seed(1);
-  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+  proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> Qp(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  Qp.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  qp.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
   T pri_res =
-    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   T dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -3623,103 +3623,103 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
   pri_res =
-    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-             qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp2(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  proxqp::sparse::QP<T, I> qp2(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
 
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res =
-    std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+    std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-     qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+     qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp3(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  proxqp::sparse::QP<T, I> qp3(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res =
-    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -3729,20 +3729,20 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
              compute_preconditioner,
              1.e-6,
              1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
   pri_res =
-    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -3765,43 +3765,43 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
   ::proxsuite::proxqp::utils::rand::set_seed(1);
-  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+  proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> Qp(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
   T pri_res =
-    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   T dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -3810,105 +3810,105 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
   pri_res =
-    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-             qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp2(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp2.settings.initial_guess =
+  proxqp::sparse::QP<T, I> qp2(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
 
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res =
-    std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+    std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-     qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+     qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp3(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp3.settings.initial_guess =
+  proxqp::sparse::QP<T, I> qp3(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res =
-    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -3918,20 +3918,20 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
              compute_preconditioner,
              1.e-6,
              1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
   pri_res =
-    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -3954,43 +3954,43 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
   ::proxsuite::proxqp::utils::rand::set_seed(1);
-  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+  proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> Qp(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
   T pri_res =
-    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   T dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -3999,105 +3999,105 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
   pri_res =
-    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-             qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp2(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp2.settings.initial_guess =
+  proxqp::sparse::QP<T, I> qp2(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
 
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res =
-    std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+    std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-     qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+     qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp3(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp3.settings.initial_guess =
+  proxqp::sparse::QP<T, I> qp3(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res =
-    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -4107,20 +4107,20 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
              compute_preconditioner,
              1.e-6,
              1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
   pri_res =
-    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -4143,43 +4143,43 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
   ::proxsuite::proxqp::utils::rand::set_seed(1);
-  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+  proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> Qp(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  proxqp::sparse::QP<T, I> qp(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
   T pri_res =
-    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   T dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -4188,105 +4188,105 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) <= 1.E-9);
 
   pri_res =
-    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-             qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+  dua_res = (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+             qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp2(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp2.settings.initial_guess =
+  proxqp::sparse::QP<T, I> qp2(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
 
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res =
-    std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+    std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp2.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp2.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-     qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+     qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp3(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp3.settings.initial_guess =
+  proxqp::sparse::QP<T, I> qp3(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
+  DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
 
   pri_res =
-    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -4296,20 +4296,20 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
              compute_preconditioner,
              1.e-6,
              1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-  Qp3.solve();
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+  qp3.solve();
   pri_res =
-    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+    std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp3.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp3.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+     qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -4333,66 +4333,66 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
   ::proxsuite::proxqp::utils::rand::set_seed(1);
-  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+  proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> Qp(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  // proxqp::sparse::QP<T,I> Qp(n,n_eq,n_in);
-  Qp.settings.eps_abs = eps_abs;
+  proxqp::sparse::QP<T, I> qp(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  // proxqp::sparse::QP<T,I> qp(n,n_eq,n_in);
+  qp.settings.eps_abs = eps_abs;
 
   std::cout << "Test rho update for different initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.internal.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.internal.dirty
             << std::endl;
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  Qp.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  qp.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  // Qp.settings.verbose = true;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  // qp.settings.verbose = true;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
   T pri_res =
-    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   T dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
+    qp.solve();
+    DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
     pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -4402,114 +4402,114 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             compute_preconditioner,
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
+    qp.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
     pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp2(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  proxqp::sparse::QP<T, I> qp2(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-    Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+    qp2.solve();
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
     pri_res =
-      std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-       qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp3(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  proxqp::sparse::QP<T, I> qp3(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res =
-      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -4520,25 +4520,25 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
              1.e-6,
              1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res =
-      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
@@ -4564,67 +4564,67 @@ DOCTEST_TEST_CASE(
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
   ::proxsuite::proxqp::utils::rand::set_seed(1);
-  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+  proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> Qp(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  // proxqp::sparse::QP<T,I> Qp(n,n_eq,n_in);
-  Qp.settings.eps_abs = eps_abs;
+  proxqp::sparse::QP<T, I> qp(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  // proxqp::sparse::QP<T,I> qp(n,n_eq,n_in);
+  qp.settings.eps_abs = eps_abs;
 
   std::cout << "Test rho update for different initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.internal.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.internal.dirty
             << std::endl;
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  // Qp.settings.verbose = true;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  // qp.settings.verbose = true;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
   T pri_res =
-    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   T dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
+    qp.solve();
+    DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
     pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -4634,116 +4634,116 @@ DOCTEST_TEST_CASE(
             compute_preconditioner,
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
+    qp.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
     pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp2(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp2.settings.initial_guess =
+  proxqp::sparse::QP<T, I> qp2(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-    Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+    qp2.solve();
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
     pri_res =
-      std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-       qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp3(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp3.settings.initial_guess =
+  proxqp::sparse::QP<T, I> qp3(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res =
-      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -4754,25 +4754,25 @@ DOCTEST_TEST_CASE(
              1.e-6,
              1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res =
-      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
@@ -4797,67 +4797,67 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
   ::proxsuite::proxqp::utils::rand::set_seed(1);
-  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+  proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> Qp(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  // proxqp::sparse::QP<T,I> Qp(n,n_eq,n_in);
-  Qp.settings.eps_abs = eps_abs;
+  proxqp::sparse::QP<T, I> qp(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  // proxqp::sparse::QP<T,I> qp(n,n_eq,n_in);
+  qp.settings.eps_abs = eps_abs;
 
   std::cout << "Test rho update for different initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.internal.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.internal.dirty
             << std::endl;
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  // Qp.settings.verbose = true;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  // qp.settings.verbose = true;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
   T pri_res =
-    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   T dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
+    qp.solve();
+    DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
     pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -4867,116 +4867,116 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             compute_preconditioner,
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
+    qp.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
     pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp2(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp2.settings.initial_guess =
+  proxqp::sparse::QP<T, I> qp2(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-    Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+    qp2.solve();
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
     pri_res =
-      std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-       qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp3(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp3.settings.initial_guess =
+  proxqp::sparse::QP<T, I> qp3(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res =
-      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -4987,25 +4987,25 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
              1.e-6,
              1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res =
-      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
@@ -5030,67 +5030,67 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   dense::isize n_in(dim / 4);
   T strong_convexity_factor(1.e-2);
   ::proxsuite::proxqp::utils::rand::set_seed(1);
-  proxqp::sparse::SparseModel<T> qp = utils::sparse_strongly_convex_qp(
+  proxqp::sparse::SparseModel<T> qp_random = utils::sparse_strongly_convex_qp(
     dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
 
-  proxqp::sparse::QP<T, I> Qp(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  // proxqp::sparse::QP<T,I> Qp(n,n_eq,n_in);
-  Qp.settings.eps_abs = eps_abs;
+  proxqp::sparse::QP<T, I> qp(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  // proxqp::sparse::QP<T,I> qp(n,n_eq,n_in);
+  qp.settings.eps_abs = eps_abs;
 
   std::cout << "Test rho update for different initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: " << Qp.work.internal.dirty
+  std::cout << "dirty workspace before any solving: " << qp.work.internal.dirty
             << std::endl;
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  Qp.settings.initial_guess =
+  qp.settings.initial_guess =
     proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp.settings.initial_guess ==
+  DOCTEST_CHECK(qp.settings.initial_guess ==
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
-  Qp.settings.eps_abs = eps_abs;
-  Qp.settings.eps_rel = 0;
-  // Qp.settings.verbose = true;
-  Qp.init(
-    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
-  Qp.solve();
-  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.eps_rel = 0;
+  // qp.settings.verbose = true;
+  qp.init(
+    qp_random.H, qp_random.g, qp_random.A, qp_random.b, qp_random.C, qp_random.u, qp_random.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
+  qp.solve();
+  DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) <= 1.E-9);
 
   T pri_res =
-    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+    std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+              sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                .lpNorm<Eigen::Infinity>());
   T dua_res =
-    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+    (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+     qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
       .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
+    qp.solve();
+    DOCTEST_CHECK(std::abs(rho - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - qp.results.info.rho) < 1.e-9);
     pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp.update(std::nullopt,
+  qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -5100,116 +5100,116 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             compute_preconditioner,
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
-    Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
+    qp.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp.results.info.rho) < 1.e-9);
     pri_res =
-      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
-       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp.results.x + qp_random.g +
+       qp_random.A.transpose() * qp.results.y + qp_random.C.transpose() * qp.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp2(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp2.settings.initial_guess =
+  proxqp::sparse::QP<T, I> qp2(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp2.settings.initial_guess =
     proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+  DOCTEST_CHECK(qp2.settings.initial_guess ==
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
-  Qp2.settings.eps_abs = eps_abs;
-  Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp2.settings.eps_abs = eps_abs;
+  qp2.settings.eps_rel = 0;
+  qp2.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            std::nullopt,
            mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-  Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+  qp2.solve();
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
-    Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
+    qp2.solve();
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp2.results.info.mu_eq_inv) <= 1.E-9);
     pri_res =
-      std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp2.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
-       qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp2.results.x + qp_random.g +
+       qp_random.A.transpose() * qp2.results.y + qp_random.C.transpose() * qp2.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
   // conter factual check with another QP object starting at the updated model
-  proxqp::sparse::QP<T, I> Qp3(
-    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp3.settings.initial_guess =
+  proxqp::sparse::QP<T, I> qp3(
+    qp_random.H.cast<bool>(), qp_random.A.cast<bool>(), qp_random.C.cast<bool>());
+  qp3.settings.initial_guess =
     proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+  DOCTEST_CHECK(qp3.settings.initial_guess ==
                 proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
-  Qp3.settings.eps_abs = eps_abs;
-  Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H,
-           qp.g,
-           qp.A,
-           qp.b,
-           qp.C,
-           qp.u,
-           qp.l,
+  qp3.settings.eps_abs = eps_abs;
+  qp3.settings.eps_rel = 0;
+  qp3.init(qp_random.H,
+           qp_random.g,
+           qp_random.A,
+           qp_random.b,
+           qp_random.C,
+           qp_random.u,
+           qp_random.l,
            compute_preconditioner,
            rho,
            mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(rho - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res =
-      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  Qp3.update(std::nullopt,
+  qp3.update(std::nullopt,
              std::nullopt,
              std::nullopt,
              std::nullopt,
@@ -5220,25 +5220,25 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
              1.e-6,
              1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
-    Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
+    qp3.solve();
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - qp3.results.info.mu_eq_inv) <= 1.E-9);
     pri_res =
-      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+      std::max((qp_random.A * qp3.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+                sparse::detail::negative_part(qp_random.C * qp.results.x - qp_random.l))
                  .lpNorm<Eigen::Infinity>());
     dua_res =
-      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
-       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      (qp_random.H.selfadjointView<Eigen::Upper>() * qp3.results.x + qp_random.g +
+       qp_random.A.transpose() * qp3.results.y + qp_random.C.transpose() * qp3.results.z)
         .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);

--- a/test/src/sparse_qp_wrapper.cpp
+++ b/test/src/sparse_qp_wrapper.cpp
@@ -3562,12 +3562,13 @@ TEST_CASE("Test rho update for different initial guess")
   }
 }
 
-
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after updates using no initial guess")
+                  "inequality constraints: test changing default settings "
+                  "after updates using no initial guess")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after updates using no initial guess---"
+               "inequality constraints: test changing default settings after "
+               "updates using no initial guess---"
             << std::endl;
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
@@ -3589,23 +3590,27 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   bool compute_preconditioner = true;
 
   Qp.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                        sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+  T pri_res =
+    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  T dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
@@ -3618,18 +3623,19 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>()  * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  pri_res =
+    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+             qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
@@ -3637,93 +3643,118 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   proxqp::sparse::QP<T, I> Qp2(
     qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
   Qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
 
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res =
+    std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
+     qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-
 
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp3(
     qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
   Qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res =
+    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res =
+    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-
 }
 
-
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after updates using EQUALITY_CONSTRAINED_INITIAL_GUESS")
+                  "inequality constraints: test changing default settings "
+                  "after updates using EQUALITY_CONSTRAINED_INITIAL_GUESS")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after updates using EQUALITY_CONSTRAINED_INITIAL_GUESS---"
+               "inequality constraints: test changing default settings after "
+               "updates using EQUALITY_CONSTRAINED_INITIAL_GUESS---"
             << std::endl;
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
@@ -3744,24 +3775,29 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  Qp.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp.settings.initial_guess =
+    proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                        sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+  T pri_res =
+    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  T dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
@@ -3774,112 +3810,140 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>()  * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  pri_res =
+    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+             qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp2(
     qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp2.settings.initial_guess =
+    proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
 
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res =
+    std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
+     qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-
 
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp3(
     qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp3.settings.initial_guess =
+    proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res =
+    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res =
+    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-
 }
 
-
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after updates using COLD_START_WITH_PREVIOUS_RESULT")
+                  "inequality constraints: test changing default settings "
+                  "after updates using COLD_START_WITH_PREVIOUS_RESULT")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after updates using COLD_START_WITH_PREVIOUS_RESULT---"
+               "inequality constraints: test changing default settings after "
+               "updates using COLD_START_WITH_PREVIOUS_RESULT---"
             << std::endl;
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
@@ -3900,24 +3964,29 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  Qp.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp.settings.initial_guess =
+    proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                        sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+  T pri_res =
+    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  T dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
@@ -3930,111 +3999,140 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>()  * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  pri_res =
+    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+             qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp2(
     qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp2.settings.initial_guess =
+    proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
 
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res =
+    std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
+     qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-
 
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp3(
     qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp3.settings.initial_guess =
+    proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res =
+    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res =
+    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after updates using WARM_START_WITH_PREVIOUS_RESULT")
+                  "inequality constraints: test changing default settings "
+                  "after updates using WARM_START_WITH_PREVIOUS_RESULT")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after updates using WARM_START_WITH_PREVIOUS_RESULT---"
+               "inequality constraints: test changing default settings after "
+               "updates using WARM_START_WITH_PREVIOUS_RESULT---"
             << std::endl;
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
@@ -4055,24 +4153,29 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  Qp.settings.initial_guess = proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  Qp.settings.initial_guess =
+    proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                        sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+  T pri_res =
+    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  T dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
 
@@ -4085,116 +4188,142 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             std::nullopt,
             compute_preconditioner,
             1.e-6);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>()  * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-             qp.C.transpose() * Qp.results.z)
+  pri_res =
+    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+             qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
               .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp2(
     qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  Qp2.settings.initial_guess =
+    proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
 
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-             qp.C.transpose() * Qp2.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res =
+    std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp2.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp2.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
+     qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-
 
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp3(
     qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  Qp3.settings.initial_guess =
+    proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
 
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res =
+    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
   Qp3.solve();
-  pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                     (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
-                      sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-  dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-             qp.C.transpose() * Qp3.results.z)
-              .lpNorm<Eigen::Infinity>();
+  pri_res =
+    std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp3.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp3.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+     qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-
 }
 
-
-
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after several solves using no initial guess")
+                  "inequality constraints: test changing default settings "
+                  "after several solves using no initial guess")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after several solves using no initial guess---"
+               "inequality constraints: test changing default settings after "
+               "several solves using no initial guess---"
             << std::endl;
 
-  
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
   utils::rand::set_seed(1);
@@ -4213,50 +4342,56 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   Qp.settings.eps_abs = eps_abs;
 
   std::cout << "Test rho update for different initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: "
-            << Qp.work.internal.dirty << std::endl;  
+  std::cout << "dirty workspace before any solving: " << Qp.work.internal.dirty
+            << std::endl;
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
   Qp.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  //Qp.settings.verbose = true;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  // Qp.settings.verbose = true;
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+  T pri_res =
+    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  T dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  
+
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
+    pri_res =
+      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
- 
+
   Qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -4268,131 +4403,158 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
+    pri_res =
+      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp2(
-  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
   Qp2.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
     Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
-    pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-              qp.C.transpose() * Qp2.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res =
+      std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
+       qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp3(
-  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
   Qp3.settings.initial_guess = proxqp::InitialGuessStatus::NO_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::NO_INITIAL_GUESS);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res =
+      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
+
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res =
+      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 }
 
-DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after several solves using equality constrained initial guess")
+DOCTEST_TEST_CASE(
+  "sparse random strongly convex qp with equality and "
+  "inequality constraints: test changing default settings after several solves "
+  "using equality constrained initial guess")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after several solves using equality constrained initial guess---"
+               "inequality constraints: test changing default settings after "
+               "several solves using equality constrained initial guess---"
             << std::endl;
 
-  
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
   utils::rand::set_seed(1);
@@ -4411,50 +4573,57 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   Qp.settings.eps_abs = eps_abs;
 
   std::cout << "Test rho update for different initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: "
-            << Qp.work.internal.dirty << std::endl;  
+  std::cout << "dirty workspace before any solving: " << Qp.work.internal.dirty
+            << std::endl;
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  Qp.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+  Qp.settings.initial_guess =
+    proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  //Qp.settings.verbose = true;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  // Qp.settings.verbose = true;
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+  T pri_res =
+    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  T dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  
+
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
+    pri_res =
+      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
- 
+
   Qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -4466,131 +4635,159 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
+    pri_res =
+      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp2(
-  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp2.settings.initial_guess =
+    proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
     Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
-    pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-              qp.C.transpose() * Qp2.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res =
+      std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
+       qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp3(
-  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp3.settings.initial_guess =
+    proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS;
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res =
+      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
+
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res =
+      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 }
 
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after several solves using cold start with previous result")
+                  "inequality constraints: test changing default settings "
+                  "after several solves using cold start with previous result")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after several solves using cold start with previous result---"
+               "inequality constraints: test changing default settings after "
+               "several solves using cold start with previous result---"
             << std::endl;
 
-  
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
   utils::rand::set_seed(1);
@@ -4609,50 +4806,57 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   Qp.settings.eps_abs = eps_abs;
 
   std::cout << "Test rho update for different initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: "
-            << Qp.work.internal.dirty << std::endl;  
+  std::cout << "dirty workspace before any solving: " << Qp.work.internal.dirty
+            << std::endl;
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  Qp.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+  Qp.settings.initial_guess =
+    proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  //Qp.settings.verbose = true;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  // Qp.settings.verbose = true;
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+  T pri_res =
+    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  T dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  
+
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
+    pri_res =
+      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
- 
+
   Qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -4664,132 +4868,159 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
+    pri_res =
+      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp2(
-  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp2.settings.initial_guess =
+    proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
     Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
-    pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-              qp.C.transpose() * Qp2.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res =
+      std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
+       qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp3(
-  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp3.settings.initial_guess =
+    proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res =
+      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
+
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res =
+      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 }
 
-
 DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
-                  "inequality constraints: test changing default settings after several solves using warm start with previous result")
+                  "inequality constraints: test changing default settings "
+                  "after several solves using warm start with previous result")
 {
   std::cout << "---testing sparse random strongly convex qp with equality and "
-               "inequality constraints: test changing default settings after several solves using warm start with previous result---"
+               "inequality constraints: test changing default settings after "
+               "several solves using warm start with previous result---"
             << std::endl;
 
-  
   double sparsity_factor = 0.15;
   T eps_abs = T(1e-9);
   utils::rand::set_seed(1);
@@ -4808,50 +5039,57 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
   Qp.settings.eps_abs = eps_abs;
 
   std::cout << "Test rho update for different initial guess" << std::endl;
-  std::cout << "dirty workspace before any solving: "
-            << Qp.work.internal.dirty << std::endl;  
+  std::cout << "dirty workspace before any solving: " << Qp.work.internal.dirty
+            << std::endl;
 
   T rho(1.e-7);
   T mu_eq(1.e-4);
   bool compute_preconditioner = true;
 
-  Qp.settings.initial_guess = proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+  Qp.settings.initial_guess =
+    proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp.settings.initial_guess ==
+                proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   Qp.settings.eps_abs = eps_abs;
   Qp.settings.eps_rel = 0;
-  //Qp.settings.verbose = true;
-  Qp.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho);
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  // Qp.settings.verbose = true;
+  Qp.init(
+    qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l, compute_preconditioner, rho);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
   Qp.solve();
-  DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<=1.E-9);
-  DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<=1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) <= 1.E-9);
 
-  T pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                         .lpNorm<Eigen::Infinity>());
-  T dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-               qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+  T pri_res =
+    std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+             (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+              sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+               .lpNorm<Eigen::Infinity>());
+  T dua_res =
+    (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+     qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+      .lpNorm<Eigen::Infinity>();
   DOCTEST_CHECK(pri_res <= eps_abs);
   DOCTEST_CHECK(dua_res <= eps_abs);
-  
+
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(rho-Qp.results.info.rho)<1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(rho - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(rho - Qp.results.info.rho) < 1.e-9);
+    pri_res =
+      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
- 
+
   Qp.update(std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -4863,119 +5101,146 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with equality and "
             1.e-6);
   for (isize iter = 0; iter < 10; ++iter) {
     Qp.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.settings.default_rho)<1.e-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp.results.info.rho)<1.e-9);
-    pri_res = std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g + qp.A.transpose() * Qp.results.y +
-              qp.C.transpose() * Qp.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.settings.default_rho) < 1.e-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp.results.info.rho) < 1.e-9);
+    pri_res =
+      std::max((qp.A * Qp.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp.results.x + qp.g +
+       qp.A.transpose() * Qp.results.y + qp.C.transpose() * Qp.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp2(
-  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp2.settings.initial_guess = proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp2.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp2.settings.initial_guess =
+    proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp2.settings.initial_guess ==
+                proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   Qp2.settings.eps_abs = eps_abs;
   Qp2.settings.eps_rel = 0;
-  Qp2.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,std::nullopt,mu_eq);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  Qp2.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           std::nullopt,
+           mu_eq);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
   Qp2.solve();
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-  DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+  DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
     Qp2.solve();
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp2.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp2.results.info.mu_eq_inv)<=1.E-9);
-    pri_res = std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g + qp.A.transpose() * Qp2.results.y +
-              qp.C.transpose() * Qp2.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp2.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp2.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res =
+      std::max((qp.A * Qp2.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp2.results.x + qp.g +
+       qp.A.transpose() * Qp2.results.y + qp.C.transpose() * Qp2.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
 
-  
   // conter factual check with another QP object starting at the updated model
   proxqp::sparse::QP<T, I> Qp3(
-  qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
-  Qp3.settings.initial_guess = proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  DOCTEST_CHECK(Qp3.settings.initial_guess == proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
+    qp.H.cast<bool>(), qp.A.cast<bool>(), qp.C.cast<bool>());
+  Qp3.settings.initial_guess =
+    proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
+  DOCTEST_CHECK(Qp3.settings.initial_guess ==
+                proxqp::InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT);
   Qp3.settings.eps_abs = eps_abs;
   Qp3.settings.eps_rel = 0;
-  Qp3.init(qp.H, qp.g, qp.A, qp.b, qp.C, qp.u, qp.l,compute_preconditioner,rho,mu_eq);
+  Qp3.init(qp.H,
+           qp.g,
+           qp.A,
+           qp.b,
+           qp.C,
+           qp.u,
+           qp.l,
+           compute_preconditioner,
+           rho,
+           mu_eq);
 
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(rho-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(rho-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(mu_eq-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(T(1)/mu_eq-Qp3.results.info.mu_eq_inv)<=1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(rho - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(rho - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(mu_eq - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(T(1) / mu_eq - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res =
+      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
+
   Qp3.update(std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            compute_preconditioner,
-            1.e-6,
-            1.e-3);
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             compute_preconditioner,
+             1.e-6,
+             1.e-3);
   for (isize iter = 0; iter < 10; ++iter) {
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
     Qp3.solve();
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.settings.default_rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-6-Qp3.results.info.rho)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.settings.default_mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e-3-Qp3.results.info.mu_eq)<=1.E-9);
-    DOCTEST_CHECK(std::abs(1.e3-Qp3.results.info.mu_eq_inv)<=1.E-9);
-    pri_res = std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
-                       (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
-                       sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
-                       .lpNorm<Eigen::Infinity>());
-    dua_res = (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g + qp.A.transpose() * Qp3.results.y +
-              qp.C.transpose() * Qp3.results.z)
-                .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.settings.default_rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-6 - Qp3.results.info.rho) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.settings.default_mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e-3 - Qp3.results.info.mu_eq) <= 1.E-9);
+    DOCTEST_CHECK(std::abs(1.e3 - Qp3.results.info.mu_eq_inv) <= 1.E-9);
+    pri_res =
+      std::max((qp.A * Qp3.results.x - qp.b).lpNorm<Eigen::Infinity>(),
+               (sparse::detail::positive_part(qp.C * Qp.results.x - qp.u) +
+                sparse::detail::negative_part(qp.C * Qp.results.x - qp.l))
+                 .lpNorm<Eigen::Infinity>());
+    dua_res =
+      (qp.H.selfadjointView<Eigen::Upper>() * Qp3.results.x + qp.g +
+       qp.A.transpose() * Qp3.results.y + qp.C.transpose() * Qp3.results.z)
+        .lpNorm<Eigen::Infinity>();
     DOCTEST_CHECK(pri_res <= eps_abs);
     DOCTEST_CHECK(dua_res <= eps_abs);
   }
-  
 }

--- a/test/src/sparse_qp_wrapper.py
+++ b/test/src/sparse_qp_wrapper.py
@@ -3871,7 +3871,9 @@ class SparseQpWrapper(unittest.TestCase):
             )
         )
 
-    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_no_initial_guess(self):
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_no_initial_guess(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, no initial guess, multiple solve and default rho and mu_eq"
         )
@@ -3879,8 +3881,8 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
@@ -3895,15 +3897,15 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -3921,9 +3923,9 @@ class SparseQpWrapper(unittest.TestCase):
         assert pri_res <= 1e-9
         for i in range(10):
             Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-            assert np.abs(rho - Qp.results.info.rho) <1.E-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
                 H @ Qp.results.x
                 + g
@@ -3940,7 +3942,9 @@ class SparseQpWrapper(unittest.TestCase):
             assert dua_res <= 1e-9
             assert pri_res <= 1e-9
 
-    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_EQUALITY_CONSTRAINED_INITIAL_GUESS(self):
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_EQUALITY_CONSTRAINED_INITIAL_GUESS(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, EQUALITY_CONSTRAINED_INITIAL_GUESS, multiple solve and default rho and mu_eq"
         )
@@ -3948,12 +3952,14 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
+        Qp.settings.initial_guess = (
+            proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
+        )
         Qp.init(
             H,
             np.asfortranarray(g),
@@ -3964,15 +3970,15 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -3990,9 +3996,9 @@ class SparseQpWrapper(unittest.TestCase):
         assert pri_res <= 1e-9
         for i in range(10):
             Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-            assert np.abs(rho - Qp.results.info.rho) <1.E-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
                 H @ Qp.results.x
                 + g
@@ -4009,7 +4015,9 @@ class SparseQpWrapper(unittest.TestCase):
             assert dua_res <= 1e-9
             assert pri_res <= 1e-9
 
-    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_COLD_START_WITH_PREVIOUS_RESULT(self):
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_COLD_START_WITH_PREVIOUS_RESULT(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, COLD_START_WITH_PREVIOUS_RESULT, multiple solve and default rho and mu_eq"
         )
@@ -4017,12 +4025,14 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
+        Qp.settings.initial_guess = (
+            proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
+        )
         Qp.init(
             H,
             np.asfortranarray(g),
@@ -4033,15 +4043,15 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -4059,9 +4069,9 @@ class SparseQpWrapper(unittest.TestCase):
         assert pri_res <= 1e-9
         for i in range(10):
             Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-            assert np.abs(rho - Qp.results.info.rho) <1.E-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
                 H @ Qp.results.x
                 + g
@@ -4078,7 +4088,9 @@ class SparseQpWrapper(unittest.TestCase):
             assert dua_res <= 1e-9
             assert pri_res <= 1e-9
 
-    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_WARM_START_WITH_PREVIOUS_RESULT(self):
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_WARM_START_WITH_PREVIOUS_RESULT(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, WARM_START_WITH_PREVIOUS_RESULT, multiple solve and default rho and mu_eq"
         )
@@ -4086,12 +4098,14 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
+        Qp.settings.initial_guess = (
+            proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
+        )
         Qp.init(
             H,
             np.asfortranarray(g),
@@ -4102,15 +4116,15 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -4128,9 +4142,9 @@ class SparseQpWrapper(unittest.TestCase):
         assert pri_res <= 1e-9
         for i in range(10):
             Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-            assert np.abs(rho - Qp.results.info.rho) <1.E-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
                 H @ Qp.results.x
                 + g
@@ -4147,9 +4161,9 @@ class SparseQpWrapper(unittest.TestCase):
             assert dua_res <= 1e-9
             assert pri_res <= 1e-9
 
-
-
-    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_WARM_START_WITH_PREVIOUS_RESULT(self):
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_WARM_START_WITH_PREVIOUS_RESULT(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, WARM_START_WITH_PREVIOUS_RESULT, update + solve and default rho and mu_eq"
         )
@@ -4157,12 +4171,14 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
+        Qp.settings.initial_guess = (
+            proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
+        )
         Qp.init(
             H,
             np.asfortranarray(g),
@@ -4173,15 +4189,15 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -4197,10 +4213,10 @@ class SparseQpWrapper(unittest.TestCase):
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
-        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
-        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
-        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
         dua_res = normInf(
             H @ Qp.results.x
@@ -4218,7 +4234,9 @@ class SparseQpWrapper(unittest.TestCase):
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
 
-    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_COLD_START_WITH_PREVIOUS_RESULT(self):
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_COLD_START_WITH_PREVIOUS_RESULT(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, COLD_START_WITH_PREVIOUS_RESULT, update + solve and default rho and mu_eq"
         )
@@ -4226,12 +4244,14 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
+        Qp.settings.initial_guess = (
+            proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
+        )
         Qp.init(
             H,
             np.asfortranarray(g),
@@ -4242,15 +4262,15 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -4266,10 +4286,10 @@ class SparseQpWrapper(unittest.TestCase):
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
-        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
-        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
-        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
         dua_res = normInf(
             H @ Qp.results.x
@@ -4287,7 +4307,9 @@ class SparseQpWrapper(unittest.TestCase):
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
 
-    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_EQUALITY_CONSTRAINED_INITIAL_GUESS(self):
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_EQUALITY_CONSTRAINED_INITIAL_GUESS(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, EQUALITY_CONSTRAINED_INITIAL_GUESS, update + solve and default rho and mu_eq"
         )
@@ -4295,12 +4317,14 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
+        Qp.settings.initial_guess = (
+            proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
+        )
         Qp.init(
             H,
             np.asfortranarray(g),
@@ -4311,15 +4335,15 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -4335,10 +4359,10 @@ class SparseQpWrapper(unittest.TestCase):
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
-        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
-        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
-        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
         dua_res = normInf(
             H @ Qp.results.x
@@ -4356,7 +4380,9 @@ class SparseQpWrapper(unittest.TestCase):
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
 
-    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_NO_INITIAL_GUESS(self):
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_NO_INITIAL_GUESS(
+        self,
+    ):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints, NO_INITIAL_GUESS, update + solve and default rho and mu_eq"
         )
@@ -4364,8 +4390,8 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        rho = 1.E-7
-        mu_eq = 1.E-4
+        rho = 1.0e-7
+        mu_eq = 1.0e-4
         Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
         Qp.settings.eps_abs = 1.0e-9
         Qp.settings.verbose = False
@@ -4380,15 +4406,15 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
             rho=rho,
-            mu_eq=mu_eq
+            mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
-        assert np.abs(rho - Qp.results.info.rho) <1.E-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
             H @ Qp.results.x
             + g
@@ -4404,10 +4430,10 @@ class SparseQpWrapper(unittest.TestCase):
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
-        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
-        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
-        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
         Qp.solve()
         dua_res = normInf(
             H @ Qp.results.x
@@ -4424,8 +4450,6 @@ class SparseQpWrapper(unittest.TestCase):
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-
-
 
     def test_sparse_problem_with_exact_solution_known(self):
         print(

--- a/test/src/sparse_qp_wrapper.py
+++ b/test/src/sparse_qp_wrapper.py
@@ -3871,6 +3871,562 @@ class SparseQpWrapper(unittest.TestCase):
             )
         )
 
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_no_initial_guess(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, no initial guess, multiple solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        for i in range(10):
+            Qp.solve()
+            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+            assert np.abs(rho - Qp.results.info.rho) <1.E-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            dua_res = normInf(
+                H @ Qp.results.x
+                + g
+                + A.transpose() @ Qp.results.y
+                + C.transpose() @ Qp.results.z
+            )
+            pri_res = max(
+                normInf(A @ Qp.results.x - b),
+                normInf(
+                    np.maximum(C @ Qp.results.x - u, 0)
+                    + np.minimum(C @ Qp.results.x - l, 0)
+                ),
+            )
+            assert dua_res <= 1e-9
+            assert pri_res <= 1e-9
+
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_EQUALITY_CONSTRAINED_INITIAL_GUESS(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, EQUALITY_CONSTRAINED_INITIAL_GUESS, multiple solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        for i in range(10):
+            Qp.solve()
+            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+            assert np.abs(rho - Qp.results.info.rho) <1.E-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            dua_res = normInf(
+                H @ Qp.results.x
+                + g
+                + A.transpose() @ Qp.results.y
+                + C.transpose() @ Qp.results.z
+            )
+            pri_res = max(
+                normInf(A @ Qp.results.x - b),
+                normInf(
+                    np.maximum(C @ Qp.results.x - u, 0)
+                    + np.minimum(C @ Qp.results.x - l, 0)
+                ),
+            )
+            assert dua_res <= 1e-9
+            assert pri_res <= 1e-9
+
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_COLD_START_WITH_PREVIOUS_RESULT(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, COLD_START_WITH_PREVIOUS_RESULT, multiple solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        for i in range(10):
+            Qp.solve()
+            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+            assert np.abs(rho - Qp.results.info.rho) <1.E-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            dua_res = normInf(
+                H @ Qp.results.x
+                + g
+                + A.transpose() @ Qp.results.y
+                + C.transpose() @ Qp.results.z
+            )
+            pri_res = max(
+                normInf(A @ Qp.results.x - b),
+                normInf(
+                    np.maximum(C @ Qp.results.x - u, 0)
+                    + np.minimum(C @ Qp.results.x - l, 0)
+                ),
+            )
+            assert dua_res <= 1e-9
+            assert pri_res <= 1e-9
+
+    def test_sparse_problem_multiple_solve_with_default_rho_mu_eq_and_WARM_START_WITH_PREVIOUS_RESULT(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, WARM_START_WITH_PREVIOUS_RESULT, multiple solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        for i in range(10):
+            Qp.solve()
+            assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+            assert np.abs(rho - Qp.results.info.rho) <1.E-9
+            assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+            dua_res = normInf(
+                H @ Qp.results.x
+                + g
+                + A.transpose() @ Qp.results.y
+                + C.transpose() @ Qp.results.z
+            )
+            pri_res = max(
+                normInf(A @ Qp.results.x - b),
+                normInf(
+                    np.maximum(C @ Qp.results.x - u, 0)
+                    + np.minimum(C @ Qp.results.x - l, 0)
+                ),
+            )
+            assert dua_res <= 1e-9
+            assert pri_res <= 1e-9
+
+
+
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_WARM_START_WITH_PREVIOUS_RESULT(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, WARM_START_WITH_PREVIOUS_RESULT, update + solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
+        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
+        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
+        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_COLD_START_WITH_PREVIOUS_RESULT(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, COLD_START_WITH_PREVIOUS_RESULT, update + solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
+        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
+        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
+        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_EQUALITY_CONSTRAINED_INITIAL_GUESS(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, EQUALITY_CONSTRAINED_INITIAL_GUESS, update + solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
+        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
+        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
+        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+
+    def test_sparse_problem_update_and_solve_with_default_rho_mu_eq_and_NO_INITIAL_GUESS(self):
+        print(
+            "------------------------sparse random strongly convex qp with inequality constraints, NO_INITIAL_GUESS, update + solve and default rho and mu_eq"
+        )
+        n = 10
+        H, g, A, b, C, u, l = generate_mixed_qp(n)
+        n_eq = A.shape[0]
+        n_in = C.shape[0]
+        rho = 1.E-7
+        mu_eq = 1.E-4
+        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        Qp.settings.eps_abs = 1.0e-9
+        Qp.settings.verbose = False
+        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        Qp.init(
+            H,
+            np.asfortranarray(g),
+            A,
+            np.asfortranarray(b),
+            C,
+            np.asfortranarray(u),
+            np.asfortranarray(l),
+            True,
+            rho=rho,
+            mu_eq=mu_eq
+        )
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        assert np.abs(rho - Qp.settings.default_rho) <1.E-9
+        assert np.abs(rho - Qp.results.info.rho) <1.E-9
+        assert np.abs(mu_eq - Qp.settings.default_mu_eq) <1.E-9
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+        Qp.update(mu_eq = 1.E-3,rho=1.E-6)
+        assert np.abs(1.E-6 - Qp.settings.default_rho) <1.E-9
+        assert np.abs(1.E-6 - Qp.results.info.rho) <1.E-9
+        assert np.abs(1.E-3 - Qp.settings.default_mu_eq) <1.E-9
+        Qp.solve()
+        dua_res = normInf(
+            H @ Qp.results.x
+            + g
+            + A.transpose() @ Qp.results.y
+            + C.transpose() @ Qp.results.z
+        )
+        pri_res = max(
+            normInf(A @ Qp.results.x - b),
+            normInf(
+                np.maximum(C @ Qp.results.x - u, 0)
+                + np.minimum(C @ Qp.results.x - l, 0)
+            ),
+        )
+        assert dua_res <= 1e-9
+        assert pri_res <= 1e-9
+
+
+
     def test_sparse_problem_with_exact_solution_known(self):
         print(
             "------------------------sparse random strongly convex qp with inequality constraints and exact solution known"

--- a/test/src/sparse_qp_wrapper.py
+++ b/test/src/sparse_qp_wrapper.py
@@ -44,7 +44,7 @@ def generate_mixed_qp(n, seed=1):
     return P, q, A[:n_eq, :], u[:n_eq], A[n_in:, :], u[n_in:], l[n_in:]
 
 
-class SparseQpWrapper(unittest.TestCase):
+class SparseqpWrapper(unittest.TestCase):
 
     # TESTS OF GENERAL METHODS OF THE API
 
@@ -60,32 +60,32 @@ class SparseQpWrapper(unittest.TestCase):
         H_ = H != 0.0
         A_ = A != 0.0
         C_ = C != 0.0
-        Qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.init(H=H, g=g, A=A, b=b, C=C, u=u, l=l, rho=1.0e-7)
-        Qp.solve()
+        qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.init(H=H, g=g, A=A, b=b, C=C, u=u, l=l, rho=1.0e-7)
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -103,10 +103,10 @@ class SparseQpWrapper(unittest.TestCase):
         H_ = H != 0.0
         A_ = A != 0.0
         C_ = C != 0.0
-        Qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.init(
             H=H,
             g=np.asfortranarray(g),
             A=A,
@@ -116,29 +116,29 @@ class SparseQpWrapper(unittest.TestCase):
             l=np.asfortranarray(l),
             rho=1.0e-7,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -156,10 +156,10 @@ class SparseQpWrapper(unittest.TestCase):
         H_ = H != 0.0
         A_ = A != 0.0
         C_ = C != 0.0
-        Qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -169,29 +169,29 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             False,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -209,10 +209,10 @@ class SparseQpWrapper(unittest.TestCase):
         H_ = H != 0.0
         A_ = A != 0.0
         C_ = C != 0.0
-        Qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -222,29 +222,29 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -262,11 +262,11 @@ class SparseQpWrapper(unittest.TestCase):
         H_ = H != 0.0
         A_ = A != 0.0
         C_ = C != 0.0
-        Qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -275,29 +275,29 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(u),
             np.asfortranarray(l),
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -315,11 +315,11 @@ class SparseQpWrapper(unittest.TestCase):
         H_ = H != 0.0
         A_ = A != 0.0
         C_ = C != 0.0
-        Qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -329,34 +329,34 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
         g = np.random.randn(n)
         H *= 2.0  # too keep same sparsity structure
-        Qp.update(
+        qp.update(
             H,
             np.asfortranarray(g),
             A,
@@ -367,29 +367,29 @@ class SparseQpWrapper(unittest.TestCase):
             True,
         )
 
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -406,11 +406,11 @@ class SparseQpWrapper(unittest.TestCase):
         H_ = H != 0.0
         A_ = A != 0.0
         C_ = C != 0.0
-        Qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -422,29 +422,29 @@ class SparseQpWrapper(unittest.TestCase):
         x_wm = np.random.randn(n)
         y_wm = np.random.randn(n_eq)
         z_wm = np.random.randn(n_in)
-        Qp.solve(x_wm, y_wm, z_wm)
+        qp.solve(x_wm, y_wm, z_wm)
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -461,13 +461,13 @@ class SparseQpWrapper(unittest.TestCase):
         H_ = H != 0.0
         A_ = A != 0.0
         C_ = C != 0.0
-        Qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -476,36 +476,36 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(u),
             np.asfortranarray(l),
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert pri_res <= 1e-9
         assert dua_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
-        Qp2.init(
+        qp2 = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp2.init(
             H,
             np.asfortranarray(g),
             A,
@@ -515,65 +515,65 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
         )
 
-        x = Qp.results.x
-        y = Qp.results.y
-        z = Qp.results.z
-        Qp2.solve(x, y, z)
+        x = qp.results.x
+        y = qp.results.y
+        z = qp.results.z
+        qp2.solve(x, y, z)
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with Qp".format(
+            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with qp".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with Qp2".format(
+            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with qp2".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -590,13 +590,13 @@ class SparseQpWrapper(unittest.TestCase):
         H_ = H != 0.0
         A_ = A != 0.0
         C_ = C != 0.0
-        Qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -605,39 +605,39 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(u),
             np.asfortranarray(l),
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with Qp".format(
+            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with qp".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
-        Qp2 = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
-        Qp2.init(
+        qp2 = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp2.init(
             H,
             np.asfortranarray(g),
             A,
@@ -646,65 +646,65 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(u),
             np.asfortranarray(l),
         )
-        x = Qp.results.x
-        y = Qp.results.y
-        z = Qp.results.z
-        Qp2.solve(x, y, z)
+        x = qp.results.x
+        y = qp.results.y
+        z = qp.results.z
+        qp2.solve(x, y, z)
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with Qp".format(
+            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with qp".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with Qp2".format(
+            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with qp2".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -722,13 +722,13 @@ class SparseQpWrapper(unittest.TestCase):
         H_ = H != 0.0
         A_ = A != 0.0
         C_ = C != 0.0
-        Qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -738,41 +738,41 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with Qp".format(
+            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with qp".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
-        Qp2.init(
+        qp2 = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp2.init(
             H,
             np.asfortranarray(g),
             A,
@@ -782,32 +782,32 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             False,
         )
-        Qp2.solve()
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with Qp2".format(
+            "--n = {} ; n_eq = {} ; n_in = {} after warm starting with qp2".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -824,13 +824,13 @@ class SparseQpWrapper(unittest.TestCase):
         H_ = H != 0.0
         A_ = A != 0.0
         C_ = C != 0.0
-        Qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -840,81 +840,81 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
-        print("--n = {} ; n_eq = {} ; n_in = {} with Qp".format(n, n_eq, n_in))
+        print("--n = {} ; n_eq = {} ; n_in = {} with qp".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.update(update_preconditioner=True)
-        Qp.solve()
+        qp.update(update_preconditioner=True)
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} with Qp after update".format(
+            "--n = {} ; n_eq = {} ; n_in = {} with qp after update".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.sparse.QP(H_, A_, C_)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
-        Qp2.init(
+        qp2 = proxsuite.proxqp.sparse.QP(H_, A_, C_)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp2.init(
             H,
             np.asfortranarray(g),
             A,
@@ -924,58 +924,58 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             False,
         )
-        Qp2.solve()
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
-        print("--n = {} ; n_eq = {} ; n_in = {} with Qp2".format(n, n_eq, n_in))
+        print("--n = {} ; n_eq = {} ; n_in = {} with qp2".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2.update(update_preconditioner=False)
-        Qp2.solve()
+        qp2.update(update_preconditioner=False)
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
         print(
-            "--n = {} ; n_eq = {} ; n_in = {} with Qp2 after update".format(
+            "--n = {} ; n_eq = {} ; n_in = {} with qp2 after update".format(
                 n, n_eq, n_in
             )
         )
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -988,11 +988,11 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1002,29 +1002,29 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve(np.random.randn(n), np.random.randn(n_eq), np.random.randn(n_in))
+        qp.solve(np.random.randn(n), np.random.randn(n_eq), np.random.randn(n_in))
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert pri_res <= 1.0e-9
         assert dua_res <= 1.0e-9
-        print("--n = {} ; n_eq = {} ; n_in = {} with Qp".format(n, n_eq, n_in))
+        print("--n = {} ; n_eq = {} ; n_in = {} with qp".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -1039,11 +1039,11 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1053,44 +1053,44 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1098,25 +1098,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1124,25 +1124,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1150,10 +1150,10 @@ class SparseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -1166,13 +1166,13 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1182,44 +1182,44 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1227,25 +1227,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1253,25 +1253,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1279,10 +1279,10 @@ class SparseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -1297,13 +1297,13 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1313,48 +1313,48 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1362,25 +1362,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1388,25 +1388,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1414,10 +1414,10 @@ class SparseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -1430,11 +1430,11 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1444,48 +1444,48 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1493,25 +1493,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1519,25 +1519,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1545,10 +1545,10 @@ class SparseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -1561,11 +1561,11 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1575,48 +1575,48 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1624,25 +1624,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1650,25 +1650,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1676,10 +1676,10 @@ class SparseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -1692,11 +1692,11 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1706,49 +1706,49 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
-        Qp.init(H, g, A, b, C, u, l)
-        Qp.solve()
+        qp.init(H, g, A, b, C, u, l)
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
 
-        Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z)
+        qp.solve(qp.results.x, qp.results.y, qp.results.z)
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1756,25 +1756,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z)
+        qp.solve(qp.results.x, qp.results.y, qp.results.z)
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1782,25 +1782,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z)
+        qp.solve(qp.results.x, qp.results.y, qp.results.z)
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1808,10 +1808,10 @@ class SparseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -1824,11 +1824,11 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1838,51 +1838,51 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
-        Qp.init(H, g, A, b, C, u, l)
-        Qp.solve()
+        qp.init(H, g, A, b, C, u, l)
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp2.init(H, g, A, b, C, u, l)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
-        Qp2.solve(Qp.results.x, Qp.results.y, Qp.results.z)
+        qp2 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp2.init(H, g, A, b, C, u, l)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp2.solve(qp.results.x, qp.results.y, qp.results.z)
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1890,10 +1890,10 @@ class SparseQpWrapper(unittest.TestCase):
         print("Second solve with new QP object")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp2.results.info.iter))
+        print("total number of iteration: {}".format(qp2.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp2.results.info.setup_time, Qp2.results.info.solve_time
+                qp2.results.info.setup_time, qp2.results.info.solve_time
             )
         )
 
@@ -1908,11 +1908,11 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1922,36 +1922,36 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
         H *= 2.0  # keep same sparsity structure
         g = np.random.randn(n)
         update_preconditioner = True
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -1961,18 +1961,18 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             update_preconditioner,
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -1980,25 +1980,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2006,25 +2006,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2032,10 +2032,10 @@ class SparseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -2050,13 +2050,13 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2066,36 +2066,36 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
         H *= 2.0  # keep same sparsity structure
         g = np.random.randn(n)
         update_preconditioner = True
-        Qp.update(
+        qp.update(
             H,
             np.asfortranarray(g),
             A,
@@ -2105,18 +2105,18 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             update_preconditioner,
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2124,25 +2124,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2150,25 +2150,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2176,10 +2176,10 @@ class SparseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -2194,13 +2194,13 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2210,40 +2210,40 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
 
         H *= 2.0  # keep same sparsity structure
         g = np.random.randn(n)
         update_preconditioner = True
-        Qp.update(
+        qp.update(
             H,
             np.asfortranarray(g),
             A,
@@ -2253,18 +2253,18 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             update_preconditioner,
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2272,25 +2272,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2298,25 +2298,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2324,10 +2324,10 @@ class SparseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -2342,11 +2342,11 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2356,40 +2356,40 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
 
         H *= 2.0  # keep same sparsity structure
         g = np.random.randn(n)
         update_preconditioner = True
-        Qp.update(
+        qp.update(
             H,
             np.asfortranarray(g),
             A,
@@ -2399,18 +2399,18 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             update_preconditioner,
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2418,25 +2418,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2444,25 +2444,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2470,10 +2470,10 @@ class SparseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -2488,11 +2488,11 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2502,76 +2502,76 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = (
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
 
         H *= 2  # keep same sparsity structure
         g = np.random.randn(n)
-        Qp.update(H=H, g=np.asfortranarray(g), update_preconditioner=True)
-        Qp.solve()
+        qp.update(H=H, g=np.asfortranarray(g), update_preconditioner=True)
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2579,25 +2579,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2605,10 +2605,10 @@ class SparseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -2621,11 +2621,11 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2635,38 +2635,38 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
 
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.WARM_START
 
         H *= 2.0  # keep same sparsity structure
         g = np.random.randn(n)
         update_preconditioner = True
-        Qp.update(
+        qp.update(
             H,
             np.asfortranarray(g),
             A,
@@ -2676,18 +2676,18 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             update_preconditioner,
         )
-        Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z)
+        qp.solve(qp.results.x, qp.results.y, qp.results.z)
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2695,25 +2695,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Second solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z)
+        qp.solve(qp.results.x, qp.results.y, qp.results.z)
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2721,25 +2721,25 @@ class SparseQpWrapper(unittest.TestCase):
         print("Third solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp.solve(Qp.results.x, Qp.results.y, Qp.results.z)
+        qp.solve(qp.results.x, qp.results.y, qp.results.z)
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -2747,10 +2747,10 @@ class SparseQpWrapper(unittest.TestCase):
         print("Fourth solve ")
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -2763,11 +2763,11 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2778,39 +2778,39 @@ class SparseQpWrapper(unittest.TestCase):
             True,
             rho=1.0e-7,
         )
-        Qp.solve()
-        assert Qp.results.info.rho == 1.0e-7
+        qp.solve()
+        assert qp.results.info.rho == 1.0e-7
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = (
+        qp2 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
-        Qp2.init(
+        qp2.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2821,39 +2821,39 @@ class SparseQpWrapper(unittest.TestCase):
             True,
             rho=1.0e-7,
         )
-        Qp2.solve()
-        assert Qp2.results.info.rho == 1.0e-7
+        qp2.solve()
+        assert qp2.results.info.rho == 1.0e-7
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp2.results.info.iter))
+        print("total number of iteration: {}".format(qp2.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp2.results.info.setup_time, Qp2.results.info.solve_time
+                qp2.results.info.setup_time, qp2.results.info.solve_time
             )
         )
 
-        Qp3 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp3.settings.eps_abs = 1.0e-9
-        Qp3.settings.verbose = False
-        Qp3.settings.initial_guess = (
+        qp3 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp3.settings.eps_abs = 1.0e-9
+        qp3.settings.verbose = False
+        qp3.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp3.init(
+        qp3.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2864,39 +2864,39 @@ class SparseQpWrapper(unittest.TestCase):
             True,
             rho=1.0e-7,
         )
-        Qp3.solve()
-        assert Qp.results.info.rho == 1.0e-7
+        qp3.solve()
+        assert qp.results.info.rho == 1.0e-7
         dua_res = normInf(
-            H @ Qp3.results.x
+            H @ qp3.results.x
             + g
-            + A.transpose() @ Qp3.results.y
-            + C.transpose() @ Qp3.results.z
+            + A.transpose() @ qp3.results.y
+            + C.transpose() @ qp3.results.z
         )
         pri_res = max(
-            normInf(A @ Qp3.results.x - b),
+            normInf(A @ qp3.results.x - b),
             normInf(
-                np.maximum(C @ Qp3.results.x - u, 0)
-                + np.minimum(C @ Qp3.results.x - l, 0)
+                np.maximum(C @ qp3.results.x - u, 0)
+                + np.minimum(C @ qp3.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp3.results.info.iter))
+        print("total number of iteration: {}".format(qp3.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp3.results.info.setup_time, Qp3.results.info.solve_time
+                qp3.results.info.setup_time, qp3.results.info.solve_time
             )
         )
 
-        Qp4 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp4.settings.eps_abs = 1.0e-9
-        Qp4.settings.verbose = False
-        Qp4.settings.initial_guess = (
+        qp4 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp4.settings.eps_abs = 1.0e-9
+        qp4.settings.verbose = False
+        qp4.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
-        Qp4.init(
+        qp4.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2907,37 +2907,37 @@ class SparseQpWrapper(unittest.TestCase):
             True,
             rho=1.0e-7,
         )
-        Qp4.solve()
-        assert Qp4.results.info.rho == 1.0e-7
+        qp4.solve()
+        assert qp4.results.info.rho == 1.0e-7
         dua_res = normInf(
-            H @ Qp4.results.x
+            H @ qp4.results.x
             + g
-            + A.transpose() @ Qp4.results.y
-            + C.transpose() @ Qp4.results.z
+            + A.transpose() @ qp4.results.y
+            + C.transpose() @ qp4.results.z
         )
         pri_res = max(
-            normInf(A @ Qp4.results.x - b),
+            normInf(A @ qp4.results.x - b),
             normInf(
-                np.maximum(C @ Qp4.results.x - u, 0)
-                + np.minimum(C @ Qp4.results.x - l, 0)
+                np.maximum(C @ qp4.results.x - u, 0)
+                + np.minimum(C @ qp4.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp4.results.info.iter))
+        print("total number of iteration: {}".format(qp4.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp4.results.info.setup_time, Qp4.results.info.solve_time
+                qp4.results.info.setup_time, qp4.results.info.solve_time
             )
         )
 
-        Qp5 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp5.settings.eps_abs = 1.0e-9
-        Qp5.settings.verbose = False
-        Qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp5.init(
+        qp5 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp5.settings.eps_abs = 1.0e-9
+        qp5.settings.verbose = False
+        qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp5.init(
             H,
             np.asfortranarray(g),
             A,
@@ -2948,29 +2948,29 @@ class SparseQpWrapper(unittest.TestCase):
             True,
             rho=1.0e-7,
         )
-        Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z)
-        assert Qp.results.info.rho == 1.0e-7
+        qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z)
+        assert qp.results.info.rho == 1.0e-7
         dua_res = normInf(
-            H @ Qp5.results.x
+            H @ qp5.results.x
             + g
-            + A.transpose() @ Qp5.results.y
-            + C.transpose() @ Qp5.results.z
+            + A.transpose() @ qp5.results.y
+            + C.transpose() @ qp5.results.z
         )
         pri_res = max(
-            normInf(A @ Qp5.results.x - b),
+            normInf(A @ qp5.results.x - b),
             normInf(
-                np.maximum(C @ Qp5.results.x - u, 0)
-                + np.minimum(C @ Qp5.results.x - l, 0)
+                np.maximum(C @ qp5.results.x - u, 0)
+                + np.minimum(C @ qp5.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp5.results.info.iter))
+        print("total number of iteration: {}".format(qp5.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp5.results.info.setup_time, Qp5.results.info.solve_time
+                qp5.results.info.setup_time, qp5.results.info.solve_time
             )
         )
 
@@ -2983,11 +2983,11 @@ class SparseQpWrapper(unittest.TestCase):
         H, g_old, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g_old),
             A,
@@ -2997,57 +2997,57 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
         g = np.random.randn(n)
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g_old
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(g=g)
-        assert normInf(Qp.model.g - g) <= 1.0e-9
-        Qp.solve()
+        qp.update(g=g)
+        assert normInf(qp.model.g - g) <= 1.0e-9
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = (
+        qp2 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
-        Qp2.init(
+        qp2.init(
             H,
             np.asfortranarray(g_old),
             A,
@@ -3057,56 +3057,56 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp2.solve()
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g_old
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp2.update(g=g)
-        assert normInf(Qp.model.g - g) <= 1.0e-9
-        Qp2.solve()
+        qp2.update(g=g)
+        assert normInf(qp.model.g - g) <= 1.0e-9
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp2.results.info.iter))
+        print("total number of iteration: {}".format(qp2.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp2.results.info.setup_time, Qp2.results.info.solve_time
+                qp2.results.info.setup_time, qp2.results.info.solve_time
             )
         )
 
-        Qp3 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp3.settings.eps_abs = 1.0e-9
-        Qp3.settings.verbose = False
-        Qp3.settings.initial_guess = (
+        qp3 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp3.settings.eps_abs = 1.0e-9
+        qp3.settings.verbose = False
+        qp3.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp3.init(
+        qp3.init(
             H,
             np.asfortranarray(g_old),
             A,
@@ -3116,56 +3116,56 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp3.solve()
+        qp3.solve()
         dua_res = normInf(
-            H @ Qp3.results.x
+            H @ qp3.results.x
             + g_old
-            + A.transpose() @ Qp3.results.y
-            + C.transpose() @ Qp3.results.z
+            + A.transpose() @ qp3.results.y
+            + C.transpose() @ qp3.results.z
         )
         pri_res = max(
-            normInf(A @ Qp3.results.x - b),
+            normInf(A @ qp3.results.x - b),
             normInf(
-                np.maximum(C @ Qp3.results.x - u, 0)
-                + np.minimum(C @ Qp3.results.x - l, 0)
+                np.maximum(C @ qp3.results.x - u, 0)
+                + np.minimum(C @ qp3.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp3.update(g=g)
-        assert normInf(Qp.model.g - g) <= 1.0e-9
-        Qp3.solve()
+        qp3.update(g=g)
+        assert normInf(qp.model.g - g) <= 1.0e-9
+        qp3.solve()
         dua_res = normInf(
-            H @ Qp3.results.x
+            H @ qp3.results.x
             + g
-            + A.transpose() @ Qp3.results.y
-            + C.transpose() @ Qp3.results.z
+            + A.transpose() @ qp3.results.y
+            + C.transpose() @ qp3.results.z
         )
         pri_res = max(
-            normInf(A @ Qp3.results.x - b),
+            normInf(A @ qp3.results.x - b),
             normInf(
-                np.maximum(C @ Qp3.results.x - u, 0)
-                + np.minimum(C @ Qp3.results.x - l, 0)
+                np.maximum(C @ qp3.results.x - u, 0)
+                + np.minimum(C @ qp3.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp3.results.info.iter))
+        print("total number of iteration: {}".format(qp3.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp3.results.info.setup_time, Qp3.results.info.solve_time
+                qp3.results.info.setup_time, qp3.results.info.solve_time
             )
         )
 
-        Qp4 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp4.settings.eps_abs = 1.0e-9
-        Qp4.settings.verbose = False
-        Qp4.settings.initial_guess = (
+        qp4 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp4.settings.eps_abs = 1.0e-9
+        qp4.settings.verbose = False
+        qp4.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
-        Qp4.init(
+        qp4.init(
             H,
             np.asfortranarray(g_old),
             A,
@@ -3175,54 +3175,54 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp4.solve()
+        qp4.solve()
         dua_res = normInf(
-            H @ Qp4.results.x
+            H @ qp4.results.x
             + g_old
-            + A.transpose() @ Qp4.results.y
-            + C.transpose() @ Qp4.results.z
+            + A.transpose() @ qp4.results.y
+            + C.transpose() @ qp4.results.z
         )
         pri_res = max(
-            normInf(A @ Qp4.results.x - b),
+            normInf(A @ qp4.results.x - b),
             normInf(
-                np.maximum(C @ Qp4.results.x - u, 0)
-                + np.minimum(C @ Qp4.results.x - l, 0)
+                np.maximum(C @ qp4.results.x - u, 0)
+                + np.minimum(C @ qp4.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp4.update(g=g)
-        assert normInf(Qp.model.g - g) <= 1.0e-9
-        Qp4.solve()
+        qp4.update(g=g)
+        assert normInf(qp.model.g - g) <= 1.0e-9
+        qp4.solve()
         dua_res = normInf(
-            H @ Qp4.results.x
+            H @ qp4.results.x
             + g
-            + A.transpose() @ Qp4.results.y
-            + C.transpose() @ Qp4.results.z
+            + A.transpose() @ qp4.results.y
+            + C.transpose() @ qp4.results.z
         )
         pri_res = max(
-            normInf(A @ Qp4.results.x - b),
+            normInf(A @ qp4.results.x - b),
             normInf(
-                np.maximum(C @ Qp4.results.x - u, 0)
-                + np.minimum(C @ Qp4.results.x - l, 0)
+                np.maximum(C @ qp4.results.x - u, 0)
+                + np.minimum(C @ qp4.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp4.results.info.iter))
+        print("total number of iteration: {}".format(qp4.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp4.results.info.setup_time, Qp4.results.info.solve_time
+                qp4.results.info.setup_time, qp4.results.info.solve_time
             )
         )
 
-        Qp5 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp5.settings.eps_abs = 1.0e-9
-        Qp5.settings.verbose = False
-        Qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp5.init(
+        qp5 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp5.settings.eps_abs = 1.0e-9
+        qp5.settings.verbose = False
+        qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp5.init(
             H,
             np.asfortranarray(g_old),
             A,
@@ -3232,46 +3232,46 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z)
+        qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z)
         dua_res = normInf(
-            H @ Qp5.results.x
+            H @ qp5.results.x
             + g_old
-            + A.transpose() @ Qp5.results.y
-            + C.transpose() @ Qp5.results.z
+            + A.transpose() @ qp5.results.y
+            + C.transpose() @ qp5.results.z
         )
         pri_res = max(
-            normInf(A @ Qp5.results.x - b),
+            normInf(A @ qp5.results.x - b),
             normInf(
-                np.maximum(C @ Qp5.results.x - u, 0)
-                + np.minimum(C @ Qp5.results.x - l, 0)
+                np.maximum(C @ qp5.results.x - u, 0)
+                + np.minimum(C @ qp5.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp5.update(g=g)
-        assert normInf(Qp.model.g - g) <= 1.0e-9
-        Qp5.solve()
+        qp5.update(g=g)
+        assert normInf(qp.model.g - g) <= 1.0e-9
+        qp5.solve()
         dua_res = normInf(
-            H @ Qp5.results.x
+            H @ qp5.results.x
             + g
-            + A.transpose() @ Qp5.results.y
-            + C.transpose() @ Qp5.results.z
+            + A.transpose() @ qp5.results.y
+            + C.transpose() @ qp5.results.z
         )
         pri_res = max(
-            normInf(A @ Qp5.results.x - b),
+            normInf(A @ qp5.results.x - b),
             normInf(
-                np.maximum(C @ Qp5.results.x - u, 0)
-                + np.minimum(C @ Qp5.results.x - l, 0)
+                np.maximum(C @ qp5.results.x - u, 0)
+                + np.minimum(C @ qp5.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp5.results.info.iter))
+        print("total number of iteration: {}".format(qp5.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp5.results.info.setup_time, Qp5.results.info.solve_time
+                qp5.results.info.setup_time, qp5.results.info.solve_time
             )
         )
 
@@ -3284,11 +3284,11 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A_old, b, C, u, l = generate_mixed_qp(n)
         n_eq = A_old.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A_old,
@@ -3298,56 +3298,56 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
         A = 2 * A_old  # keep same sparsity structure
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A_old.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A_old.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A_old @ Qp.results.x - b),
+            normInf(A_old @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(A=A)
-        Qp.solve()
+        qp.update(A=A)
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = (
+        qp2 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
-        Qp2.init(
+        qp2.init(
             H,
             np.asfortranarray(g),
             A_old,
@@ -3357,55 +3357,55 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp2.solve()
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A_old.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A_old.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A_old @ Qp2.results.x - b),
+            normInf(A_old @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp2.update(A=A)
-        Qp2.solve()
+        qp2.update(A=A)
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp2.results.info.iter))
+        print("total number of iteration: {}".format(qp2.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp2.results.info.setup_time, Qp2.results.info.solve_time
+                qp2.results.info.setup_time, qp2.results.info.solve_time
             )
         )
 
-        Qp3 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp3.settings.eps_abs = 1.0e-9
-        Qp3.settings.verbose = False
-        Qp3.settings.initial_guess = (
+        qp3 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp3.settings.eps_abs = 1.0e-9
+        qp3.settings.verbose = False
+        qp3.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp3.init(
+        qp3.init(
             H,
             np.asfortranarray(g),
             A_old,
@@ -3415,55 +3415,55 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp3.solve()
+        qp3.solve()
         dua_res = normInf(
-            H @ Qp3.results.x
+            H @ qp3.results.x
             + g
-            + A_old.transpose() @ Qp3.results.y
-            + C.transpose() @ Qp3.results.z
+            + A_old.transpose() @ qp3.results.y
+            + C.transpose() @ qp3.results.z
         )
         pri_res = max(
-            normInf(A_old @ Qp3.results.x - b),
+            normInf(A_old @ qp3.results.x - b),
             normInf(
-                np.maximum(C @ Qp3.results.x - u, 0)
-                + np.minimum(C @ Qp3.results.x - l, 0)
+                np.maximum(C @ qp3.results.x - u, 0)
+                + np.minimum(C @ qp3.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp3.update(A=A)
-        Qp3.solve()
+        qp3.update(A=A)
+        qp3.solve()
         dua_res = normInf(
-            H @ Qp3.results.x
+            H @ qp3.results.x
             + g
-            + A.transpose() @ Qp3.results.y
-            + C.transpose() @ Qp3.results.z
+            + A.transpose() @ qp3.results.y
+            + C.transpose() @ qp3.results.z
         )
         pri_res = max(
-            normInf(A @ Qp3.results.x - b),
+            normInf(A @ qp3.results.x - b),
             normInf(
-                np.maximum(C @ Qp3.results.x - u, 0)
-                + np.minimum(C @ Qp3.results.x - l, 0)
+                np.maximum(C @ qp3.results.x - u, 0)
+                + np.minimum(C @ qp3.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp3.results.info.iter))
+        print("total number of iteration: {}".format(qp3.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp3.results.info.setup_time, Qp3.results.info.solve_time
+                qp3.results.info.setup_time, qp3.results.info.solve_time
             )
         )
 
-        Qp4 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp4.settings.eps_abs = 1.0e-9
-        Qp4.settings.verbose = False
-        Qp4.settings.initial_guess = (
+        qp4 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp4.settings.eps_abs = 1.0e-9
+        qp4.settings.verbose = False
+        qp4.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
-        Qp4.init(
+        qp4.init(
             H,
             np.asfortranarray(g),
             A_old,
@@ -3473,53 +3473,53 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp4.solve()
+        qp4.solve()
         dua_res = normInf(
-            H @ Qp4.results.x
+            H @ qp4.results.x
             + g
-            + A_old.transpose() @ Qp4.results.y
-            + C.transpose() @ Qp4.results.z
+            + A_old.transpose() @ qp4.results.y
+            + C.transpose() @ qp4.results.z
         )
         pri_res = max(
-            normInf(A_old @ Qp4.results.x - b),
+            normInf(A_old @ qp4.results.x - b),
             normInf(
-                np.maximum(C @ Qp4.results.x - u, 0)
-                + np.minimum(C @ Qp4.results.x - l, 0)
+                np.maximum(C @ qp4.results.x - u, 0)
+                + np.minimum(C @ qp4.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp4.update(A=A)
-        Qp4.solve()
+        qp4.update(A=A)
+        qp4.solve()
         dua_res = normInf(
-            H @ Qp4.results.x
+            H @ qp4.results.x
             + g
-            + A.transpose() @ Qp4.results.y
-            + C.transpose() @ Qp4.results.z
+            + A.transpose() @ qp4.results.y
+            + C.transpose() @ qp4.results.z
         )
         pri_res = max(
-            normInf(A @ Qp4.results.x - b),
+            normInf(A @ qp4.results.x - b),
             normInf(
-                np.maximum(C @ Qp4.results.x - u, 0)
-                + np.minimum(C @ Qp4.results.x - l, 0)
+                np.maximum(C @ qp4.results.x - u, 0)
+                + np.minimum(C @ qp4.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp4.results.info.iter))
+        print("total number of iteration: {}".format(qp4.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp4.results.info.setup_time, Qp4.results.info.solve_time
+                qp4.results.info.setup_time, qp4.results.info.solve_time
             )
         )
 
-        Qp5 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp5.settings.eps_abs = 1.0e-9
-        Qp5.settings.verbose = False
-        Qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp5.init(
+        qp5 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp5.settings.eps_abs = 1.0e-9
+        qp5.settings.verbose = False
+        qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp5.init(
             H,
             np.asfortranarray(g),
             A_old,
@@ -3529,45 +3529,45 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z)
+        qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z)
         dua_res = normInf(
-            H @ Qp5.results.x
+            H @ qp5.results.x
             + g
-            + A_old.transpose() @ Qp5.results.y
-            + C.transpose() @ Qp5.results.z
+            + A_old.transpose() @ qp5.results.y
+            + C.transpose() @ qp5.results.z
         )
         pri_res = max(
-            normInf(A_old @ Qp5.results.x - b),
+            normInf(A_old @ qp5.results.x - b),
             normInf(
-                np.maximum(C @ Qp5.results.x - u, 0)
-                + np.minimum(C @ Qp5.results.x - l, 0)
+                np.maximum(C @ qp5.results.x - u, 0)
+                + np.minimum(C @ qp5.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp5.update(A=A)
-        Qp5.solve()
+        qp5.update(A=A)
+        qp5.solve()
         dua_res = normInf(
-            H @ Qp5.results.x
+            H @ qp5.results.x
             + g
-            + A.transpose() @ Qp5.results.y
-            + C.transpose() @ Qp5.results.z
+            + A.transpose() @ qp5.results.y
+            + C.transpose() @ qp5.results.z
         )
         pri_res = max(
-            normInf(A @ Qp5.results.x - b),
+            normInf(A @ qp5.results.x - b),
             normInf(
-                np.maximum(C @ Qp5.results.x - u, 0)
-                + np.minimum(C @ Qp5.results.x - l, 0)
+                np.maximum(C @ qp5.results.x - u, 0)
+                + np.minimum(C @ qp5.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp5.results.info.iter))
+        print("total number of iteration: {}".format(qp5.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp5.results.info.setup_time, Qp5.results.info.solve_time
+                qp5.results.info.setup_time, qp5.results.info.solve_time
             )
         )
 
@@ -3580,11 +3580,11 @@ class SparseQpWrapper(unittest.TestCase):
         H, g, A, b, C, u, l = generate_mixed_qp(n)
         n_eq = A.shape[0]
         n_in = C.shape[0]
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -3594,56 +3594,56 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp.solve()
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(rho=1.0e-7)
-        assert Qp.results.info.rho == 1.0e-7
-        Qp.solve()
+        qp.update(rho=1.0e-7)
+        assert qp.results.info.rho == 1.0e-7
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
-        Qp2 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp2.settings.eps_abs = 1.0e-9
-        Qp2.settings.verbose = False
-        Qp2.settings.initial_guess = (
+        qp2 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp2.settings.eps_abs = 1.0e-9
+        qp2.settings.verbose = False
+        qp2.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
-        Qp2.init(
+        qp2.init(
             H,
             np.asfortranarray(g),
             A,
@@ -3653,56 +3653,56 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp2.solve()
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp2.update(rho=1.0e-7)
-        assert Qp2.results.info.rho == 1.0e-7
-        Qp2.solve()
+        qp2.update(rho=1.0e-7)
+        assert qp2.results.info.rho == 1.0e-7
+        qp2.solve()
         dua_res = normInf(
-            H @ Qp2.results.x
+            H @ qp2.results.x
             + g
-            + A.transpose() @ Qp2.results.y
-            + C.transpose() @ Qp2.results.z
+            + A.transpose() @ qp2.results.y
+            + C.transpose() @ qp2.results.z
         )
         pri_res = max(
-            normInf(A @ Qp2.results.x - b),
+            normInf(A @ qp2.results.x - b),
             normInf(
-                np.maximum(C @ Qp2.results.x - u, 0)
-                + np.minimum(C @ Qp2.results.x - l, 0)
+                np.maximum(C @ qp2.results.x - u, 0)
+                + np.minimum(C @ qp2.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp2.results.info.iter))
+        print("total number of iteration: {}".format(qp2.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp2.results.info.setup_time, Qp2.results.info.solve_time
+                qp2.results.info.setup_time, qp2.results.info.solve_time
             )
         )
 
-        Qp3 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp3.settings.eps_abs = 1.0e-9
-        Qp3.settings.verbose = False
-        Qp3.settings.initial_guess = (
+        qp3 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp3.settings.eps_abs = 1.0e-9
+        qp3.settings.verbose = False
+        qp3.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp3.init(
+        qp3.init(
             H,
             np.asfortranarray(g),
             A,
@@ -3712,56 +3712,56 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp3.solve()
+        qp3.solve()
         dua_res = normInf(
-            H @ Qp3.results.x
+            H @ qp3.results.x
             + g
-            + A.transpose() @ Qp3.results.y
-            + C.transpose() @ Qp3.results.z
+            + A.transpose() @ qp3.results.y
+            + C.transpose() @ qp3.results.z
         )
         pri_res = max(
-            normInf(A @ Qp3.results.x - b),
+            normInf(A @ qp3.results.x - b),
             normInf(
-                np.maximum(C @ Qp3.results.x - u, 0)
-                + np.minimum(C @ Qp3.results.x - l, 0)
+                np.maximum(C @ qp3.results.x - u, 0)
+                + np.minimum(C @ qp3.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp3.update(rho=1.0e-7)
-        assert Qp3.results.info.rho == 1.0e-7
-        Qp3.solve()
+        qp3.update(rho=1.0e-7)
+        assert qp3.results.info.rho == 1.0e-7
+        qp3.solve()
         dua_res = normInf(
-            H @ Qp3.results.x
+            H @ qp3.results.x
             + g
-            + A.transpose() @ Qp3.results.y
-            + C.transpose() @ Qp3.results.z
+            + A.transpose() @ qp3.results.y
+            + C.transpose() @ qp3.results.z
         )
         pri_res = max(
-            normInf(A @ Qp3.results.x - b),
+            normInf(A @ qp3.results.x - b),
             normInf(
-                np.maximum(C @ Qp3.results.x - u, 0)
-                + np.minimum(C @ Qp3.results.x - l, 0)
+                np.maximum(C @ qp3.results.x - u, 0)
+                + np.minimum(C @ qp3.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp3.results.info.iter))
+        print("total number of iteration: {}".format(qp3.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp3.results.info.setup_time, Qp3.results.info.solve_time
+                qp3.results.info.setup_time, qp3.results.info.solve_time
             )
         )
 
-        Qp4 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp4.settings.eps_abs = 1.0e-9
-        Qp4.settings.verbose = False
-        Qp4.settings.initial_guess = (
+        qp4 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp4.settings.eps_abs = 1.0e-9
+        qp4.settings.verbose = False
+        qp4.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
-        Qp4.init(
+        qp4.init(
             H,
             np.asfortranarray(g),
             A,
@@ -3771,54 +3771,54 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp4.solve()
+        qp4.solve()
         dua_res = normInf(
-            H @ Qp4.results.x
+            H @ qp4.results.x
             + g
-            + A.transpose() @ Qp4.results.y
-            + C.transpose() @ Qp4.results.z
+            + A.transpose() @ qp4.results.y
+            + C.transpose() @ qp4.results.z
         )
         pri_res = max(
-            normInf(A @ Qp4.results.x - b),
+            normInf(A @ qp4.results.x - b),
             normInf(
-                np.maximum(C @ Qp4.results.x - u, 0)
-                + np.minimum(C @ Qp4.results.x - l, 0)
+                np.maximum(C @ qp4.results.x - u, 0)
+                + np.minimum(C @ qp4.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp4.update(rho=1.0e-7)
-        assert Qp4.results.info.rho == 1.0e-7
-        Qp4.solve()
+        qp4.update(rho=1.0e-7)
+        assert qp4.results.info.rho == 1.0e-7
+        qp4.solve()
         dua_res = normInf(
-            H @ Qp4.results.x
+            H @ qp4.results.x
             + g
-            + A.transpose() @ Qp4.results.y
-            + C.transpose() @ Qp4.results.z
+            + A.transpose() @ qp4.results.y
+            + C.transpose() @ qp4.results.z
         )
         pri_res = max(
-            normInf(A @ Qp4.results.x - b),
+            normInf(A @ qp4.results.x - b),
             normInf(
-                np.maximum(C @ Qp4.results.x - u, 0)
-                + np.minimum(C @ Qp4.results.x - l, 0)
+                np.maximum(C @ qp4.results.x - u, 0)
+                + np.minimum(C @ qp4.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp4.results.info.iter))
+        print("total number of iteration: {}".format(qp4.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp4.results.info.setup_time, Qp4.results.info.solve_time
+                qp4.results.info.setup_time, qp4.results.info.solve_time
             )
         )
 
-        Qp5 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp5.settings.eps_abs = 1.0e-9
-        Qp5.settings.verbose = False
-        Qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp5.init(
+        qp5 = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp5.settings.eps_abs = 1.0e-9
+        qp5.settings.verbose = False
+        qp5.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp5.init(
             H,
             np.asfortranarray(g),
             A,
@@ -3828,46 +3828,46 @@ class SparseQpWrapper(unittest.TestCase):
             np.asfortranarray(l),
             True,
         )
-        Qp5.solve(Qp3.results.x, Qp3.results.y, Qp3.results.z)
+        qp5.solve(qp3.results.x, qp3.results.y, qp3.results.z)
         dua_res = normInf(
-            H @ Qp5.results.x
+            H @ qp5.results.x
             + g
-            + A.transpose() @ Qp5.results.y
-            + C.transpose() @ Qp5.results.z
+            + A.transpose() @ qp5.results.y
+            + C.transpose() @ qp5.results.z
         )
         pri_res = max(
-            normInf(A @ Qp5.results.x - b),
+            normInf(A @ qp5.results.x - b),
             normInf(
-                np.maximum(C @ Qp5.results.x - u, 0)
-                + np.minimum(C @ Qp5.results.x - l, 0)
+                np.maximum(C @ qp5.results.x - u, 0)
+                + np.minimum(C @ qp5.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp5.update(rho=1.0e-7)
-        assert Qp5.results.info.rho == 1.0e-7
-        Qp5.solve()
+        qp5.update(rho=1.0e-7)
+        assert qp5.results.info.rho == 1.0e-7
+        qp5.solve()
         dua_res = normInf(
-            H @ Qp5.results.x
+            H @ qp5.results.x
             + g
-            + A.transpose() @ Qp5.results.y
-            + C.transpose() @ Qp5.results.z
+            + A.transpose() @ qp5.results.y
+            + C.transpose() @ qp5.results.z
         )
         pri_res = max(
-            normInf(A @ Qp5.results.x - b),
+            normInf(A @ qp5.results.x - b),
             normInf(
-                np.maximum(C @ Qp5.results.x - u, 0)
-                + np.minimum(C @ Qp5.results.x - l, 0)
+                np.maximum(C @ qp5.results.x - u, 0)
+                + np.minimum(C @ qp5.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, n_eq, n_in))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp5.results.info.iter))
+        print("total number of iteration: {}".format(qp5.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp5.results.info.setup_time, Qp5.results.info.solve_time
+                qp5.results.info.setup_time, qp5.results.info.solve_time
             )
         )
 
@@ -3883,11 +3883,11 @@ class SparseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -3899,44 +3899,44 @@ class SparseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         for i in range(10):
-            Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+            qp.solve()
+            assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
-                H @ Qp.results.x
+                H @ qp.results.x
                 + g
-                + A.transpose() @ Qp.results.y
-                + C.transpose() @ Qp.results.z
+                + A.transpose() @ qp.results.y
+                + C.transpose() @ qp.results.z
             )
             pri_res = max(
-                normInf(A @ Qp.results.x - b),
+                normInf(A @ qp.results.x - b),
                 normInf(
-                    np.maximum(C @ Qp.results.x - u, 0)
-                    + np.minimum(C @ Qp.results.x - l, 0)
+                    np.maximum(C @ qp.results.x - u, 0)
+                    + np.minimum(C @ qp.results.x - l, 0)
                 ),
             )
             assert dua_res <= 1e-9
@@ -3954,13 +3954,13 @@ class SparseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -3972,44 +3972,44 @@ class SparseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         for i in range(10):
-            Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+            qp.solve()
+            assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
-                H @ Qp.results.x
+                H @ qp.results.x
                 + g
-                + A.transpose() @ Qp.results.y
-                + C.transpose() @ Qp.results.z
+                + A.transpose() @ qp.results.y
+                + C.transpose() @ qp.results.z
             )
             pri_res = max(
-                normInf(A @ Qp.results.x - b),
+                normInf(A @ qp.results.x - b),
                 normInf(
-                    np.maximum(C @ Qp.results.x - u, 0)
-                    + np.minimum(C @ Qp.results.x - l, 0)
+                    np.maximum(C @ qp.results.x - u, 0)
+                    + np.minimum(C @ qp.results.x - l, 0)
                 ),
             )
             assert dua_res <= 1e-9
@@ -4027,13 +4027,13 @@ class SparseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -4045,44 +4045,44 @@ class SparseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         for i in range(10):
-            Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+            qp.solve()
+            assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
-                H @ Qp.results.x
+                H @ qp.results.x
                 + g
-                + A.transpose() @ Qp.results.y
-                + C.transpose() @ Qp.results.z
+                + A.transpose() @ qp.results.y
+                + C.transpose() @ qp.results.z
             )
             pri_res = max(
-                normInf(A @ Qp.results.x - b),
+                normInf(A @ qp.results.x - b),
                 normInf(
-                    np.maximum(C @ Qp.results.x - u, 0)
-                    + np.minimum(C @ Qp.results.x - l, 0)
+                    np.maximum(C @ qp.results.x - u, 0)
+                    + np.minimum(C @ qp.results.x - l, 0)
                 ),
             )
             assert dua_res <= 1e-9
@@ -4100,13 +4100,13 @@ class SparseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -4118,44 +4118,44 @@ class SparseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
         for i in range(10):
-            Qp.solve()
-            assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-            assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-            assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+            qp.solve()
+            assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+            assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+            assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
             dua_res = normInf(
-                H @ Qp.results.x
+                H @ qp.results.x
                 + g
-                + A.transpose() @ Qp.results.y
-                + C.transpose() @ Qp.results.z
+                + A.transpose() @ qp.results.y
+                + C.transpose() @ qp.results.z
             )
             pri_res = max(
-                normInf(A @ Qp.results.x - b),
+                normInf(A @ qp.results.x - b),
                 normInf(
-                    np.maximum(C @ Qp.results.x - u, 0)
-                    + np.minimum(C @ Qp.results.x - l, 0)
+                    np.maximum(C @ qp.results.x - u, 0)
+                    + np.minimum(C @ qp.results.x - l, 0)
                 ),
             )
             assert dua_res <= 1e-9
@@ -4173,13 +4173,13 @@ class SparseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.WARM_START_WITH_PREVIOUS_RESULT
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -4191,44 +4191,44 @@ class SparseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
-        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
+        qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -4246,13 +4246,13 @@ class SparseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.COLD_START_WITH_PREVIOUS_RESULT
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -4264,44 +4264,44 @@ class SparseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
-        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
+        qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -4319,13 +4319,13 @@ class SparseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = (
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = (
             proxsuite.proxqp.InitialGuess.EQUALITY_CONSTRAINED_INITIAL_GUESS
         )
-        Qp.init(
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -4337,44 +4337,44 @@ class SparseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
-        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
+        qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -4392,11 +4392,11 @@ class SparseQpWrapper(unittest.TestCase):
         n_in = C.shape[0]
         rho = 1.0e-7
         mu_eq = 1.0e-4
-        Qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
-        Qp.settings.eps_abs = 1.0e-9
-        Qp.settings.verbose = False
-        Qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
-        Qp.init(
+        qp = proxsuite.proxqp.sparse.QP(n, n_eq, n_in)
+        qp.settings.eps_abs = 1.0e-9
+        qp.settings.verbose = False
+        qp.settings.initial_guess = proxsuite.proxqp.InitialGuess.NO_INITIAL_GUESS
+        qp.init(
             H,
             np.asfortranarray(g),
             A,
@@ -4408,44 +4408,44 @@ class SparseQpWrapper(unittest.TestCase):
             rho=rho,
             mu_eq=mu_eq,
         )
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
-        assert np.abs(rho - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(rho - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(mu_eq - Qp.settings.default_mu_eq) < 1.0e-9
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
+        assert np.abs(rho - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(rho - qp.results.info.rho) < 1.0e-9
+        assert np.abs(mu_eq - qp.settings.default_mu_eq) < 1.0e-9
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
         assert pri_res <= 1e-9
-        Qp.update(mu_eq=1.0e-3, rho=1.0e-6)
-        assert np.abs(1.0e-6 - Qp.settings.default_rho) < 1.0e-9
-        assert np.abs(1.0e-6 - Qp.results.info.rho) < 1.0e-9
-        assert np.abs(1.0e-3 - Qp.settings.default_mu_eq) < 1.0e-9
-        Qp.solve()
+        qp.update(mu_eq=1.0e-3, rho=1.0e-6)
+        assert np.abs(1.0e-6 - qp.settings.default_rho) < 1.0e-9
+        assert np.abs(1.0e-6 - qp.results.info.rho) < 1.0e-9
+        assert np.abs(1.0e-3 - qp.settings.default_mu_eq) < 1.0e-9
+        qp.solve()
         dua_res = normInf(
-            H @ Qp.results.x
+            H @ qp.results.x
             + g
-            + A.transpose() @ Qp.results.y
-            + C.transpose() @ Qp.results.z
+            + A.transpose() @ qp.results.y
+            + C.transpose() @ qp.results.z
         )
         pri_res = max(
-            normInf(A @ Qp.results.x - b),
+            normInf(A @ qp.results.x - b),
             normInf(
-                np.maximum(C @ Qp.results.x - u, 0)
-                + np.minimum(C @ Qp.results.x - l, 0)
+                np.maximum(C @ qp.results.x - u, 0)
+                + np.minimum(C @ qp.results.x - l, 0)
             ),
         )
         assert dua_res <= 1e-9
@@ -4470,25 +4470,25 @@ class SparseQpWrapper(unittest.TestCase):
         l = 2.0 * np.ones((n,))
         u = np.full(l.shape, +np.infty)
 
-        Qp = proxsuite.proxqp.sparse.QP(n, 0, n)
-        Qp.init(H, g, A, b, C, u, l)
-        Qp.solve()
+        qp = proxsuite.proxqp.sparse.QP(n, 0, n)
+        qp.init(H, g, A, b, C, u, l)
+        qp.solve()
         x_theoretically_optimal = np.array([2.0] * 149 + [3.0])
 
-        dua_res = normInf(H @ Qp.results.x + g + C.transpose() @ Qp.results.z)
+        dua_res = normInf(H @ qp.results.x + g + C.transpose() @ qp.results.z)
         pri_res = normInf(
-            np.maximum(C @ Qp.results.x - u, 0) + np.minimum(C @ Qp.results.x - l, 0)
+            np.maximum(C @ qp.results.x - u, 0) + np.minimum(C @ qp.results.x - l, 0)
         )
 
         assert dua_res <= 1e-3  # default precision of the solver
         assert pri_res <= 1e-3
-        assert normInf(x_theoretically_optimal - Qp.results.x) <= 1e-3
+        assert normInf(x_theoretically_optimal - qp.results.x) <= 1e-3
         print("--n = {} ; n_eq = {} ; n_in = {}".format(n, 0, n))
         print("dual residual = {} ; primal residual = {}".format(dua_res, pri_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 
@@ -4503,20 +4503,20 @@ class SparseQpWrapper(unittest.TestCase):
         u = None
         l = None
 
-        Qp = proxsuite.proxqp.sparse.QP(3, 0, 0)
-        Qp.init(H, g, A, b, C, u, l)
-        Qp.solve()
-        print("optimal x: {}".format(Qp.results.x))
+        qp = proxsuite.proxqp.sparse.QP(3, 0, 0)
+        qp.init(H, g, A, b, C, u, l)
+        qp.solve()
+        print("optimal x: {}".format(qp.results.x))
 
-        dua_res = normInf(H @ Qp.results.x + g)
+        dua_res = normInf(H @ qp.results.x + g)
 
         assert dua_res <= 1e-3  # default precision of the solver
         print("--n = {} ; n_eq = {} ; n_in = {}".format(3, 0, 0))
         print("dual residual = {} ".format(dua_res))
-        print("total number of iteration: {}".format(Qp.results.info.iter))
+        print("total number of iteration: {}".format(qp.results.info.iter))
         print(
             "setup timing = {} ; solve time = {}".format(
-                Qp.results.info.setup_time, Qp.results.info.solve_time
+                qp.results.info.setup_time, qp.results.info.solve_time
             )
         )
 


### PR DESCRIPTION
Add default proximal step sizes in the setting subclass, which can be set by the user (in the init or update methods for example). After each solve method the proximal step sizes of the result class are re-set to the ones of the setting subclass.

1. code unit tested in cpp and python,
2. documented in doxygen with small examples.