### PR TITLE
Support python 3.7 for proxsuite wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build ${{ matrix.os }} ${{ matrix.python-version }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "proxsuite"
 version = "0.1.1"
 description = "Quadratic Programming Solver for Robotics and beyond."
 readme = "README.md"
-requires-python = ">= 3.8"
+requires-python = ">= 3.7"
 license = "BSD-2-Clause"
 
 [project.urls]


### PR DESCRIPTION
Enables `pip install proxsuite` for python >=3.7, instead python >= 3.8.