### PR TITLE
Additional option to check eigen runtime malloc

### DIFF
--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -89,8 +89,6 @@ jobs:
       run: |
         echo $(whereis ccache)
         echo $(which ccache)
-        git submodule update --init
-        mkdir build
         cd build
         cmake .. -GNinja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCHECK_RUNTIME_MALLOC:BOOL=ON -DCMAKE_CXX_STANDARD=${{ matrix.cxx_std }} -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_EXECUTABLE=$(which python3) -DINSTALL_DOCUMENTATION:BOOL=ON -DTEST_JULIA_INTERFACE:BOOL=ON
 

--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -83,6 +83,17 @@ jobs:
         cd build
         cmake .. -GNinja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_STANDARD=${{ matrix.cxx_std }} -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_EXECUTABLE=$(which python3) -DINSTALL_DOCUMENTATION:BOOL=ON -DTEST_JULIA_INTERFACE:BOOL=ON
 
+    - name: Configure [Conda/macOS-debug/CheckMalloc]
+      if: contains(matrix.os, 'macos') && contains(matrix.build_type, 'Debug')
+      shell: bash -l {0}
+      run: |
+        echo $(whereis ccache)
+        echo $(which ccache)
+        git submodule update --init
+        mkdir build
+        cd build
+        cmake .. -GNinja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCHECK_RUNTIME_MALLOC:BOOL=ON -DCMAKE_CXX_STANDARD=${{ matrix.cxx_std }} -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_EXECUTABLE=$(which python3) -DINSTALL_DOCUMENTATION:BOOL=ON -DTEST_JULIA_INTERFACE:BOOL=ON
+
     - name: Configure [Conda/Windows-2019]
       if: contains(matrix.os, 'windows-2019')
       shell: bash -l {0}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,25 +146,6 @@ install(
   ARCHIVE DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
 
-# Activate only for advanced users to profile and benchmark the code
-if(ADVANCED_USERS)
-  include(${CMAKE_CURRENT_LIST_DIR}/cmake-module/compiler_warnings.cmake)
-  include(${CMAKE_CURRENT_LIST_DIR}/cmake-module/extra_local_settings.cmake)
-  include(${CMAKE_CURRENT_LIST_DIR}/cmake-module/static_analyzers.cmake)
-  include(${CMAKE_CURRENT_LIST_DIR}/cmake-module/sanitizers.cmake)
-
-  target_compile_definitions(proxsuite INTERFACE EIGEN_RUNTIME_NO_MALLOC)
-  target_compile_definitions(proxsuite
-                             INTERFACE EIGEN_INITIALIZE_MATRICES_BY_NAN)
-  add_library(project_warnings INTERFACE)
-  add_library(project_options INTERFACE)
-
-  target_link_libraries(proxsuite INTERFACE project_options project_warnings)
-
-  set_project_warnings(project_warnings)
-  enable_sanitizers(project_options)
-endif()
-
 add_subdirectory(bindings)
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,9 @@ apply_default_apple_configuration()
 
 option(BUILD_PYTHON_INTERFACE "Build the Python bindings" OFF)
 option(INSTALL_DOCUMENTATION "Generate and install the C++ documentation" OFF)
-option(INITIALIZE_EIGEN_WITH_NAN "Initializa Eigen objects with NAN values" OFF)
+option(INITIALIZE_EIGEN_WITH_NAN "Initialize Eigen objects with NAN values" OFF)
+option(CHECK_RUNTIME_MALLOC
+       "Check if some memory allocations are performed at runtime" OFF)
 option(SUFFIX_SO_VERSION "Suffix library name with its version" ON)
 
 option(BUILD_WITH_VECTORIZATION_SUPPORT
@@ -71,6 +73,11 @@ message(STATUS "CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
 if(INITIALIZE_EIGEN_WITH_NAN)
   add_definitions(-DEIGEN_INITIALIZE_MATRICES_BY_NAN)
 endif(INITIALIZE_EIGEN_WITH_NAN)
+if(CHECK_RUNTIME_MALLOC)
+  message(STATUS "Check if some memory allocations are performed at runtime.")
+  add_definitions(-DPROXSUITE_EIGEN_CHECK_MALLOC)
+  add_definitions(-DEIGEN_RUNTIME_NO_MALLOC)
+endif(CHECK_RUNTIME_MALLOC)
 
 # set CXX standard
 if(DEFINED CMAKE_CXX_STANDARD)
@@ -141,10 +148,10 @@ install(
 
 # Activate only for advanced users to profile and benchmark the code
 if(ADVANCED_USERS)
-  include(cmake/compiler_warnings.cmake)
-  include(cmake/extra_local_settings.cmake)
-  include(cmake/static_analyzers.cmake)
-  include(cmake/sanitizers.cmake)
+  include(${CMAKE_CURRENT_LIST_DIR}/cmake-module/compiler_warnings.cmake)
+  include(${CMAKE_CURRENT_LIST_DIR}/cmake-module/extra_local_settings.cmake)
+  include(${CMAKE_CURRENT_LIST_DIR}/cmake-module/static_analyzers.cmake)
+  include(${CMAKE_CURRENT_LIST_DIR}/cmake-module/sanitizers.cmake)
 
   target_compile_definitions(proxsuite INTERFACE EIGEN_RUNTIME_NO_MALLOC)
   target_compile_definitions(proxsuite

--- a/include/proxsuite/fwd.hpp
+++ b/include/proxsuite/fwd.hpp
@@ -20,4 +20,33 @@
 #define PROXSUITE_MAYBE_UNUSED __attribute__((__unused__))
 #endif
 
+// Same logic as in Pinocchio to check eigen malloc
+#ifdef PROXSUITE_EIGEN_CHECK_MALLOC
+#ifndef EIGEN_RUNTIME_NO_MALLOC
+#define EIGEN_RUNTIME_NO_MALLOC_WAS_NOT_DEFINED
+#define EIGEN_RUNTIME_NO_MALLOC
+#endif
+#endif
+
+#include <Eigen/Core>
+
+#ifdef PROXSUITE_EIGEN_CHECK_MALLOC
+#ifdef EIGEN_RUNTIME_NO_MALLOC_WAS_NOT_DEFINED
+#undef EIGEN_RUNTIME_NO_MALLOC
+#undef EIGEN_RUNTIME_NO_MALLOC_WAS_NOT_DEFINED
+#endif
+#endif
+
+// Check memory allocation for Eigen
+#ifdef PROXSUITE_EIGEN_CHECK_MALLOC
+#define PROXSUITE_EIGEN_MALLOC(allowed)                                        \
+  ::Eigen::internal::set_is_malloc_allowed(allowed)
+#define PROXSUITE_EIGEN_MALLOC_ALLOWED() PROXSUITE_EIGEN_MALLOC(true)
+#define PROXSUITE_EIGEN_MALLOC_NOT_ALLOWED() PROXSUITE_EIGEN_MALLOC(false)
+#else
+#define PROXSUITE_EIGEN_MALLOC(allowed)
+#define PROXSUITE_EIGEN_MALLOC_ALLOWED()
+#define PROXSUITE_EIGEN_MALLOC_NOT_ALLOWED()
+#endif
+
 #endif // #ifndef __proxsuite_fwd_hpp__

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -8,6 +8,7 @@
 #ifndef PROXSUITE_PROXQP_DENSE_SOLVER_HPP
 #define PROXSUITE_PROXQP_DENSE_SOLVER_HPP
 
+#include "proxsuite/fwd.hpp"
 #include "proxsuite/proxqp/dense/views.hpp"
 #include "proxsuite/proxqp/dense/linesearch.hpp"
 #include "proxsuite/proxqp/dense/helpers.hpp"
@@ -765,7 +766,8 @@ qp_solve( //
   RowMat test(2,2); // test it is full of nan for debug
   std::cout << "test " << test << std::endl;
   */
-  //::Eigen::internal::set_is_malloc_allowed(false);
+  PROXSUITE_EIGEN_MALLOC_NOT_ALLOWED();
+
   if (qpsettings.compute_timings) {
     qpwork.timer.stop();
     qpwork.timer.start();
@@ -1291,6 +1293,7 @@ qp_solve( //
               << std::endl;
   }
   qpwork.dirty = true;
+  PROXSUITE_EIGEN_MALLOC_ALLOWED();
 }
 
 } // namespace dense


### PR DESCRIPTION
after #91 , seems useful to have an option to quickly check. The macOS debug pipeline was adapted to use the `CHECK_RUNTIME_MALLOC` option. For now, this is just introduced in the dense backend.