### PR TITLE
Fix epsilon relative stopping criteria

### DIFF
--- a/include/proxsuite/proxqp/dense/helpers.hpp
+++ b/include/proxsuite/proxqp/dense/helpers.hpp
@@ -437,10 +437,7 @@ setup( //
       .select(qpmodel.l,
               Eigen::Matrix<T, Eigen::Dynamic, 1>::Zero(qpmodel.n_in).array() -
                 T(1.E20));
-
-  qpwork.primal_feasibility_rhs_1_eq = infty_norm(qpmodel.b);
-  qpwork.primal_feasibility_rhs_1_in_u = infty_norm(qpwork.u_scaled);
-  qpwork.primal_feasibility_rhs_1_in_l = infty_norm(qpwork.l_scaled);
+  
   qpwork.dual_feasibility_rhs_2 = infty_norm(qpmodel.g);
 
   switch (preconditioner_status) {

--- a/include/proxsuite/proxqp/dense/helpers.hpp
+++ b/include/proxsuite/proxqp/dense/helpers.hpp
@@ -437,7 +437,7 @@ setup( //
       .select(qpmodel.l,
               Eigen::Matrix<T, Eigen::Dynamic, 1>::Zero(qpmodel.n_in).array() -
                 T(1.E20));
-  
+
   qpwork.dual_feasibility_rhs_2 = infty_norm(qpmodel.g);
 
   switch (preconditioner_status) {

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -1016,9 +1016,8 @@ qp_solve( //
     T rhs_pri(qpsettings.eps_abs);
     if (qpsettings.eps_rel != 0) {
       rhs_pri +=
-        qpsettings.eps_rel * std::max(std::max(primal_feasibility_eq_rhs_0,
-                                               primal_feasibility_in_rhs_0),
-                                      qpwork.primal_feasibility_rhs_1_eq);
+        qpsettings.eps_rel * std::max(primal_feasibility_eq_rhs_0,
+                                      primal_feasibility_in_rhs_0);
     }
     bool is_primal_feasible = primal_feasibility_lhs <= rhs_pri;
 

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -1016,12 +1016,9 @@ qp_solve( //
     T rhs_pri(qpsettings.eps_abs);
     if (qpsettings.eps_rel != 0) {
       rhs_pri +=
-        qpsettings.eps_rel *
-        std::max(
-          std::max(primal_feasibility_eq_rhs_0, primal_feasibility_in_rhs_0),
-          std::max(std::max(qpwork.primal_feasibility_rhs_1_eq,
-                            qpwork.primal_feasibility_rhs_1_in_u),
-                   qpwork.primal_feasibility_rhs_1_in_l));
+        qpsettings.eps_rel * std::max(std::max(primal_feasibility_eq_rhs_0,
+                                               primal_feasibility_in_rhs_0),
+                                      qpwork.primal_feasibility_rhs_1_eq);
     }
     bool is_primal_feasible = primal_feasibility_lhs <= rhs_pri;
 
@@ -1057,11 +1054,7 @@ qp_solve( //
                                                                                        std::max(
                                                                                                        primal_feasibility_eq_rhs_0,
                                                                                                        primal_feasibility_in_rhs_0),
-                                                                                       std::max(
-                                                                                                       std::max(
-                                                                                                                       qpwork.primal_feasibility_rhs_1_eq,
-                                                                                                                       qpwork.primal_feasibility_rhs_1_in_u),
-                                                                                                       qpwork.primal_feasibility_rhs_1_in_l))
+                                                                                       qpwork.primal_feasibility_rhs_1_eq)
                                               << std::endl;
       std::cout << "is_primal_feasible " << is_primal_feasible
                                               << " is_dual_feasible " <<
@@ -1163,12 +1156,9 @@ qp_solve( //
     is_primal_feasible =
       primal_feasibility_lhs_new <=
       (qpsettings.eps_abs +
-       qpsettings.eps_rel *
-         std::max(
-           std::max(primal_feasibility_eq_rhs_0, primal_feasibility_in_rhs_0),
-           std::max(std::max(qpwork.primal_feasibility_rhs_1_eq,
-                             qpwork.primal_feasibility_rhs_1_in_u),
-                    qpwork.primal_feasibility_rhs_1_in_l)));
+       qpsettings.eps_rel * std::max(std::max(primal_feasibility_eq_rhs_0,
+                                              primal_feasibility_in_rhs_0),
+                                     qpwork.primal_feasibility_rhs_1_eq));
     qpresults.info.pri_res = primal_feasibility_lhs_new;
     if (is_primal_feasible) {
       T dual_feasibility_lhs_new(dual_feasibility_lhs);

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -1015,9 +1015,8 @@ qp_solve( //
 
     T rhs_pri(qpsettings.eps_abs);
     if (qpsettings.eps_rel != 0) {
-      rhs_pri +=
-        qpsettings.eps_rel * std::max(primal_feasibility_eq_rhs_0,
-                                      primal_feasibility_in_rhs_0);
+      rhs_pri += qpsettings.eps_rel * std::max(primal_feasibility_eq_rhs_0,
+                                               primal_feasibility_in_rhs_0);
     }
     bool is_primal_feasible = primal_feasibility_lhs <= rhs_pri;
 

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -1032,32 +1032,6 @@ qp_solve( //
     bool is_dual_feasible = dual_feasibility_lhs <= rhs_dua;
 
     if (qpsettings.verbose) {
-      /* TO PUT IN DEBUG MODE
-      std::cout << "---------------it : " << iter
-                                              << " primal residual : " <<
-      primal_feasibility_lhs
-                                              << " dual residual : " <<
-      dual_feasibility_lhs << std::endl; std::cout << "bcl_eta_ext : " <<
-      bcl_eta_ext
-                                              << " bcl_eta_in : " << bcl_eta_in
-                                              << " rho : " << qpresults.info.rho
-                                              << " bcl_mu_eq : " <<
-      qpresults.info.mu_eq
-                                              << " bcl_mu_in : " <<
-      qpresults.info.mu_in << std::endl; std::cout << "qpsettings.eps_abs " <<
-      qpsettings.eps_abs
-                                              << "  qpsettings.eps_rel *rhs "
-                                              << qpsettings.eps_rel *
-                                                                       std::max(
-                                                                                       std::max(
-                                                                                                       primal_feasibility_eq_rhs_0,
-                                                                                                       primal_feasibility_in_rhs_0),
-                                                                                       qpwork.primal_feasibility_rhs_1_eq)
-                                              << std::endl;
-      std::cout << "is_primal_feasible " << is_primal_feasible
-                                              << " is_dual_feasible " <<
-      is_dual_feasible << std::endl;
-      */
 
       ruiz.unscale_primal_in_place(VectorViewMut<T>{ from_eigen, qpresults.x });
       ruiz.unscale_dual_in_place_eq(
@@ -1155,8 +1129,7 @@ qp_solve( //
       primal_feasibility_lhs_new <=
       (qpsettings.eps_abs +
        qpsettings.eps_rel * std::max(std::max(primal_feasibility_eq_rhs_0,
-                                              primal_feasibility_in_rhs_0),
-                                     qpwork.primal_feasibility_rhs_1_eq));
+                                              primal_feasibility_in_rhs_0)));
     qpresults.info.pri_res = primal_feasibility_lhs_new;
     if (is_primal_feasible) {
       T dual_feasibility_lhs_new(dual_feasibility_lhs);

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -1128,8 +1128,8 @@ qp_solve( //
     is_primal_feasible =
       primal_feasibility_lhs_new <=
       (qpsettings.eps_abs +
-       qpsettings.eps_rel * std::max(std::max(primal_feasibility_eq_rhs_0,
-                                              primal_feasibility_in_rhs_0)));
+       qpsettings.eps_rel * std::max(primal_feasibility_eq_rhs_0,
+                                              primal_feasibility_in_rhs_0));
     qpresults.info.pri_res = primal_feasibility_lhs_new;
     if (is_primal_feasible) {
       T dual_feasibility_lhs_new(dual_feasibility_lhs);

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -1128,8 +1128,8 @@ qp_solve( //
     is_primal_feasible =
       primal_feasibility_lhs_new <=
       (qpsettings.eps_abs +
-       qpsettings.eps_rel * std::max(primal_feasibility_eq_rhs_0,
-                                              primal_feasibility_in_rhs_0));
+       qpsettings.eps_rel *
+         std::max(primal_feasibility_eq_rhs_0, primal_feasibility_in_rhs_0));
     qpresults.info.pri_res = primal_feasibility_lhs_new;
     if (is_primal_feasible) {
       T dual_feasibility_lhs_new(dual_feasibility_lhs);

--- a/include/proxsuite/proxqp/dense/workspace.hpp
+++ b/include/proxsuite/proxqp/dense/workspace.hpp
@@ -73,9 +73,6 @@ struct Workspace
 
   //// Relative residuals constants
 
-  T primal_feasibility_rhs_1_eq;
-  T primal_feasibility_rhs_1_in_u;
-  T primal_feasibility_rhs_1_in_l;
   T dual_feasibility_rhs_2;
   T correction_guess_rhs_g;
   T correction_guess_rhs_b;
@@ -194,9 +191,6 @@ struct Workspace
     rhs.setZero();
     err.setZero();
 
-    primal_feasibility_rhs_1_eq = 0;
-    primal_feasibility_rhs_1_in_u = 0;
-    primal_feasibility_rhs_1_in_l = 0;
     dual_feasibility_rhs_2 = 0;
     correction_guess_rhs_g = 0;
     correction_guess_rhs_b = 0;

--- a/include/proxsuite/proxqp/sparse/solver.hpp
+++ b/include/proxsuite/proxqp/sparse/solver.hpp
@@ -519,7 +519,6 @@ qp_solve(Results<T>& results,
     { proxsuite::linalg::sparse::from_eigen, u_scaled_e },
   };
 
-  T const primal_feasibility_rhs_1_eq = infty_norm(data.b);
   T const dual_feasibility_rhs_2 = infty_norm(data.g);
 
   // auto ldl_col_ptrs = work.ldl_col_ptrs_mut();
@@ -756,8 +755,7 @@ qp_solve(Results<T>& results,
         if (settings.eps_rel != 0) {
           rhs_pri += settings.eps_rel * std::max({
                                           primal_feasibility_eq_rhs_0,
-                                          primal_feasibility_in_rhs_0,
-                                          primal_feasibility_rhs_1_eq,
+                                          primal_feasibility_in_rhs_0
                                         });
         }
         return primal_feasibility_lhs <= rhs_pri;

--- a/include/proxsuite/proxqp/sparse/solver.hpp
+++ b/include/proxsuite/proxqp/sparse/solver.hpp
@@ -753,10 +753,9 @@ qp_solve(Results<T>& results,
       auto is_primal_feasible = [&](T primal_feasibility_lhs) -> bool {
         T rhs_pri = settings.eps_abs;
         if (settings.eps_rel != 0) {
-          rhs_pri += settings.eps_rel * std::max({
-                                          primal_feasibility_eq_rhs_0,
-                                          primal_feasibility_in_rhs_0
-                                        });
+          rhs_pri +=
+            settings.eps_rel * std::max({ primal_feasibility_eq_rhs_0,
+                                          primal_feasibility_in_rhs_0 });
         }
         return primal_feasibility_lhs <= rhs_pri;
       };

--- a/include/proxsuite/proxqp/sparse/solver.hpp
+++ b/include/proxsuite/proxqp/sparse/solver.hpp
@@ -520,8 +520,6 @@ qp_solve(Results<T>& results,
   };
 
   T const primal_feasibility_rhs_1_eq = infty_norm(data.b);
-  T const primal_feasibility_rhs_1_in_u = infty_norm(data.u);
-  T const primal_feasibility_rhs_1_in_l = infty_norm(data.l);
   T const dual_feasibility_rhs_2 = infty_norm(data.g);
 
   // auto ldl_col_ptrs = work.ldl_col_ptrs_mut();
@@ -760,8 +758,6 @@ qp_solve(Results<T>& results,
                                           primal_feasibility_eq_rhs_0,
                                           primal_feasibility_in_rhs_0,
                                           primal_feasibility_rhs_1_eq,
-                                          primal_feasibility_rhs_1_in_l,
-                                          primal_feasibility_rhs_1_in_u,
                                         });
         }
         return primal_feasibility_lhs <= rhs_pri;


### PR DESCRIPTION
As seen in #46, very large bounds on the inequality constraints (in this case 1e20) cause strange behavior in the solver. After discussing with @Bambade, this PR fixes the issue.