### PR TITLE
CI for c++14 compatibility

### DIFF
--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -6,13 +6,14 @@ on:
 
 jobs:
   build-with-conda:
-    name: '[conda:${{ matrix.os }}:${{ matrix.build_type }}]'
+    name: '[conda:${{ matrix.os }}:${{ matrix.build_type }}:c++${{ matrix.cxx_std }}]'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         build_type: [Release, Debug]
         name: [ubuntu-latest, macos-latest, windows-2019-clang-cl, windows-latest]
+        cxx_std: [17]
 
         include:
           - name: ubuntu-latest
@@ -24,6 +25,10 @@ jobs:
             compiler: clang-cl
           - name: windows-latest
             os: windows-latest
+          - name: macos-latest
+            os: macos-latest
+            build_type: Release
+            cxx_std: 14
 
     steps:
     - uses: actions/checkout@v2
@@ -84,7 +89,7 @@ jobs:
         git submodule update --init
         mkdir build
         cd build
-        cmake .. -GNinja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_EXECUTABLE=$(which python3) -DINSTALL_DOCUMENTATION:BOOL=ON -DTEST_JULIA_INTERFACE:BOOL=ON
+        cmake .. -GNinja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_STANDARD=${{ matrix.cxx_std }} -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_EXECUTABLE=$(which python3) -DINSTALL_DOCUMENTATION:BOOL=ON -DTEST_JULIA_INTERFACE:BOOL=ON
 
     - name: Configure [Conda/Windows-2019]
       if: contains(matrix.os, 'windows-2019')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ endif(INITIALIZE_EIGEN_WITH_NAN)
 
 # set CXX standard
 if(DEFINED CMAKE_CXX_STANDARD)
-  check_minimal_cxx_standard(17 ENFORCE)
+  check_minimal_cxx_standard(14 ENFORCE)
 else()
   set(CMAKE_CXX_STANDARD 17)
 endif()

--- a/include/proxsuite/helpers/instruction-set.hpp
+++ b/include/proxsuite/helpers/instruction-set.hpp
@@ -41,81 +41,11 @@ cpuidex(std::array<int, 4>& cpui, int level, int count)
   __cpuidex(cpui.data(), level, count);
 #endif
 }
-}
 
-// Adapted from
-// https://docs.microsoft.com/fr-fr/cpp/intrinsics/cpuid-cpuidex?view=msvc-170
-struct InstructionSet
+template<typename T = void>
+struct InstructionSetBase
 {
-  static std::string vendor(void) { return data.vendor_; }
-  static std::string brand(void) { return data.brand_; }
-
-  static bool has_SSE3(void) { return data.f_1_ECX_[0]; }
-  static bool has_PCLMULQDQ(void) { return data.f_1_ECX_[1]; }
-  static bool has_MONITOR(void) { return data.f_1_ECX_[3]; }
-  static bool has_SSSE3(void) { return data.f_1_ECX_[9]; }
-  static bool has_FMA(void) { return data.f_1_ECX_[12]; }
-  static bool has_CMPXCHG16B(void) { return data.f_1_ECX_[13]; }
-  static bool has_SSE41(void) { return data.f_1_ECX_[19]; }
-  static bool has_SSE42(void) { return data.f_1_ECX_[20]; }
-  static bool has_MOVBE(void) { return data.f_1_ECX_[22]; }
-  static bool has_POPCNT(void) { return data.f_1_ECX_[23]; }
-  static bool has_AES(void) { return data.f_1_ECX_[25]; }
-  static bool has_XSAVE(void) { return data.f_1_ECX_[26]; }
-  static bool has_OSXSAVE(void) { return data.f_1_ECX_[27]; }
-  static bool has_AVX(void) { return data.f_1_ECX_[28]; }
-  static bool has_F16C(void) { return data.f_1_ECX_[29]; }
-  static bool has_RDRAND(void) { return data.f_1_ECX_[30]; }
-
-  static bool has_MSR(void) { return data.f_1_EDX_[5]; }
-  static bool has_CX8(void) { return data.f_1_EDX_[8]; }
-  static bool has_SEP(void) { return data.f_1_EDX_[11]; }
-  static bool has_CMOV(void) { return data.f_1_EDX_[15]; }
-  static bool has_CLFSH(void) { return data.f_1_EDX_[19]; }
-  static bool has_MMX(void) { return data.f_1_EDX_[23]; }
-  static bool has_FXSR(void) { return data.f_1_EDX_[24]; }
-  static bool has_SSE(void) { return data.f_1_EDX_[25]; }
-  static bool has_SSE2(void) { return data.f_1_EDX_[26]; }
-
-  static bool has_FSGSBASE(void) { return data.f_7_EBX_[0]; }
-  static bool has_AVX512VBMI(void) { return data.f_7_EBX_[1]; }
-  static bool has_BMI1(void) { return data.f_7_EBX_[3]; }
-  static bool has_HLE(void) { return data.isIntel_ && data.f_7_EBX_[4]; }
-  static bool has_AVX2(void) { return data.f_7_EBX_[5]; }
-  static bool has_BMI2(void) { return data.f_7_EBX_[8]; }
-  static bool has_ERMS(void) { return data.f_7_EBX_[9]; }
-  static bool has_INVPCID(void) { return data.f_7_EBX_[10]; }
-  static bool has_RTM(void) { return data.isIntel_ && data.f_7_EBX_[11]; }
-  static bool has_AVX512F(void) { return data.f_7_EBX_[16]; }
-  static bool has_AVX512DQ(void) { return data.f_7_EBX_[17]; }
-  static bool has_RDSEED(void) { return data.f_7_EBX_[18]; }
-  static bool has_ADX(void) { return data.f_7_EBX_[19]; }
-  static bool has_AVX512IFMA(void) { return data.f_7_EBX_[21]; }
-  static bool has_AVX512PF(void) { return data.f_7_EBX_[26]; }
-  static bool has_AVX512ER(void) { return data.f_7_EBX_[27]; }
-  static bool has_AVX512CD(void) { return data.f_7_EBX_[28]; }
-  static bool has_SHA(void) { return data.f_7_EBX_[29]; }
-  static bool has_AVX512BW(void) { return data.f_7_EBX_[30]; }
-  static bool has_AVX512VL(void) { return data.f_7_EBX_[31]; }
-
-  static bool has_PREFETCHWT1(void) { return data.f_7_ECX_[0]; }
-
-  static bool has_LAHF(void) { return data.f_81_ECX_[0]; }
-  static bool has_LZCNT(void) { return data.isIntel_ && data.f_81_ECX_[5]; }
-  static bool has_ABM(void) { return data.isAMD_ && data.f_81_ECX_[5]; }
-  static bool has_SSE4a(void) { return data.isAMD_ && data.f_81_ECX_[6]; }
-  static bool has_XOP(void) { return data.isAMD_ && data.f_81_ECX_[11]; }
-  static bool has_FMA4(void) { return data.isAMD_ && data.f_81_ECX_[16]; }
-  static bool has_TBM(void) { return data.isAMD_ && data.f_81_ECX_[21]; }
-
-  static bool has_SYSCALL(void) { return data.isIntel_ && data.f_81_EDX_[11]; }
-  static bool has_MMXEXT(void) { return data.isAMD_ && data.f_81_EDX_[22]; }
-  static bool has_RDTSCP(void) { return data.isIntel_ && data.f_81_EDX_[27]; }
-  static bool has_x64(void) { return data.isIntel_ && data.f_81_EDX_[29]; }
-  static bool has_3DNOWEXT(void) { return data.isAMD_ && data.f_81_EDX_[30]; }
-  static bool has_3DNOW(void) { return data.isAMD_ && data.f_81_EDX_[31]; }
-
-private:
+protected:
   struct Data
   {
     Data()
@@ -214,7 +144,284 @@ private:
     std::vector<std::array<int, 4>> extdata_;
   };
 
-  inline static const Data data = Data();
+  static const Data data;
+};
+
+template<>
+const typename InstructionSetBase<>::Data InstructionSetBase<>::data =
+  typename InstructionSetBase<>::Data();
+} // namespace internal
+
+// Adapted from
+// https://docs.microsoft.com/fr-fr/cpp/intrinsics/cpuid-cpuidex?view=msvc-170
+// template <typename T>
+// struct InstructionSet: public internal::InstructionSetBase<T>
+struct InstructionSet : public internal::InstructionSetBase<>
+{
+  static std::string vendor(void)
+  {
+    return internal::InstructionSetBase<>::data.vendor_;
+  }
+  static std::string brand(void)
+  {
+    return internal::InstructionSetBase<>::data.brand_;
+  }
+
+  static bool has_SSE3(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[0];
+  }
+  static bool has_PCLMULQDQ(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[1];
+  }
+  static bool has_MONITOR(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[3];
+  }
+  static bool has_SSSE3(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[9];
+  }
+  static bool has_FMA(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[12];
+  }
+  static bool has_CMPXCHG16B(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[13];
+  }
+  static bool has_SSE41(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[19];
+  }
+  static bool has_SSE42(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[20];
+  }
+  static bool has_MOVBE(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[22];
+  }
+  static bool has_POPCNT(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[23];
+  }
+  static bool has_AES(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[25];
+  }
+  static bool has_XSAVE(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[26];
+  }
+  static bool has_OSXSAVE(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[27];
+  }
+  static bool has_AVX(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[28];
+  }
+  static bool has_F16C(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[29];
+  }
+  static bool has_RDRAND(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_ECX_[30];
+  }
+
+  static bool has_MSR(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_EDX_[5];
+  }
+  static bool has_CX8(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_EDX_[8];
+  }
+  static bool has_SEP(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_EDX_[11];
+  }
+  static bool has_CMOV(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_EDX_[15];
+  }
+  static bool has_CLFSH(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_EDX_[19];
+  }
+  static bool has_MMX(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_EDX_[23];
+  }
+  static bool has_FXSR(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_EDX_[24];
+  }
+  static bool has_SSE(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_EDX_[25];
+  }
+  static bool has_SSE2(void)
+  {
+    return internal::InstructionSetBase<>::data.f_1_EDX_[26];
+  }
+
+  static bool has_FSGSBASE(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[0];
+  }
+  static bool has_AVX512VBMI(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[1];
+  }
+  static bool has_BMI1(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[3];
+  }
+  static bool has_HLE(void)
+  {
+    return internal::InstructionSetBase<>::data.isIntel_ &&
+           internal::InstructionSetBase<>::data.f_7_EBX_[4];
+  }
+  static bool has_AVX2(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[5];
+  }
+  static bool has_BMI2(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[8];
+  }
+  static bool has_ERMS(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[9];
+  }
+  static bool has_INVPCID(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[10];
+  }
+  static bool has_RTM(void)
+  {
+    return internal::InstructionSetBase<>::data.isIntel_ &&
+           internal::InstructionSetBase<>::data.f_7_EBX_[11];
+  }
+  static bool has_AVX512F(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[16];
+  }
+  static bool has_AVX512DQ(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[17];
+  }
+  static bool has_RDSEED(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[18];
+  }
+  static bool has_ADX(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[19];
+  }
+  static bool has_AVX512IFMA(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[21];
+  }
+  static bool has_AVX512PF(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[26];
+  }
+  static bool has_AVX512ER(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[27];
+  }
+  static bool has_AVX512CD(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[28];
+  }
+  static bool has_SHA(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[29];
+  }
+  static bool has_AVX512BW(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[30];
+  }
+  static bool has_AVX512VL(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_EBX_[31];
+  }
+
+  static bool has_PREFETCHWT1(void)
+  {
+    return internal::InstructionSetBase<>::data.f_7_ECX_[0];
+  }
+
+  static bool has_LAHF(void)
+  {
+    return internal::InstructionSetBase<>::data.f_81_ECX_[0];
+  }
+  static bool has_LZCNT(void)
+  {
+    return internal::InstructionSetBase<>::data.isIntel_ &&
+           internal::InstructionSetBase<>::data.f_81_ECX_[5];
+  }
+  static bool has_ABM(void)
+  {
+    return internal::InstructionSetBase<>::data.isAMD_ &&
+           internal::InstructionSetBase<>::data.f_81_ECX_[5];
+  }
+  static bool has_SSE4a(void)
+  {
+    return internal::InstructionSetBase<>::data.isAMD_ &&
+           internal::InstructionSetBase<>::data.f_81_ECX_[6];
+  }
+  static bool has_XOP(void)
+  {
+    return internal::InstructionSetBase<>::data.isAMD_ &&
+           internal::InstructionSetBase<>::data.f_81_ECX_[11];
+  }
+  static bool has_FMA4(void)
+  {
+    return internal::InstructionSetBase<>::data.isAMD_ &&
+           internal::InstructionSetBase<>::data.f_81_ECX_[16];
+  }
+  static bool has_TBM(void)
+  {
+    return internal::InstructionSetBase<>::data.isAMD_ &&
+           internal::InstructionSetBase<>::data.f_81_ECX_[21];
+  }
+
+  static bool has_SYSCALL(void)
+  {
+    return internal::InstructionSetBase<>::data.isIntel_ &&
+           internal::InstructionSetBase<>::data.f_81_EDX_[11];
+  }
+  static bool has_MMXEXT(void)
+  {
+    return internal::InstructionSetBase<>::data.isAMD_ &&
+           internal::InstructionSetBase<>::data.f_81_EDX_[22];
+  }
+  static bool has_RDTSCP(void)
+  {
+    return internal::InstructionSetBase<>::data.isIntel_ &&
+           internal::InstructionSetBase<>::data.f_81_EDX_[27];
+  }
+  static bool has_x64(void)
+  {
+    return internal::InstructionSetBase<>::data.isIntel_ &&
+           internal::InstructionSetBase<>::data.f_81_EDX_[29];
+  }
+  static bool has_3DNOWEXT(void)
+  {
+    return internal::InstructionSetBase<>::data.isAMD_ &&
+           internal::InstructionSetBase<>::data.f_81_EDX_[30];
+  }
+  static bool has_3DNOW(void)
+  {
+    return internal::InstructionSetBase<>::data.isAMD_ &&
+           internal::InstructionSetBase<>::data.f_81_EDX_[31];
+  }
 };
 
 } // helpers

--- a/include/proxsuite/helpers/instruction-set.hpp
+++ b/include/proxsuite/helpers/instruction-set.hpp
@@ -156,269 +156,116 @@ const typename InstructionSetBase<>::Data InstructionSetBase<>::data =
 // https://docs.microsoft.com/fr-fr/cpp/intrinsics/cpuid-cpuidex?view=msvc-170
 struct InstructionSet : public internal::InstructionSetBase<>
 {
-  static std::string vendor(void)
-  {
-    return internal::InstructionSetBase<>::data.vendor_;
-  }
-  static std::string brand(void)
-  {
-    return internal::InstructionSetBase<>::data.brand_;
-  }
+  typedef internal::InstructionSetBase<> Base;
 
-  static bool has_SSE3(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[0];
-  }
-  static bool has_PCLMULQDQ(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[1];
-  }
-  static bool has_MONITOR(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[3];
-  }
-  static bool has_SSSE3(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[9];
-  }
-  static bool has_FMA(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[12];
-  }
-  static bool has_CMPXCHG16B(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[13];
-  }
-  static bool has_SSE41(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[19];
-  }
-  static bool has_SSE42(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[20];
-  }
-  static bool has_MOVBE(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[22];
-  }
-  static bool has_POPCNT(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[23];
-  }
-  static bool has_AES(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[25];
-  }
-  static bool has_XSAVE(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[26];
-  }
-  static bool has_OSXSAVE(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[27];
-  }
-  static bool has_AVX(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[28];
-  }
-  static bool has_F16C(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[29];
-  }
-  static bool has_RDRAND(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_ECX_[30];
-  }
+  static std::string vendor(void) { return Base::data.vendor_; }
+  static std::string brand(void) { return Base::data.brand_; }
 
-  static bool has_MSR(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_EDX_[5];
-  }
-  static bool has_CX8(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_EDX_[8];
-  }
-  static bool has_SEP(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_EDX_[11];
-  }
-  static bool has_CMOV(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_EDX_[15];
-  }
-  static bool has_CLFSH(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_EDX_[19];
-  }
-  static bool has_MMX(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_EDX_[23];
-  }
-  static bool has_FXSR(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_EDX_[24];
-  }
-  static bool has_SSE(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_EDX_[25];
-  }
-  static bool has_SSE2(void)
-  {
-    return internal::InstructionSetBase<>::data.f_1_EDX_[26];
-  }
+  static bool has_SSE3(void) { return Base::data.f_1_ECX_[0]; }
+  static bool has_PCLMULQDQ(void) { return Base::data.f_1_ECX_[1]; }
+  static bool has_MONITOR(void) { return Base::data.f_1_ECX_[3]; }
+  static bool has_SSSE3(void) { return Base::data.f_1_ECX_[9]; }
+  static bool has_FMA(void) { return Base::data.f_1_ECX_[12]; }
+  static bool has_CMPXCHG16B(void) { return Base::data.f_1_ECX_[13]; }
+  static bool has_SSE41(void) { return Base::data.f_1_ECX_[19]; }
+  static bool has_SSE42(void) { return Base::data.f_1_ECX_[20]; }
+  static bool has_MOVBE(void) { return Base::data.f_1_ECX_[22]; }
+  static bool has_POPCNT(void) { return Base::data.f_1_ECX_[23]; }
+  static bool has_AES(void) { return Base::data.f_1_ECX_[25]; }
+  static bool has_XSAVE(void) { return Base::data.f_1_ECX_[26]; }
+  static bool has_OSXSAVE(void) { return Base::data.f_1_ECX_[27]; }
+  static bool has_AVX(void) { return Base::data.f_1_ECX_[28]; }
+  static bool has_F16C(void) { return Base::data.f_1_ECX_[29]; }
+  static bool has_RDRAND(void) { return Base::data.f_1_ECX_[30]; }
 
-  static bool has_FSGSBASE(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[0];
-  }
-  static bool has_AVX512VBMI(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[1];
-  }
-  static bool has_BMI1(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[3];
-  }
+  static bool has_MSR(void) { return Base::data.f_1_EDX_[5]; }
+  static bool has_CX8(void) { return Base::data.f_1_EDX_[8]; }
+  static bool has_SEP(void) { return Base::data.f_1_EDX_[11]; }
+  static bool has_CMOV(void) { return Base::data.f_1_EDX_[15]; }
+  static bool has_CLFSH(void) { return Base::data.f_1_EDX_[19]; }
+  static bool has_MMX(void) { return Base::data.f_1_EDX_[23]; }
+  static bool has_FXSR(void) { return Base::data.f_1_EDX_[24]; }
+  static bool has_SSE(void) { return Base::data.f_1_EDX_[25]; }
+  static bool has_SSE2(void) { return Base::data.f_1_EDX_[26]; }
+
+  static bool has_FSGSBASE(void) { return Base::data.f_7_EBX_[0]; }
+  static bool has_AVX512VBMI(void) { return Base::data.f_7_EBX_[1]; }
+  static bool has_BMI1(void) { return Base::data.f_7_EBX_[3]; }
   static bool has_HLE(void)
   {
-    return internal::InstructionSetBase<>::data.isIntel_ &&
-           internal::InstructionSetBase<>::data.f_7_EBX_[4];
+    return Base::data.isIntel_ && Base::data.f_7_EBX_[4];
   }
-  static bool has_AVX2(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[5];
-  }
-  static bool has_BMI2(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[8];
-  }
-  static bool has_ERMS(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[9];
-  }
-  static bool has_INVPCID(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[10];
-  }
+  static bool has_AVX2(void) { return Base::data.f_7_EBX_[5]; }
+  static bool has_BMI2(void) { return Base::data.f_7_EBX_[8]; }
+  static bool has_ERMS(void) { return Base::data.f_7_EBX_[9]; }
+  static bool has_INVPCID(void) { return Base::data.f_7_EBX_[10]; }
   static bool has_RTM(void)
   {
-    return internal::InstructionSetBase<>::data.isIntel_ &&
-           internal::InstructionSetBase<>::data.f_7_EBX_[11];
+    return Base::data.isIntel_ && Base::data.f_7_EBX_[11];
   }
-  static bool has_AVX512F(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[16];
-  }
-  static bool has_AVX512DQ(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[17];
-  }
-  static bool has_RDSEED(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[18];
-  }
-  static bool has_ADX(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[19];
-  }
-  static bool has_AVX512IFMA(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[21];
-  }
-  static bool has_AVX512PF(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[26];
-  }
-  static bool has_AVX512ER(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[27];
-  }
-  static bool has_AVX512CD(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[28];
-  }
-  static bool has_SHA(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[29];
-  }
-  static bool has_AVX512BW(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[30];
-  }
-  static bool has_AVX512VL(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_EBX_[31];
-  }
+  static bool has_AVX512F(void) { return Base::data.f_7_EBX_[16]; }
+  static bool has_AVX512DQ(void) { return Base::data.f_7_EBX_[17]; }
+  static bool has_RDSEED(void) { return Base::data.f_7_EBX_[18]; }
+  static bool has_ADX(void) { return Base::data.f_7_EBX_[19]; }
+  static bool has_AVX512IFMA(void) { return Base::data.f_7_EBX_[21]; }
+  static bool has_AVX512PF(void) { return Base::data.f_7_EBX_[26]; }
+  static bool has_AVX512ER(void) { return Base::data.f_7_EBX_[27]; }
+  static bool has_AVX512CD(void) { return Base::data.f_7_EBX_[28]; }
+  static bool has_SHA(void) { return Base::data.f_7_EBX_[29]; }
+  static bool has_AVX512BW(void) { return Base::data.f_7_EBX_[30]; }
+  static bool has_AVX512VL(void) { return Base::data.f_7_EBX_[31]; }
 
-  static bool has_PREFETCHWT1(void)
-  {
-    return internal::InstructionSetBase<>::data.f_7_ECX_[0];
-  }
+  static bool has_PREFETCHWT1(void) { return Base::data.f_7_ECX_[0]; }
 
-  static bool has_LAHF(void)
-  {
-    return internal::InstructionSetBase<>::data.f_81_ECX_[0];
-  }
+  static bool has_LAHF(void) { return Base::data.f_81_ECX_[0]; }
   static bool has_LZCNT(void)
   {
-    return internal::InstructionSetBase<>::data.isIntel_ &&
-           internal::InstructionSetBase<>::data.f_81_ECX_[5];
+    return Base::data.isIntel_ && Base::data.f_81_ECX_[5];
   }
   static bool has_ABM(void)
   {
-    return internal::InstructionSetBase<>::data.isAMD_ &&
-           internal::InstructionSetBase<>::data.f_81_ECX_[5];
+    return Base::data.isAMD_ && Base::data.f_81_ECX_[5];
   }
   static bool has_SSE4a(void)
   {
-    return internal::InstructionSetBase<>::data.isAMD_ &&
-           internal::InstructionSetBase<>::data.f_81_ECX_[6];
+    return Base::data.isAMD_ && Base::data.f_81_ECX_[6];
   }
   static bool has_XOP(void)
   {
-    return internal::InstructionSetBase<>::data.isAMD_ &&
-           internal::InstructionSetBase<>::data.f_81_ECX_[11];
+    return Base::data.isAMD_ && Base::data.f_81_ECX_[11];
   }
   static bool has_FMA4(void)
   {
-    return internal::InstructionSetBase<>::data.isAMD_ &&
-           internal::InstructionSetBase<>::data.f_81_ECX_[16];
+    return Base::data.isAMD_ && Base::data.f_81_ECX_[16];
   }
   static bool has_TBM(void)
   {
-    return internal::InstructionSetBase<>::data.isAMD_ &&
-           internal::InstructionSetBase<>::data.f_81_ECX_[21];
+    return Base::data.isAMD_ && Base::data.f_81_ECX_[21];
   }
 
   static bool has_SYSCALL(void)
   {
-    return internal::InstructionSetBase<>::data.isIntel_ &&
-           internal::InstructionSetBase<>::data.f_81_EDX_[11];
+    return Base::data.isIntel_ && Base::data.f_81_EDX_[11];
   }
   static bool has_MMXEXT(void)
   {
-    return internal::InstructionSetBase<>::data.isAMD_ &&
-           internal::InstructionSetBase<>::data.f_81_EDX_[22];
+    return Base::data.isAMD_ && Base::data.f_81_EDX_[22];
   }
   static bool has_RDTSCP(void)
   {
-    return internal::InstructionSetBase<>::data.isIntel_ &&
-           internal::InstructionSetBase<>::data.f_81_EDX_[27];
+    return Base::data.isIntel_ && Base::data.f_81_EDX_[27];
   }
   static bool has_x64(void)
   {
-    return internal::InstructionSetBase<>::data.isIntel_ &&
-           internal::InstructionSetBase<>::data.f_81_EDX_[29];
+    return Base::data.isIntel_ && Base::data.f_81_EDX_[29];
   }
   static bool has_3DNOWEXT(void)
   {
-    return internal::InstructionSetBase<>::data.isAMD_ &&
-           internal::InstructionSetBase<>::data.f_81_EDX_[30];
+    return Base::data.isAMD_ && Base::data.f_81_EDX_[30];
   }
   static bool has_3DNOW(void)
   {
-    return internal::InstructionSetBase<>::data.isAMD_ &&
-           internal::InstructionSetBase<>::data.f_81_EDX_[31];
+    return Base::data.isAMD_ && Base::data.f_81_EDX_[31];
   }
 };
 

--- a/include/proxsuite/helpers/instruction-set.hpp
+++ b/include/proxsuite/helpers/instruction-set.hpp
@@ -154,8 +154,6 @@ const typename InstructionSetBase<>::Data InstructionSetBase<>::data =
 
 // Adapted from
 // https://docs.microsoft.com/fr-fr/cpp/intrinsics/cpuid-cpuidex?view=msvc-170
-// template <typename T>
-// struct InstructionSet: public internal::InstructionSetBase<T>
 struct InstructionSet : public internal::InstructionSetBase<>
 {
   static std::string vendor(void)

--- a/include/proxsuite/helpers/optional.hpp
+++ b/include/proxsuite/helpers/optional.hpp
@@ -21,10 +21,23 @@ using optional = std::optional<T>;
 using nullopt_t = std::nullopt_t;
 inline constexpr nullopt_t nullopt = std::nullopt;
 #else
+namespace detail {
+// Source boost: https://www.boost.org/doc/libs/1_74_0/boost/none.hpp
+// the trick here is to make instance defined once as a global but in a header
+// file
+template<typename T>
+struct nullopt_instance
+{
+  static const T instance;
+};
+template<typename T>
+const T nullopt_instance<T>::instance =
+  T(tl::nullopt); // global, but because 'tis a template, no cpp file required
+} // namespace detail
 template<class T>
 using optional = tl::optional<T>;
 using nullopt_t = tl::nullopt_t;
-inline constexpr nullopt_t nullopt = tl::nullopt;
+constexpr nullopt_t nullopt = detail::nullopt_instance<tl::nullopt_t>::instance;
 #endif
 } // namespace proxsuite
 

--- a/include/proxsuite/linalg/veg/memory/alloc.hpp
+++ b/include/proxsuite/linalg/veg/memory/alloc.hpp
@@ -28,7 +28,8 @@ namespace veg {
 namespace alignment {
 
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= 101500 &&                                 \
-  (defined(_LIBCPP_HAS_ALIGNED_ALLOC) || defined(_LIBCPP_HAS_C11_FEATURES))
+  (defined(_LIBCPP_HAS_ALIGNED_ALLOC) || defined(_LIBCPP_HAS_C11_FEATURES)) && \
+  defined(PROXSUITE_WITH_CPP_17)
 VEG_INLINE void*
 aligned_alloc(std::size_t alignment, std::size_t size)
 {
@@ -167,11 +168,15 @@ aligned_alloc(usize align, usize size) noexcept -> void*
 #if defined(_WIN32)
   return _aligned_malloc((size + mask) & ~mask, align);
 #elif defined(__APPLE__)
+#if defined(PROXSUITE_WITH_CPP_17)
   return alignment::aligned_alloc(align, (size + mask) & ~mask);
+#elif defined(PROXSUITE_WITH_CPP_14)
+  return alignment::detail::aligned_alloc(align, (size + mask) & ~mask);
+#endif
 #else
 #ifdef PROXSUITE_WITH_CPP_17
   return std::aligned_alloc(align, (size + mask) & ~mask);
-#else
+#elif defined(PROXSUITE_WITH_CPP_14)
   return alignment::detail::aligned_alloc(align, (size + mask) & ~mask);
 #endif
 #endif

--- a/include/proxsuite/proxqp/dense/wrapper.hpp
+++ b/include/proxsuite/proxqp/dense/wrapper.hpp
@@ -327,11 +327,11 @@ struct QP
    * @param mu_eq proximal step size wrt equality constrained multiplier.
    * @param mu_in proximal step size wrt inequality constrained multiplier.
    */
-  void update([[maybe_unused]] const nullopt_t H,
+  void update(PROXSUITE_MAYBE_UNUSED const nullopt_t H,
               optional<Vec<T>> g,
-              [[maybe_unused]] const nullopt_t A,
+              PROXSUITE_MAYBE_UNUSED const nullopt_t A,
               optional<Vec<T>> b,
-              [[maybe_unused]] const nullopt_t C,
+              PROXSUITE_MAYBE_UNUSED const nullopt_t C,
               optional<Vec<T>> l,
               optional<Vec<T>> u,
               bool update_preconditioner = true,


### PR DESCRIPTION
This PR adds one additonal pipeline running the macos workflow with std=c++14. In the `CMakeLists.txt` file, we check now that the defined cxx standard is at least 14, but our default will still be 17 if user is not setting it.