### PR TITLE
Support ARM64 architecture

### DIFF
--- a/.github/workflows/ci-osx-arm64-conda.yml
+++ b/.github/workflows/ci-osx-arm64-conda.yml
@@ -1,0 +1,74 @@
+name: CI - OSX ARM64 - Conda
+
+on:
+  push:
+  pull_request:
+
+env:
+  PYTHONPATH: ${CONDA_PREFIX}/lib/python3.8/site-packages/
+
+jobs:
+  build-with-conda:
+    name: '[conda:${{ matrix.os }}:${{ matrix.build_type }}]'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release, Debug]
+        name: [macos-m1]
+
+        include:
+          - name: macos-m1
+            os: self-hosted-arm64
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # not working due to The node12 is not supported on macOS ARM64 platform. Use node16 instead.
+    # open issue https://github.com/conda-incubator/setup-miniconda/issues/247
+    # - uses: conda-incubator/setup-miniconda@v2
+    #   with:
+    #     activate-environment: proxarm
+
+    - name: Environment
+      shell: bash -l {0}
+      run: |
+        echo $CONDA_PREFIX
+        conda info
+        conda list
+        env
+
+    - name: Configure
+      shell: bash -l {0}
+      run: |
+        cd $GITHUB_WORKSPACE
+        git submodule update --init
+        mkdir build
+        cd build
+        cmake .. -GNinja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DBUILD_WITH_VECTORIZATION_SUPPORT:BOOL=OFF -DPYTHON_SITELIB=${CONDA_PREFIX}/Lib/site-packages -DPYTHON_EXECUTABLE=${CONDA_PYTHON_EXE} -DINSTALL_DOCUMENTATION:BOOL=ON -DTEST_JULIA_INTERFACE:BOOL=OFF
+
+    - name: Build
+      shell: bash -l {0}
+      run: |
+        cd $GITHUB_WORKSPACE/build
+        cmake --build . --config ${{ matrix.build_type }} -v
+
+    - name: Install
+      shell: bash -l {0}
+      run: |
+        cd $GITHUB_WORKSPACE/build
+        cmake --install . --config ${{ matrix.build_type }}
+
+
+    - name: Test
+      shell: bash -l {0}
+      run: |
+        cd $GITHUB_WORKSPACE/build
+        ctest --output-on-failure -C ${{ matrix.build_type }}
+
+
+    - name: Uninstall [Conda]
+      shell: bash -l {0}
+      run: |
+        cd $GITHUB_WORKSPACE/build
+        cmake --build . --config ${{ matrix.build_type }} --target uninstall

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -19,24 +19,27 @@ file(GLOB_RECURSE PYWRAP_HEADERS ${CMAKE_CURRENT_LIST_DIR}/src/*.hpp)
 
 file(GLOB_RECURSE PYWRAP_SOURCES ${CMAKE_CURRENT_LIST_DIR}/src/*.cpp)
 
-# Add simd feature detectors for current CPU
-python3_add_library(instructionset MODULE helpers/instruction-set.cpp)
-add_dependencies(python instructionset)
-target_link_libraries(instructionset PRIVATE proxsuite pybind11::module)
-set_target_properties(
-  instructionset
-  PROPERTIES OUTPUT_NAME instructionset
-             LIBRARY_OUTPUT_DIRECTORY
-             "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}")
-if(UNIX AND NOT APPLE)
-  set_target_properties(instructionset PROPERTIES INSTALL_RPATH
-                                                  "\$ORIGIN/../../..")
+# Add simd feature detectors for current intel CPU
+message("-- CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "AMD64" OR ${CMAKE_SYSTEM_PROCESSOR}
+                                                MATCHES "x86_64")
+  python3_add_library(instructionset MODULE helpers/instruction-set.cpp)
+  add_dependencies(python instructionset)
+  target_link_libraries(instructionset PRIVATE proxsuite pybind11::module)
+  set_target_properties(
+    instructionset
+    PROPERTIES OUTPUT_NAME instructionset
+               LIBRARY_OUTPUT_DIRECTORY
+               "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}")
+  if(UNIX AND NOT APPLE)
+    set_target_properties(instructionset PROPERTIES INSTALL_RPATH
+                                                    "\$ORIGIN/../../..")
+  endif()
+  install(
+    TARGETS instructionset
+    EXPORT ${TARGETS_EXPORT_NAME}
+    DESTINATION ${${PYWRAP}_INSTALL_DIR})
 endif()
-install(
-  TARGETS instructionset
-  EXPORT ${TARGETS_EXPORT_NAME}
-  DESTINATION ${${PYWRAP}_INSTALL_DIR})
-
 function(CREATE_PYTHON_TARGET target_name COMPILE_OPTIONS dependencies)
   python3_add_library(${target_name} MODULE ${PYWRAP_SOURCES} ${PYWRAP_HEADERS})
   add_dependencies(python ${target_name})
@@ -46,7 +49,6 @@ function(CREATE_PYTHON_TARGET target_name COMPILE_OPTIONS dependencies)
   target_link_libraries(${target_name} PRIVATE proxsuite pybind11::module)
   target_compile_definitions(${target_name}
                              PRIVATE PYTHON_MODULE_NAME=${target_name})
-
   set_target_properties(
     ${target_name}
     PROPERTIES OUTPUT_NAME ${target_name}

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -16,13 +16,11 @@ add_custom_target(python)
 
 # Collect files
 file(GLOB_RECURSE PYWRAP_HEADERS ${CMAKE_CURRENT_LIST_DIR}/src/*.hpp)
-
 file(GLOB_RECURSE PYWRAP_SOURCES ${CMAKE_CURRENT_LIST_DIR}/src/*.cpp)
 
 # Add simd feature detectors for current intel CPU
 message("-- CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "AMD64" OR ${CMAKE_SYSTEM_PROCESSOR}
-                                                MATCHES "x86_64")
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
   python3_add_library(instructionset MODULE helpers/instruction-set.cpp)
   add_dependencies(python instructionset)
   target_link_libraries(instructionset PRIVATE proxsuite pybind11::module)
@@ -40,6 +38,7 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "AMD64" OR ${CMAKE_SYSTEM_PROCESSOR}
     EXPORT ${TARGETS_EXPORT_NAME}
     DESTINATION ${${PYWRAP}_INSTALL_DIR})
 endif()
+
 function(CREATE_PYTHON_TARGET target_name COMPILE_OPTIONS dependencies)
   python3_add_library(${target_name} MODULE ${PYWRAP_SOURCES} ${PYWRAP_HEADERS})
   add_dependencies(python ${target_name})

--- a/bindings/python/proxsuite/__init__.py
+++ b/bindings/python/proxsuite/__init__.py
@@ -1,4 +1,11 @@
-from . import instructionset
+import platform
+
+if (
+    "i386" in platform.processor()
+    or "x86_64" in platform.processor()
+    or "Intel64" in platform.processor()
+):
+    from . import instructionset
 
 
 def load_main_module(globals):
@@ -13,17 +20,19 @@ def load_main_module(globals):
         except ModuleNotFoundError:
             return False
 
-    all_modules = [
-        ("proxsuite_pywrap_avx512", instructionset.has_AVX512F),
-        ("proxsuite_pywrap_avx2", instructionset.has_AVX2),
-    ]
+    if "arm" not in platform.processor():
+        all_modules = [
+            ("proxsuite_pywrap_avx512", instructionset.has_AVX512F),
+            ("proxsuite_pywrap_avx2", instructionset.has_AVX2),
+        ]
 
-    for module_name, checker in all_modules:
-        if checker() and load_module(module_name):
-            return
+        for module_name, checker in all_modules:
+            if checker() and load_module(module_name):
+                return
 
     assert load_module("proxsuite_pywrap") == True
 
 
 load_main_module(globals=globals())
 del load_main_module
+del platform

--- a/include/proxsuite/linalg/dense/core.hpp
+++ b/include/proxsuite/linalg/dense/core.hpp
@@ -9,7 +9,9 @@
 #include <proxsuite/linalg/veg/util/assert.hpp>
 #include <proxsuite/linalg/veg/memory/dynamic_stack.hpp>
 
+#ifndef __aarch64__
 #include <immintrin.h>
+#endif
 
 #ifdef PROXSUITE_VECTORIZE
 #include <cmath> // to avoid error of the type no member named 'isnan' in namespace 'std';


### PR DESCRIPTION
As requested in #41, this PR 
- do not use instructionset for python bindings
- add CI workflow for ARM64 on self-hosted runner (M1)