### PR TITLE
Doc: matio link

### DIFF
--- a/doc/5-installation.md
+++ b/doc/5-installation.md
@@ -63,4 +63,4 @@ make install
 
 #### Testing
 
-To test the whole framework, you need installing first [Matio](https://github.com/ami-iit/matio-cpp) (for reading .mat files in C++). You can then activate the build of the unit tests by activating the cmake option `BUILD_TESTING=ON`.
+To test the whole framework, you need installing first [Matio](https://github.com/tbeu/matio) (for reading .mat files in C++). You can then activate the build of the unit tests by activating the cmake option `BUILD_TESTING=ON`.


### PR DESCRIPTION
as pointed out in #57, the link in our doc is pointing to matio-cpp but we are actually using matio, see [here](https://github.com/Simple-Robotics/proxsuite/blob/e97f76605da03ae624927b3615cb2540144bbacc/cmake-external/FindMatio.cmake#L32) and [here](https://github.com/Simple-Robotics/proxsuite/blob/e97f76605da03ae624927b3615cb2540144bbacc/test/include/maros_meszaros.hpp#L2)