### PR TITLE
release: wheels for macos arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,10 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-latest, macos-latest]
-
+        os: [ubuntu-latest, macos-latest, self-hosted-arm64]
+        exclude:
+          - os: self-hosted-arm64
+            python-version: 3.7
     steps:
       - name: Set docker for linux
         if: contains(matrix.os, 'ubuntu')
@@ -31,7 +33,9 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
           git submodule update
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - name: Setup conda
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
+        uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
@@ -40,6 +44,7 @@ jobs:
           activate-environment: proxsuite
 
       - name: Install dependencies [Conda]
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         shell: bash -l {0}
         run: |
           # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
@@ -47,6 +52,7 @@ jobs:
           mamba install doxygen graphviz eigen simde cmake compilers
 
       - name: Print environment [Conda]
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         shell: bash -l {0}
         run: |
           conda info
@@ -54,8 +60,35 @@ jobs:
           env
 
       - name: Build wheel
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         shell: bash -l {0}
         run: |
+          pip wheel . -w dist
+
+      - name: Turn off vectorization in pyproject.toml [arm64]
+        if: contains(matrix.os, 'self-hosted')
+        uses: jannekem/run-python-script-action@v1
+        with:
+          script: |
+            import os
+            print("Directory contents:")
+            for f in os.listdir():
+                print(f)
+            import tomlkit
+            with open("pyproject.toml") as f:
+                doc = tomlkit.load(f)
+            doc["build-system"]["configure-args"] = "-DBUILD_TESTING:BOOL=OFF","-DBUILD_PYTHON_INTERFACE:BOOL=ON","-DBUILD_WITH_VECTORIZATION_SUPPORT:BOOL=OFF","-DINSTALL_DOCUMENTATION:BOOL=OFF"
+            with open("pyproject.toml", "w") as f:
+                tomlkit.dump(doc, f)
+
+      - name: Build wheel on self-hosted
+        if: contains(matrix.os, 'self-hosted')
+        shell: bash -l {0}
+        run: |
+          conda activate proxarm-py${{ matrix.python-version }}
+          conda info
+          mamba list
+          env
           pip wheel . -w dist
 
       - name: Move proxsuite to specific dist folder


### PR DESCRIPTION
This PR builds and uploads wheels for macos ARM64. 
It uses the self-hosted M1 runner and a conda environment with the corresponding python version. An additional step is necessary, to turn off vectorization in the `pyproject.toml`.

The additional artifacts are:
```
proxsuite-<version>-cp38-cp38-macosx_12_0_arm64.whl
proxsuite-<version>-cp39-cp39-macosx_12_0_arm64.whl
proxsuite-<version>-cp310-cp310-macosx_12_0_arm64.whl
```