### PR TITLE
C++14 compliant implementation of aligned_alloc

### DIFF
--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -55,7 +55,15 @@ jobs:
         mamba install julia
 
     - name: Activate ccache [Conda]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ matrix.os }}-${{ matrix.type }}
+        max-size: 1G
+
+    - name: Activate ccache windows [Conda]
+      if: contains(matrix.os, 'windows')
+      uses: hendrikmuhs/ccache-action@v1.1
       with:
         key: ${{ matrix.os }}-${{ matrix.type }}
         max-size: 1G

--- a/bindings/python/src/expose-all.cpp
+++ b/bindings/python/src/expose-all.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2022 INRIA
 //
+#include <proxsuite/fwd.hpp>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/eigen.h>

--- a/include/proxsuite/fwd.hpp
+++ b/include/proxsuite/fwd.hpp
@@ -1,0 +1,24 @@
+//
+// Copyright (c) 2022 INRIA
+//
+
+#ifndef __proxsuite_fwd_hpp__
+#define __proxsuite_fwd_hpp__
+
+#if __cplusplus >= 201703L
+#define PROXSUITE_WITH_CPP_17
+#elif __cplusplus >= 201402L
+#define PROXSUITE_WITH_CPP_14
+#else
+#error "Please use at least c++14"  // should not happen
+#endif
+
+#if defined PROXSUITE_WITH_CPP_17
+#define PROXSUITE_MAYBE_UNUSED [[maybe_unused]]
+#elif defined(_MSC_VER) && !defined(__clang__)
+#define PROXSUITE_MAYBE_UNUSED
+#else
+#define PROXSUITE_MAYBE_UNUSED __attribute__((__unused__))
+#endif
+
+#endif // #ifndef __proxsuite_fwd_hpp__

--- a/include/proxsuite/fwd.hpp
+++ b/include/proxsuite/fwd.hpp
@@ -7,13 +7,12 @@
 
 #if __cplusplus >= 201703L
 #define PROXSUITE_WITH_CPP_17
-#elif __cplusplus >= 201402L
+#endif
+#if __cplusplus >= 201402L
 #define PROXSUITE_WITH_CPP_14
-#else
-#error "Please use at least c++14"  // should not happen
 #endif
 
-#if defined PROXSUITE_WITH_CPP_17
+#if defined(PROXSUITE_WITH_CPP_17)
 #define PROXSUITE_MAYBE_UNUSED [[maybe_unused]]
 #elif defined(_MSC_VER) && !defined(__clang__)
 #define PROXSUITE_MAYBE_UNUSED

--- a/include/proxsuite/helpers/common.hpp
+++ b/include/proxsuite/helpers/common.hpp
@@ -27,12 +27,4 @@ struct infinite_bound
 } // helpers
 } // proxsuite
 
-#if __cplusplus >= 201703L
-#define PROXSUITE_MAYBE_UNUSED [[maybe_unused]]
-#elif defined(_MSC_VER) && !defined(__clang__)
-#define PROXSUITE_MAYBE_UNUSED
-#else
-#define PROXSUITE_MAYBE_UNUSED __attribute__((__unused__))
-#endif
-
 #endif // ifndef PROXSUITE_HELPERS_COMMON_HPP

--- a/include/proxsuite/helpers/common.hpp
+++ b/include/proxsuite/helpers/common.hpp
@@ -27,4 +27,12 @@ struct infinite_bound
 } // helpers
 } // proxsuite
 
+#if __cplusplus >= 201703L
+#define PROXSUITE_MAYBE_UNUSED [[maybe_unused]]
+#elif defined(_MSC_VER) && !defined(__clang__)
+#define PROXSUITE_MAYBE_UNUSED
+#else
+#define PROXSUITE_MAYBE_UNUSED __attribute__((__unused__))
+#endif
+
 #endif // ifndef PROXSUITE_HELPERS_COMMON_HPP

--- a/include/proxsuite/linalg/sparse/update.hpp
+++ b/include/proxsuite/linalg/sparse/update.hpp
@@ -34,7 +34,7 @@ merge_second_col_into_first( //
   I* difference,
   T* first_values,
   I* first_ptr,
-  [[maybe_unused]] isize first_full_len,
+  PROXSUITE_MAYBE_UNUSED isize first_full_len,
   isize first_initial_len,
   Slice<I> second,
   proxsuite::linalg::veg::DoNotDeduce<I> ignore_threshold_inclusive,

--- a/include/proxsuite/linalg/veg/internal/narrow.hpp
+++ b/include/proxsuite/linalg/veg/internal/narrow.hpp
@@ -3,6 +3,7 @@
 
 #include "proxsuite/linalg/veg/util/assert.hpp"
 #include "proxsuite/linalg/veg/internal/prologue.hpp"
+#include "proxsuite/helpers/common.hpp"
 
 namespace proxsuite {
 namespace linalg {
@@ -22,7 +23,7 @@ struct narrow
 #if defined(VEG_WITH_CXX14_SUPPORT)
 
     To to = static_cast<To>(from);
-    [[maybe_unused]] From roundtrip_from =
+    PROXSUITE_MAYBE_UNUSED From roundtrip_from =
       static_cast<From>(static_cast<To>(from));
     VEG_INTERNAL_ASSERT_PRECONDITION(roundtrip_from == from);
     return to;

--- a/include/proxsuite/linalg/veg/internal/narrow.hpp
+++ b/include/proxsuite/linalg/veg/internal/narrow.hpp
@@ -1,6 +1,7 @@
 #ifndef VEG_NARROW_HPP_H0EXKJTAS
 #define VEG_NARROW_HPP_H0EXKJTAS
 
+#include "proxsuite/fwd.hpp"
 #include "proxsuite/linalg/veg/util/assert.hpp"
 #include "proxsuite/linalg/veg/internal/prologue.hpp"
 #include "proxsuite/helpers/common.hpp"

--- a/include/proxsuite/linalg/veg/memory/alloc.hpp
+++ b/include/proxsuite/linalg/veg/memory/alloc.hpp
@@ -52,6 +52,72 @@ aligned_alloc(std::size_t alignment, std::size_t size)
 } // namespace alignment
 #endif
 
+namespace alignment {
+namespace detail {
+template<std::size_t A, std::size_t B>
+struct min_size : std::integral_constant<std::size_t, (A < B) ? A : B>
+{
+};
+
+template<class T>
+struct offset_value
+{
+  char value;
+  T object;
+};
+
+template<class T>
+struct alignment_of : min_size<sizeof(T), sizeof(offset_value<T>) - sizeof(T)>
+{
+};
+
+constexpr inline bool
+is_alignment(std::size_t value)
+{
+  return (value > 0) && ((value & (value - 1)) == 0);
+}
+
+inline void*
+align(std::size_t alignment, std::size_t size, void*& ptr, std::size_t& space)
+{
+  assert(is_alignment(alignment));
+  if (size <= space) {
+    char* p = reinterpret_cast<char*>(
+      ~(alignment - 1) & (reinterpret_cast<std::size_t>(ptr) + alignment - 1));
+    std::size_t n = space - (p - static_cast<char*>(ptr));
+    if (size <= n) {
+      ptr = p;
+      space = n;
+      return p;
+    }
+  }
+  return 0;
+}
+
+inline void*
+aligned_alloc(std::size_t alignment, std::size_t size)
+{
+  assert(is_alignment(alignment));
+  enum
+  {
+    N = alignment_of<void*>::value
+  };
+  if (alignment < N) {
+    alignment = N;
+  }
+  std::size_t n = size + alignment - N;
+  void* p = std::malloc(sizeof(void*) + n);
+  if (p) {
+    void* r = static_cast<char*>(p) + sizeof(void*);
+    (void)align(alignment, size, r, n);
+    *(static_cast<void**>(r) - 1) = p;
+    p = r;
+  }
+  return p;
+}
+} // namespace detail
+} // namespace alignment
+
 namespace mem {
 enum struct CopyAvailable
 {
@@ -95,7 +161,11 @@ aligned_alloc(usize align, usize size) noexcept -> void*
 #elif defined(__APPLE__)
   return alignment::aligned_alloc(align, (size + mask) & ~mask);
 #else
+#if __cplusplus >= 201703L
   return std::aligned_alloc(align, (size + mask) & ~mask);
+#else
+  return alignment::detail::aligned_alloc(align, (size + mask) & ~mask);
+#endif
 #endif
 }
 

--- a/include/proxsuite/linalg/veg/memory/alloc.hpp
+++ b/include/proxsuite/linalg/veg/memory/alloc.hpp
@@ -52,8 +52,10 @@ aligned_alloc(std::size_t alignment, std::size_t size)
 } // namespace alignment
 #endif
 
+// Support aligned_alloc for c++14, code from boost/align.
 namespace alignment {
 namespace detail {
+// Source: https://www.boost.org/doc/libs/1_65_0/boost/align/detail/min_size.hpp
 template<std::size_t A, std::size_t B>
 struct min_size : std::integral_constant<std::size_t, (A < B) ? A : B>
 {
@@ -66,17 +68,22 @@ struct offset_value
   T object;
 };
 
+// Source:
+// https://www.boost.org/doc/libs/1_65_0/boost/align/detail/alignment_of.hpp
 template<class T>
 struct alignment_of : min_size<sizeof(T), sizeof(offset_value<T>) - sizeof(T)>
 {
 };
 
+// Source:
+// https://www.boost.org/doc/libs/1_65_0/boost/align/detail/is_alignment.hpp
 constexpr inline bool
 is_alignment(std::size_t value)
 {
   return (value > 0) && ((value & (value - 1)) == 0);
 }
 
+// Source: https://www.boost.org/doc/libs/1_65_0/boost/align/detail/align.hpp
 inline void*
 align(std::size_t alignment, std::size_t size, void*& ptr, std::size_t& space)
 {
@@ -94,6 +101,8 @@ align(std::size_t alignment, std::size_t size, void*& ptr, std::size_t& space)
   return 0;
 }
 
+// Source:
+// https://www.boost.org/doc/libs/1_65_0/boost/align/detail/aligned_alloc.hpp
 inline void*
 aligned_alloc(std::size_t alignment, std::size_t size)
 {

--- a/include/proxsuite/linalg/veg/memory/alloc.hpp
+++ b/include/proxsuite/linalg/veg/memory/alloc.hpp
@@ -170,7 +170,7 @@ aligned_alloc(usize align, usize size) noexcept -> void*
 #elif defined(__APPLE__)
   return alignment::aligned_alloc(align, (size + mask) & ~mask);
 #else
-#if __cplusplus >= 201703L
+#ifdef PROXSUITE_WITH_CPP_17
   return std::aligned_alloc(align, (size + mask) & ~mask);
 #else
   return alignment::detail::aligned_alloc(align, (size + mask) & ~mask);

--- a/include/proxsuite/linalg/veg/memory/dynamic_stack.hpp
+++ b/include/proxsuite/linalg/veg/memory/dynamic_stack.hpp
@@ -236,7 +236,8 @@ public:
   auto ptr() const VEG_NOEXCEPT->void const* { return stack_data; }
 
 private:
-  VEG_INLINE void assert_valid_len([[maybe_unused]] isize len) VEG_NOEXCEPT
+  VEG_INLINE void assert_valid_len(PROXSUITE_MAYBE_UNUSED isize len)
+    VEG_NOEXCEPT
   {
     VEG_INTERNAL_ASSERT_PRECONDITIONS(isize(len) >= 0);
   }
@@ -332,11 +333,11 @@ struct DynAllocBase
   {
     if (data != nullptr) {
       // in case resource lifetimes are reodered by moving ownership
-      [[maybe_unused]] auto* parent_stack_data =
+      PROXSUITE_MAYBE_UNUSED auto* parent_stack_data =
         static_cast<unsigned char*>(parent->stack_data);
-      [[maybe_unused]] auto* old_position =
+      PROXSUITE_MAYBE_UNUSED auto* old_position =
         static_cast<unsigned char*>(old_pos);
-      [[maybe_unused]] auto* data_end =
+      PROXSUITE_MAYBE_UNUSED auto* data_end =
         static_cast<unsigned char*>(const_cast<void*>(void_data_end));
 
       VEG_INTERNAL_ASSERT_PRECONDITIONS( //

--- a/include/proxsuite/linalg/veg/memory/dynamic_stack.hpp
+++ b/include/proxsuite/linalg/veg/memory/dynamic_stack.hpp
@@ -1,6 +1,7 @@
 #ifndef VEG_DYNAMIC_STACK_DYNAMIC_STACK_HPP_UBOMZFTOS
 #define VEG_DYNAMIC_STACK_DYNAMIC_STACK_HPP_UBOMZFTOS
 
+#include "proxsuite/fwd.hpp"
 #include "proxsuite/linalg/veg/util/assert.hpp"
 #include "proxsuite/linalg/veg/internal/collection_algo.hpp"
 #include "proxsuite/linalg/veg/memory/alloc.hpp"

--- a/include/proxsuite/optional.hpp
+++ b/include/proxsuite/optional.hpp
@@ -9,12 +9,12 @@
 #define PROXSUITE_OPTIONAL_HPP
 
 #include <proxsuite/helpers/tl-optional.hpp>
-#if __cplusplus >= 201703L
+#ifdef PROXSUITE_WITH_CPP_17
 #include <optional>
 #endif
 
 namespace proxsuite {
-#if __cplusplus >= 201703L
+#ifdef PROXSUITE_WITH_CPP_17
 template<class T>
 using optional = std::optional<T>;
 using nullopt_t = std::nullopt_t;

--- a/include/proxsuite/proxqp/sparse/utils.hpp
+++ b/include/proxsuite/proxqp/sparse/utils.hpp
@@ -745,7 +745,7 @@ struct generic_product_impl<
   static void scaleAndAddTo(Dst& dst,
                             Mat_ const& lhs,
                             Rhs const& rhs,
-                            [[maybe_unused]] Scalar const& alpha)
+                            PROXSUITE_MAYBE_UNUSED Scalar const& alpha)
   {
     using proxsuite::linalg::veg::isize;
 

--- a/test/doctest/doctest.hpp
+++ b/test/doctest/doctest.hpp
@@ -2331,7 +2331,7 @@ registerReporter(const char* name, int priority, bool isReporter)
                                        decorators)
 
 // for registering tests in classes - requires C++17 for inline variables!
-#if __cplusplus >= 201703L ||                                                  \
+#if defined PROXSUITE_WITH_CPP_17 ||                                           \
   (DOCTEST_MSVC >= DOCTEST_COMPILER(19, 12, 0) && _MSVC_LANG >= 201703L)
 #define DOCTEST_TEST_CASE_CLASS(decorators)                                    \
   DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(                               \


### PR DESCRIPTION
- also fix the [[MAYBE_UNSUED]] problem which is introduced in c++17

with this PR, including also the changes done in #78, I can compile the proxsuite library enforcing c++14.