### PR TITLE
Fix calculation of objection function value

### DIFF
--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -1232,6 +1232,7 @@ qp_solve( //
 
   {
     // EigenAllowAlloc _{};
+    qpresults.info.objValue = 0;
     for (Eigen::Index j = 0; j < qpmodel.dim; ++j) {
       qpresults.info.objValue +=
         0.5 * (qpresults.x(j) * qpresults.x(j)) * qpmodel.H(j, j);


### PR DESCRIPTION
Reset was missing. If run with verbose `true` this caused that the `objVal` was half of what it should have been, found with @Bambade.