### PR TITLE
CI/release: fix uploading proxsuite wheels only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,17 +58,17 @@ jobs:
         run: |
           pip wheel . -w dist
 
-      - name: Keep only proxsuite in dist
+      - name: Move proxsuite to specific dist folder
         shell: bash -l {0}
         run: |
-          rm dist/cmeel*.whl
-          rm dist/tomli*.whl
+          mkdir -p dist_proxsuite
+          mv dist/proxsuite*.whl dist_proxsuite
 
       - name: Archive artifacts
         uses: actions/upload-artifact@v3
         with:
           name: dist
-          path: dist
+          path: dist_proxsuite
 
   release:
     needs: "build-wheel"


### PR DESCRIPTION
Currently, additional wheels were built ([workflow](https://github.com/Simple-Robotics/proxsuite/actions/runs/3130836562/jobs/5086549476#step:6:19)), and it was changing over time. This leads to errors when uploading them to pypi. PR fixes this problem.