### PR TITLE
Add duality gap measure

### DIFF
--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -1087,8 +1087,8 @@ qp_solve( //
         qpresults.info.rho = rho_new;
       }
       if (is_dual_feasible) {
-        if (qpresults.info.duality_gap <=
-            qpsettings.eps_abs * rhs_duality_gap) {
+        if (qpresults.info.duality_gap <= qpsettings.eps_abs + 
+           (qpsettings.eps_abs + qpsettings.eps_rel) * rhs_duality_gap) {
           qpresults.info.status = QPSolverOutput::PROXQP_SOLVED;
           break;
         }
@@ -1169,8 +1169,8 @@ qp_solve( //
              std::max(dual_feasibility_rhs_1, qpwork.dual_feasibility_rhs_2)));
 
       if (is_dual_feasible) {
-        if (qpresults.info.duality_gap <=
-            qpsettings.eps_abs * rhs_duality_gap) {
+        if (qpresults.info.duality_gap <= qpsettings.eps_abs +
+            (qpsettings.eps_abs + qpsettings.eps_rel) * rhs_duality_gap) {
           qpresults.info.status = QPSolverOutput::PROXQP_SOLVED;
           break;
         }

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -987,9 +987,6 @@ qp_solve( //
 
   T duality_gap(0);
   T rhs_duality_gap(0);
-  isize max_dim = std::max(qpmodel.dim, qpmodel.n_eq);
-  max_dim = std::max(max_dim, qpmodel.n_in);
-  T sqrt_max_dim(std::sqrt(max_dim));
 
   for (i64 iter = 0; iter < qpsettings.max_iter; ++iter) {
 
@@ -1015,8 +1012,7 @@ qp_solve( //
                          dual_feasibility_rhs_1,
                          dual_feasibility_rhs_3,
                          rhs_duality_gap,
-                         duality_gap,
-                         sqrt_max_dim);
+                         duality_gap);
     qpresults.info.pri_res = primal_feasibility_lhs;
     qpresults.info.dua_res = dual_feasibility_lhs;
     qpresults.info.duality_gap = duality_gap;
@@ -1160,8 +1156,7 @@ qp_solve( //
                            dual_feasibility_rhs_1,
                            dual_feasibility_rhs_3,
                            rhs_duality_gap,
-                           duality_gap,
-                           sqrt_max_dim);
+                           duality_gap);
       qpresults.info.dua_res = dual_feasibility_lhs_new;
       qpresults.info.duality_gap = duality_gap;
 
@@ -1220,8 +1215,7 @@ qp_solve( //
                          dual_feasibility_rhs_1,
                          dual_feasibility_rhs_3,
                          rhs_duality_gap,
-                         duality_gap,
-                         sqrt_max_dim);
+                         duality_gap);
     qpresults.info.dua_res = dual_feasibility_lhs_new;
     qpresults.info.duality_gap = duality_gap;
 

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -985,6 +985,12 @@ qp_solve( //
   T primal_feasibility_in_lhs(0);
   T dual_feasibility_lhs(0);
 
+  T duality_gap(0);
+  T rhs_duality_gap(0);
+  isize max_dim = std::max(qpmodel.dim,qpmodel.n_eq);
+  max_dim = std::max(max_dim,qpmodel.n_in);
+  T sqrt_max_dim(std::sqrt(max_dim));
+
   for (i64 iter = 0; iter < qpsettings.max_iter; ++iter) {
 
     // compute primal residual
@@ -1002,13 +1008,19 @@ qp_solve( //
 
     global_dual_residual(qpresults,
                          qpwork,
+                         qpmodel,
                          ruiz,
                          dual_feasibility_lhs,
                          dual_feasibility_rhs_0,
                          dual_feasibility_rhs_1,
-                         dual_feasibility_rhs_3);
+                         dual_feasibility_rhs_3,
+                         rhs_duality_gap,
+                         duality_gap,
+                         sqrt_max_dim
+                         );
     qpresults.info.pri_res = primal_feasibility_lhs;
     qpresults.info.dua_res = dual_feasibility_lhs;
+    qpresults.info.duality_gap = duality_gap;
 
     T new_bcl_mu_in(qpresults.info.mu_in);
     T new_bcl_mu_eq(qpresults.info.mu_eq);
@@ -1059,8 +1071,9 @@ qp_solve( //
       std::cout << std::scientific << std::setw(2) << std::setprecision(2)
                 << "| primal residual=" << qpresults.info.pri_res
                 << "| dual residual=" << qpresults.info.dua_res
-                << " | mu_in=" << qpresults.info.mu_in
-                << " | rho=" << qpresults.info.rho << std::endl;
+                << "| duality gap=" << qpresults.info.duality_gap
+                << "| mu_in=" << qpresults.info.mu_in
+                << "| rho=" << qpresults.info.rho << std::endl;
       ruiz.scale_primal_in_place(VectorViewMut<T>{ from_eigen, qpresults.x });
       ruiz.scale_dual_in_place_eq(VectorViewMut<T>{ from_eigen, qpresults.y });
       ruiz.scale_dual_in_place_in(VectorViewMut<T>{ from_eigen, qpresults.z });
@@ -1079,8 +1092,10 @@ qp_solve( //
         qpresults.info.rho = rho_new;
       }
       if (is_dual_feasible) {
-        qpresults.info.status = QPSolverOutput::PROXQP_SOLVED;
-        break;
+        if (qpresults.info.duality_gap<=qpsettings.eps_abs* rhs_duality_gap ){
+          qpresults.info.status = QPSolverOutput::PROXQP_SOLVED;
+          break;
+        }
       }
     }
     qpresults.info.iter_ext += 1; // We start a new external loop update
@@ -1138,12 +1153,17 @@ qp_solve( //
 
       global_dual_residual(qpresults,
                            qpwork,
+                           qpmodel,
                            ruiz,
                            dual_feasibility_lhs_new,
                            dual_feasibility_rhs_0,
                            dual_feasibility_rhs_1,
-                           dual_feasibility_rhs_3);
+                           dual_feasibility_rhs_3,
+                           rhs_duality_gap,
+                           duality_gap,
+                           sqrt_max_dim);
       qpresults.info.dua_res = dual_feasibility_lhs_new;
+      qpresults.info.duality_gap = duality_gap;
 
       is_dual_feasible =
         dual_feasibility_lhs_new <=
@@ -1154,8 +1174,10 @@ qp_solve( //
              std::max(dual_feasibility_rhs_1, qpwork.dual_feasibility_rhs_2)));
 
       if (is_dual_feasible) {
-        qpresults.info.status = QPSolverOutput::PROXQP_SOLVED;
-        break;
+        if (qpresults.info.duality_gap<=qpsettings.eps_abs * rhs_duality_gap ){
+          qpresults.info.status = QPSolverOutput::PROXQP_SOLVED;
+          break;
+        }
       }
     }
     if (qpsettings.bcl_update) {
@@ -1190,12 +1212,17 @@ qp_solve( //
 
     global_dual_residual(qpresults,
                          qpwork,
+                         qpmodel,
                          ruiz,
                          dual_feasibility_lhs_new,
                          dual_feasibility_rhs_0,
                          dual_feasibility_rhs_1,
-                         dual_feasibility_rhs_3);
+                         dual_feasibility_rhs_3,
+                         rhs_duality_gap,
+                         duality_gap,
+                         sqrt_max_dim);
     qpresults.info.dua_res = dual_feasibility_lhs_new;
+    qpresults.info.duality_gap = duality_gap;
 
     if (primal_feasibility_lhs_new >= primal_feasibility_lhs &&
         dual_feasibility_lhs_new >= dual_feasibility_lhs &&

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -987,8 +987,8 @@ qp_solve( //
 
   T duality_gap(0);
   T rhs_duality_gap(0);
-  isize max_dim = std::max(qpmodel.dim,qpmodel.n_eq);
-  max_dim = std::max(max_dim,qpmodel.n_in);
+  isize max_dim = std::max(qpmodel.dim, qpmodel.n_eq);
+  max_dim = std::max(max_dim, qpmodel.n_in);
   T sqrt_max_dim(std::sqrt(max_dim));
 
   for (i64 iter = 0; iter < qpsettings.max_iter; ++iter) {
@@ -1016,8 +1016,7 @@ qp_solve( //
                          dual_feasibility_rhs_3,
                          rhs_duality_gap,
                          duality_gap,
-                         sqrt_max_dim
-                         );
+                         sqrt_max_dim);
     qpresults.info.pri_res = primal_feasibility_lhs;
     qpresults.info.dua_res = dual_feasibility_lhs;
     qpresults.info.duality_gap = duality_gap;
@@ -1092,7 +1091,8 @@ qp_solve( //
         qpresults.info.rho = rho_new;
       }
       if (is_dual_feasible) {
-        if (qpresults.info.duality_gap<=qpsettings.eps_abs* rhs_duality_gap ){
+        if (qpresults.info.duality_gap <=
+            qpsettings.eps_abs * rhs_duality_gap) {
           qpresults.info.status = QPSolverOutput::PROXQP_SOLVED;
           break;
         }
@@ -1174,7 +1174,8 @@ qp_solve( //
              std::max(dual_feasibility_rhs_1, qpwork.dual_feasibility_rhs_2)));
 
       if (is_dual_feasible) {
-        if (qpresults.info.duality_gap<=qpsettings.eps_abs * rhs_duality_gap ){
+        if (qpresults.info.duality_gap <=
+            qpsettings.eps_abs * rhs_duality_gap) {
           qpresults.info.status = QPSolverOutput::PROXQP_SOLVED;
           break;
         }

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -1087,8 +1087,9 @@ qp_solve( //
         qpresults.info.rho = rho_new;
       }
       if (is_dual_feasible) {
-        if (qpresults.info.duality_gap <= qpsettings.eps_abs + 
-           (qpsettings.eps_abs + qpsettings.eps_rel) * rhs_duality_gap) {
+        if (qpresults.info.duality_gap <=
+            qpsettings.eps_abs +
+              (qpsettings.eps_abs + qpsettings.eps_rel) * rhs_duality_gap) {
           qpresults.info.status = QPSolverOutput::PROXQP_SOLVED;
           break;
         }
@@ -1169,8 +1170,9 @@ qp_solve( //
              std::max(dual_feasibility_rhs_1, qpwork.dual_feasibility_rhs_2)));
 
       if (is_dual_feasible) {
-        if (qpresults.info.duality_gap <= qpsettings.eps_abs +
-            (qpsettings.eps_abs + qpsettings.eps_rel) * rhs_duality_gap) {
+        if (qpresults.info.duality_gap <=
+            qpsettings.eps_abs +
+              (qpsettings.eps_abs + qpsettings.eps_rel) * rhs_duality_gap) {
           qpresults.info.status = QPSolverOutput::PROXQP_SOLVED;
           break;
         }

--- a/include/proxsuite/proxqp/dense/utils.hpp
+++ b/include/proxsuite/proxqp/dense/utils.hpp
@@ -352,8 +352,7 @@ global_dual_residual(const Results<T>& qpresults,
                      T& dual_feasibility_rhs_1,
                      T& dual_feasibility_rhs_3,
                      T& rhs_duality_gap,
-                     T& duality_gap,
-                     T sqrt_max_dim)
+                     T& duality_gap)
 {
   // dual_feasibility_lhs = norm(dual_residual_scaled)
   // dual_feasibility_rhs_0 = norm(unscaled(Hx))
@@ -361,6 +360,9 @@ global_dual_residual(const Results<T>& qpresults,
   // dual_feasibility_rhs_3 = norm(unscaled(CTz))
   //
   // dual_residual_scaled = scaled(Hx + g + ATy + CTz)
+  const isize max_dim = std::max(qpmodel.dim,std::max(qpmodel.n_eq,qpmodel.n_in));
+  const T sqrt_max_dim(std::sqrt(max_dim)); // for normalizing scalar products 
+
   qpwork.dual_residual_scaled = qpwork.g_scaled;
   qpwork.CTz.noalias() =
     qpwork.H_scaled.template selfadjointView<Eigen::Lower>() * qpresults.x;

--- a/include/proxsuite/proxqp/dense/utils.hpp
+++ b/include/proxsuite/proxqp/dense/utils.hpp
@@ -343,7 +343,7 @@ global_dual_residual_infeasibility(
  */
 template<typename T>
 void
-global_dual_residual(const Results<T>& qpresults,
+global_dual_residual(Results<T>& qpresults,
                      Workspace<T>& qpwork,
                      const Model<T>& qpmodel,
                      const preconditioner::RuizEquilibration<T>& ruiz,

--- a/include/proxsuite/proxqp/dense/utils.hpp
+++ b/include/proxsuite/proxqp/dense/utils.hpp
@@ -372,9 +372,9 @@ global_dual_residual(const Results<T>& qpresults,
   ruiz.unscale_primal_in_place(VectorViewMut<T>{ from_eigen, qpresults.x });
   duality_gap = (qpmodel.g).dot(qpresults.x);
   rhs_duality_gap = std::abs(duality_gap);
-  T xHx = (qpwork.CTz).dot(qpresults.x) ;
-  duality_gap += xHx;// contains now xHx+g.Tx
-  rhs_duality_gap = std::max(rhs_duality_gap,std::abs(xHx));
+  T xHx = (qpwork.CTz).dot(qpresults.x);
+  duality_gap += xHx; // contains now xHx+g.Tx
+  rhs_duality_gap = std::max(rhs_duality_gap, std::abs(xHx));
 
   ruiz.scale_primal_in_place(VectorViewMut<T>{ from_eigen, qpresults.x });
 
@@ -398,24 +398,21 @@ global_dual_residual(const Results<T>& qpresults,
   ruiz.scale_dual_residual_in_place(
     VectorViewMut<T>{ from_eigen, qpwork.dual_residual_scaled });
 
-  ruiz.unscale_dual_in_place_eq(
-    VectorViewMut<T>{ from_eigen, qpresults.y });
+  ruiz.unscale_dual_in_place_eq(VectorViewMut<T>{ from_eigen, qpresults.y });
   T by = (qpmodel.b).dot(qpresults.y);
-  rhs_duality_gap = std::max(rhs_duality_gap,std::abs(by));
+  rhs_duality_gap = std::max(rhs_duality_gap, std::abs(by));
   duality_gap += by;
   ruiz.scale_dual_in_place_eq(VectorViewMut<T>{ from_eigen, qpresults.y });
-  ruiz.unscale_dual_in_place_in(
-    VectorViewMut<T>{ from_eigen, qpresults.z });
-  T zu= positive_part(qpresults.z).dot(qpmodel.u);
-  rhs_duality_gap = std::max(rhs_duality_gap,std::abs(zu));
+  ruiz.unscale_dual_in_place_in(VectorViewMut<T>{ from_eigen, qpresults.z });
+  T zu = positive_part(qpresults.z).dot(qpmodel.u);
+  rhs_duality_gap = std::max(rhs_duality_gap, std::abs(zu));
   duality_gap += zu;
   T zl = negative_part(qpresults.z).dot(qpmodel.l);
-  rhs_duality_gap = std::max(rhs_duality_gap,std::abs(zl));
+  rhs_duality_gap = std::max(rhs_duality_gap, std::abs(zl));
   duality_gap += zl;
-  ruiz.scale_dual_in_place_in(
-    VectorViewMut<T>{ from_eigen, qpresults.z });
+  ruiz.scale_dual_in_place_in(VectorViewMut<T>{ from_eigen, qpresults.z });
   duality_gap /= sqrt_max_dim; // in order to get an a-dimensional duality gap
-  rhs_duality_gap +=1.;
+  rhs_duality_gap += 1.;
 }
 
 } // namespace dense

--- a/include/proxsuite/proxqp/dense/utils.hpp
+++ b/include/proxsuite/proxqp/dense/utils.hpp
@@ -360,8 +360,9 @@ global_dual_residual(const Results<T>& qpresults,
   // dual_feasibility_rhs_3 = norm(unscaled(CTz))
   //
   // dual_residual_scaled = scaled(Hx + g + ATy + CTz)
-  const isize max_dim = std::max(qpmodel.dim,std::max(qpmodel.n_eq,qpmodel.n_in));
-  const T sqrt_max_dim(std::sqrt(max_dim)); // for normalizing scalar products 
+  const isize max_dim =
+    std::max(qpmodel.dim, std::max(qpmodel.n_eq, qpmodel.n_in));
+  const T sqrt_max_dim(std::sqrt(max_dim)); // for normalizing scalar products
 
   qpwork.dual_residual_scaled = qpwork.g_scaled;
   qpwork.CTz.noalias() =

--- a/include/proxsuite/proxqp/dense/utils.hpp
+++ b/include/proxsuite/proxqp/dense/utils.hpp
@@ -415,7 +415,6 @@ global_dual_residual(const Results<T>& qpresults,
   duality_gap += zl;
   ruiz.scale_dual_in_place_in(VectorViewMut<T>{ from_eigen, qpresults.z });
   duality_gap /= sqrt_max_dim; // in order to get an a-dimensional duality gap
-  rhs_duality_gap += 1.;
 }
 
 } // namespace dense

--- a/include/proxsuite/proxqp/dense/utils.hpp
+++ b/include/proxsuite/proxqp/dense/utils.hpp
@@ -373,7 +373,7 @@ global_dual_residual(const Results<T>& qpresults,
   duality_gap = (qpmodel.g).dot(qpresults.x);
   rhs_duality_gap = std::abs(duality_gap);
   T xHx = (qpwork.CTz).dot(qpresults.x) ;
-  duality_gap += xHx;// contains now 0.5*xHx+g.Tx
+  duality_gap += xHx;// contains now xHx+g.Tx
   rhs_duality_gap = std::max(rhs_duality_gap,std::abs(xHx));
 
   ruiz.scale_primal_in_place(VectorViewMut<T>{ from_eigen, qpresults.x });

--- a/include/proxsuite/proxqp/results.hpp
+++ b/include/proxsuite/proxqp/results.hpp
@@ -49,7 +49,7 @@ struct Info
   T objValue;
   T pri_res;
   T dua_res;
-
+  T duality_gap;
   //// sparse backend used by solver, either CholeskySparse or MatrixFree
   SparseBackend sparse_backend;
 };
@@ -106,6 +106,7 @@ struct Results
     info.objValue = 0.;
     info.pri_res = 0.;
     info.dua_res = 0.;
+    info.duality_gap = 0.;
     info.status = QPSolverOutput::PROXQP_NOT_RUN;
     info.sparse_backend = SparseBackend::Automatic;
   }
@@ -132,6 +133,7 @@ struct Results
     info.rho_updates = 0;
     info.pri_res = 0.;
     info.dua_res = 0.;
+    info.duality_gap = 0.;
     info.status = QPSolverOutput::PROXQP_MAX_ITER_REACHED;
     info.sparse_backend = SparseBackend::Automatic;
   }

--- a/include/proxsuite/proxqp/sparse/solver.hpp
+++ b/include/proxsuite/proxqp/sparse/solver.hpp
@@ -724,6 +724,11 @@ qp_solve(Results<T>& results,
       break;
     }
   }
+  T rhs_duality_gap(0);
+  isize max_dim = std::max(data.dim,data.n_eq);
+  max_dim = std::max(max_dim,data.n_in);
+  T sqrt_max_dim(std::sqrt(max_dim));
+  
   for (isize iter = 0; iter < settings.max_iter; ++iter) {
 
     results.info.iter_ext += 1;
@@ -777,7 +782,8 @@ qp_solve(Results<T>& results,
       VEG_BIND( // ?
         auto,
         (primal_feasibility_lhs, dual_feasibility_lhs),
-        detail::unscaled_primal_dual_residual(primal_residual_eq_scaled,
+        detail::unscaled_primal_dual_residual(results,
+                                              primal_residual_eq_scaled,
                                               primal_residual_in_scaled_lo,
                                               primal_residual_in_scaled_up,
                                               dual_residual_scaled,
@@ -786,12 +792,14 @@ qp_solve(Results<T>& results,
                                               dual_feasibility_rhs_0,
                                               dual_feasibility_rhs_1,
                                               dual_feasibility_rhs_3,
+                                              rhs_duality_gap,
+                                              sqrt_max_dim,
                                               precond,
                                               data,
                                               qp_scaled.as_const(),
-                                              detail::vec(x_e),
-                                              detail::vec(y_e),
-                                              detail::vec(z_e),
+                                              detail::vec_mut(x_e),
+                                              detail::vec_mut(y_e),
+                                              detail::vec_mut(z_e),
                                               stack));
       /*put in debug mode
       if (settings.verbose) {
@@ -824,8 +832,9 @@ qp_solve(Results<T>& results,
         std::cout << std::scientific << std::setw(2) << std::setprecision(2)
                   << "| primal residual=" << primal_feasibility_lhs
                   << "| dual residual=" << dual_feasibility_lhs
-                  << " | mu_in=" << results.info.mu_in
-                  << " | rho=" << results.info.rho << std::endl;
+                  << "| dualality gap=" << results.info.duality_gap
+                  << "| mu_in=" << results.info.mu_in
+                  << "| rho=" << results.info.rho << std::endl;
         results.info.pri_res = primal_feasibility_lhs;
         results.info.dua_res = dual_feasibility_lhs;
         precond.scale_primal_in_place(VectorViewMut<T>{ from_eigen, x_e });
@@ -834,10 +843,12 @@ qp_solve(Results<T>& results,
       }
       if (is_primal_feasible(primal_feasibility_lhs) &&
           is_dual_feasible(dual_feasibility_lhs)) {
-        results.info.pri_res = primal_feasibility_lhs;
-        results.info.dua_res = dual_feasibility_lhs;
-        results.info.status = QPSolverOutput::PROXQP_SOLVED;
-        break;
+          if (results.info.duality_gap<=settings.eps_abs*rhs_duality_gap){
+          results.info.pri_res = primal_feasibility_lhs;
+          results.info.dua_res = dual_feasibility_lhs;
+          results.info.status = QPSolverOutput::PROXQP_SOLVED;
+          break;
+        }
       }
 
       LDLT_TEMP_VEC_UNINIT(T, x_prev_e, n, stack);
@@ -1202,7 +1213,8 @@ qp_solve(Results<T>& results,
       VEG_BIND(
         auto,
         (primal_feasibility_lhs_new, dual_feasibility_lhs_new),
-        detail::unscaled_primal_dual_residual(primal_residual_eq_scaled,
+        detail::unscaled_primal_dual_residual(results,
+                                              primal_residual_eq_scaled,
                                               primal_residual_in_scaled_lo,
                                               primal_residual_in_scaled_up,
                                               dual_residual_scaled,
@@ -1211,20 +1223,24 @@ qp_solve(Results<T>& results,
                                               dual_feasibility_rhs_0,
                                               dual_feasibility_rhs_1,
                                               dual_feasibility_rhs_3,
+                                              rhs_duality_gap,
+                                              sqrt_max_dim,
                                               precond,
                                               data,
                                               qp_scaled.as_const(),
-                                              detail::vec(x_e),
-                                              detail::vec(y_e),
-                                              detail::vec(z_e),
+                                              detail::vec_mut(x_e),
+                                              detail::vec_mut(y_e),
+                                              detail::vec_mut(z_e),
                                               stack));
 
       if (is_primal_feasible(primal_feasibility_lhs_new) &&
           is_dual_feasible(dual_feasibility_lhs_new)) {
-        results.info.pri_res = primal_feasibility_lhs_new;
-        results.info.dua_res = dual_feasibility_lhs_new;
-        results.info.status = QPSolverOutput::PROXQP_SOLVED;
-        break;
+          if (results.info.duality_gap<=settings.eps_abs*rhs_duality_gap){
+            results.info.pri_res = primal_feasibility_lhs_new;
+            results.info.dua_res = dual_feasibility_lhs_new;
+            results.info.status = QPSolverOutput::PROXQP_SOLVED;
+            break;
+          }
       }
 
       // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
@@ -1259,7 +1275,8 @@ qp_solve(Results<T>& results,
       VEG_BIND(
         auto,
         (_, dual_feasibility_lhs_new_2),
-        detail::unscaled_primal_dual_residual(primal_residual_eq_scaled,
+        detail::unscaled_primal_dual_residual(results,
+                                              primal_residual_eq_scaled,
                                               primal_residual_in_scaled_lo,
                                               primal_residual_in_scaled_up,
                                               dual_residual_scaled,
@@ -1268,12 +1285,14 @@ qp_solve(Results<T>& results,
                                               dual_feasibility_rhs_0,
                                               dual_feasibility_rhs_1,
                                               dual_feasibility_rhs_3,
+                                              rhs_duality_gap,
+                                              sqrt_max_dim,
                                               precond,
                                               data,
                                               qp_scaled.as_const(),
-                                              detail::vec(x_e),
-                                              detail::vec(y_e),
-                                              detail::vec(z_e),
+                                              detail::vec_mut(x_e),
+                                              detail::vec_mut(y_e),
+                                              detail::vec_mut(z_e),
                                               stack));
       proxsuite::linalg::veg::unused(_);
 

--- a/include/proxsuite/proxqp/sparse/solver.hpp
+++ b/include/proxsuite/proxqp/sparse/solver.hpp
@@ -839,7 +839,9 @@ qp_solve(Results<T>& results,
       }
       if (is_primal_feasible(primal_feasibility_lhs) &&
           is_dual_feasible(dual_feasibility_lhs)) {
-        if (results.info.duality_gap <= settings.eps_abs + (settings.eps_rel+settings.eps_abs)* rhs_duality_gap) {
+        if (results.info.duality_gap <=
+            settings.eps_abs +
+              (settings.eps_rel + settings.eps_abs) * rhs_duality_gap) {
           results.info.pri_res = primal_feasibility_lhs;
           results.info.dua_res = dual_feasibility_lhs;
           results.info.status = QPSolverOutput::PROXQP_SOLVED;
@@ -1230,7 +1232,9 @@ qp_solve(Results<T>& results,
 
       if (is_primal_feasible(primal_feasibility_lhs_new) &&
           is_dual_feasible(dual_feasibility_lhs_new)) {
-        if (results.info.duality_gap <= settings.eps_abs + (settings.eps_abs+settings.eps_rel) * rhs_duality_gap) {
+        if (results.info.duality_gap <=
+            settings.eps_abs +
+              (settings.eps_abs + settings.eps_rel) * rhs_duality_gap) {
           results.info.pri_res = primal_feasibility_lhs_new;
           results.info.dua_res = dual_feasibility_lhs_new;
           results.info.status = QPSolverOutput::PROXQP_SOLVED;

--- a/include/proxsuite/proxqp/sparse/solver.hpp
+++ b/include/proxsuite/proxqp/sparse/solver.hpp
@@ -725,7 +725,7 @@ qp_solve(Results<T>& results,
     }
   }
   T rhs_duality_gap(0);
-  
+
   for (isize iter = 0; iter < settings.max_iter; ++iter) {
 
     results.info.iter_ext += 1;

--- a/include/proxsuite/proxqp/sparse/solver.hpp
+++ b/include/proxsuite/proxqp/sparse/solver.hpp
@@ -725,10 +725,10 @@ qp_solve(Results<T>& results,
     }
   }
   T rhs_duality_gap(0);
-  isize max_dim = std::max(data.dim,data.n_eq);
-  max_dim = std::max(max_dim,data.n_in);
+  isize max_dim = std::max(data.dim, data.n_eq);
+  max_dim = std::max(max_dim, data.n_in);
   T sqrt_max_dim(std::sqrt(max_dim));
-  
+
   for (isize iter = 0; iter < settings.max_iter; ++iter) {
 
     results.info.iter_ext += 1;
@@ -843,7 +843,7 @@ qp_solve(Results<T>& results,
       }
       if (is_primal_feasible(primal_feasibility_lhs) &&
           is_dual_feasible(dual_feasibility_lhs)) {
-          if (results.info.duality_gap<=settings.eps_abs*rhs_duality_gap){
+        if (results.info.duality_gap <= settings.eps_abs * rhs_duality_gap) {
           results.info.pri_res = primal_feasibility_lhs;
           results.info.dua_res = dual_feasibility_lhs;
           results.info.status = QPSolverOutput::PROXQP_SOLVED;
@@ -1235,12 +1235,12 @@ qp_solve(Results<T>& results,
 
       if (is_primal_feasible(primal_feasibility_lhs_new) &&
           is_dual_feasible(dual_feasibility_lhs_new)) {
-          if (results.info.duality_gap<=settings.eps_abs*rhs_duality_gap){
-            results.info.pri_res = primal_feasibility_lhs_new;
-            results.info.dua_res = dual_feasibility_lhs_new;
-            results.info.status = QPSolverOutput::PROXQP_SOLVED;
-            break;
-          }
+        if (results.info.duality_gap <= settings.eps_abs * rhs_duality_gap) {
+          results.info.pri_res = primal_feasibility_lhs_new;
+          results.info.dua_res = dual_feasibility_lhs_new;
+          results.info.status = QPSolverOutput::PROXQP_SOLVED;
+          break;
+        }
       }
 
       // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv

--- a/include/proxsuite/proxqp/sparse/solver.hpp
+++ b/include/proxsuite/proxqp/sparse/solver.hpp
@@ -839,7 +839,7 @@ qp_solve(Results<T>& results,
       }
       if (is_primal_feasible(primal_feasibility_lhs) &&
           is_dual_feasible(dual_feasibility_lhs)) {
-        if (results.info.duality_gap <= settings.eps_abs * rhs_duality_gap) {
+        if (results.info.duality_gap <= settings.eps_abs + (settings.eps_rel+settings.eps_abs)* rhs_duality_gap) {
           results.info.pri_res = primal_feasibility_lhs;
           results.info.dua_res = dual_feasibility_lhs;
           results.info.status = QPSolverOutput::PROXQP_SOLVED;
@@ -1230,7 +1230,7 @@ qp_solve(Results<T>& results,
 
       if (is_primal_feasible(primal_feasibility_lhs_new) &&
           is_dual_feasible(dual_feasibility_lhs_new)) {
-        if (results.info.duality_gap <= settings.eps_abs * rhs_duality_gap) {
+        if (results.info.duality_gap <= settings.eps_abs + (settings.eps_abs+settings.eps_rel) * rhs_duality_gap) {
           results.info.pri_res = primal_feasibility_lhs_new;
           results.info.dua_res = dual_feasibility_lhs_new;
           results.info.status = QPSolverOutput::PROXQP_SOLVED;

--- a/include/proxsuite/proxqp/sparse/solver.hpp
+++ b/include/proxsuite/proxqp/sparse/solver.hpp
@@ -725,10 +725,7 @@ qp_solve(Results<T>& results,
     }
   }
   T rhs_duality_gap(0);
-  isize max_dim = std::max(data.dim, data.n_eq);
-  max_dim = std::max(max_dim, data.n_in);
-  T sqrt_max_dim(std::sqrt(max_dim));
-
+  
   for (isize iter = 0; iter < settings.max_iter; ++iter) {
 
     results.info.iter_ext += 1;
@@ -793,7 +790,6 @@ qp_solve(Results<T>& results,
                                               dual_feasibility_rhs_1,
                                               dual_feasibility_rhs_3,
                                               rhs_duality_gap,
-                                              sqrt_max_dim,
                                               precond,
                                               data,
                                               qp_scaled.as_const(),
@@ -1224,7 +1220,6 @@ qp_solve(Results<T>& results,
                                               dual_feasibility_rhs_1,
                                               dual_feasibility_rhs_3,
                                               rhs_duality_gap,
-                                              sqrt_max_dim,
                                               precond,
                                               data,
                                               qp_scaled.as_const(),
@@ -1286,7 +1281,6 @@ qp_solve(Results<T>& results,
                                               dual_feasibility_rhs_1,
                                               dual_feasibility_rhs_3,
                                               rhs_duality_gap,
-                                              sqrt_max_dim,
                                               precond,
                                               data,
                                               qp_scaled.as_const(),

--- a/include/proxsuite/proxqp/sparse/utils.hpp
+++ b/include/proxsuite/proxqp/sparse/utils.hpp
@@ -649,41 +649,39 @@ unscaled_primal_dual_residual(
     noalias_symhiv_add(tmp, qp_scaled.H.to_eigen(), x_e);
     dual_residual_scaled += tmp;
 
-    precond.unscale_dual_residual_in_place({ proxqp::from_eigen, tmp });// contains unscaled Hx
+    precond.unscale_dual_residual_in_place(
+      { proxqp::from_eigen, tmp }); // contains unscaled Hx
     dual_feasibility_rhs_0 = infty_norm(tmp);
-    precond.unscale_primal_in_place({ proxqp::from_eigen, x_e});
+    precond.unscale_primal_in_place({ proxqp::from_eigen, x_e });
     results.info.duality_gap = x_e.dot(data.g); // contains gTx
     rhs_duality_gap = std::abs(results.info.duality_gap);
-    T xHx = (tmp).dot(x_e) ;
+    T xHx = (tmp).dot(x_e);
     results.info.duality_gap += xHx;
-    rhs_duality_gap = std::max(rhs_duality_gap,std::abs(xHx));
-    tmp += data.g;// contains now Hx+g
-    precond.scale_primal_in_place({ proxqp::from_eigen, x_e});
+    rhs_duality_gap = std::max(rhs_duality_gap, std::abs(xHx));
+    tmp += data.g; // contains now Hx+g
+    precond.scale_primal_in_place({ proxqp::from_eigen, x_e });
 
-    precond.unscale_dual_in_place_eq(
-          { proxsuite::proxqp::from_eigen, y_e });
+    precond.unscale_dual_in_place_eq({ proxsuite::proxqp::from_eigen, y_e });
     T by = (data.b).dot(y_e);
     results.info.duality_gap += by;
-    rhs_duality_gap = std::max(rhs_duality_gap,std::abs(by));
-    precond.scale_dual_in_place_eq(
-          { proxsuite::proxqp::from_eigen, y_e });
-    precond.unscale_dual_in_place_in(
-          { proxsuite::proxqp::from_eigen, z_e });
+    rhs_duality_gap = std::max(rhs_duality_gap, std::abs(by));
+    precond.scale_dual_in_place_eq({ proxsuite::proxqp::from_eigen, y_e });
+    precond.unscale_dual_in_place_in({ proxsuite::proxqp::from_eigen, z_e });
     T zl = (data.l).dot(detail::negative_part(z_e));
     results.info.duality_gap += zl;
-    rhs_duality_gap = std::max(rhs_duality_gap,std::abs(zl));
+    rhs_duality_gap = std::max(rhs_duality_gap, std::abs(zl));
     T zu = (data.u).dot(detail::positive_part(z_e));
     results.info.duality_gap += zu;
-    rhs_duality_gap = std::max(rhs_duality_gap,std::abs(zu));
-    precond.scale_dual_in_place_in(
-          { proxsuite::proxqp::from_eigen, z_e });
-    results.info.duality_gap /= sqrt_max_dim; // in order to get an a-dimensional duality gap
-    rhs_duality_gap +=1.;
+    rhs_duality_gap = std::max(rhs_duality_gap, std::abs(zu));
+    precond.scale_dual_in_place_in({ proxsuite::proxqp::from_eigen, z_e });
+    results.info.duality_gap /=
+      sqrt_max_dim; // in order to get an a-dimensional duality gap
+    rhs_duality_gap += 1.;
   }
 
   {
     auto ATy = tmp;
-    ATy.setZero(); 
+    ATy.setZero();
     primal_residual_eq_scaled.setZero();
 
     detail::noalias_gevmmv_add(
@@ -693,7 +691,6 @@ unscaled_primal_dual_residual(
 
     precond.unscale_dual_residual_in_place({ proxqp::from_eigen, ATy });
     dual_feasibility_rhs_1 = infty_norm(ATy);
-
   }
 
   {

--- a/include/proxsuite/proxqp/sparse/utils.hpp
+++ b/include/proxsuite/proxqp/sparse/utils.hpp
@@ -630,7 +630,6 @@ unscaled_primal_dual_residual(
   T& dual_feasibility_rhs_1,
   T& dual_feasibility_rhs_3,
   T& rhs_duality_gap,
-  T sqrt_max_dim,
   const P& precond,
   Model<T, I> const& data,
   const QpView<T, I> qp_scaled,
@@ -641,6 +640,9 @@ unscaled_primal_dual_residual(
   -> proxsuite::linalg::veg::Tuple<T, T>
 {
   isize n = x_e.rows();
+
+  const isize max_dim = std::max(data.dim,std::max(data.n_eq,data.n_in));
+  const T sqrt_max_dim(std::sqrt(max_dim)); // for normalizing scalar products 
 
   LDLT_TEMP_VEC_UNINIT(T, tmp, n, stack);
   dual_residual_scaled = qp_scaled.g.to_eigen();

--- a/include/proxsuite/proxqp/sparse/utils.hpp
+++ b/include/proxsuite/proxqp/sparse/utils.hpp
@@ -619,6 +619,7 @@ global_dual_residual_infeasibility(VectorViewMut<T> Adx,
 template<typename T, typename I, typename P>
 auto
 unscaled_primal_dual_residual(
+  Results<T>& results,
   VecMapMut<T> primal_residual_eq_scaled,
   VecMapMut<T> primal_residual_in_scaled_lo,
   VecMapMut<T> primal_residual_in_scaled_up,
@@ -628,12 +629,14 @@ unscaled_primal_dual_residual(
   T& dual_feasibility_rhs_0,
   T& dual_feasibility_rhs_1,
   T& dual_feasibility_rhs_3,
+  T& rhs_duality_gap,
+  T sqrt_max_dim,
   const P& precond,
   Model<T, I> const& data,
   const QpView<T, I> qp_scaled,
-  VecMap<T> x_e,
-  VecMap<T> y_e,
-  VecMap<T> z_e,
+  VecMapMut<T> x_e,
+  VecMapMut<T> y_e,
+  VecMapMut<T> z_e,
   proxsuite::linalg::veg::dynstack::DynStackMut stack)
   -> proxsuite::linalg::veg::Tuple<T, T>
 {
@@ -646,13 +649,41 @@ unscaled_primal_dual_residual(
     noalias_symhiv_add(tmp, qp_scaled.H.to_eigen(), x_e);
     dual_residual_scaled += tmp;
 
-    precond.unscale_dual_residual_in_place({ proxqp::from_eigen, tmp });
+    precond.unscale_dual_residual_in_place({ proxqp::from_eigen, tmp });// contains unscaled Hx
     dual_feasibility_rhs_0 = infty_norm(tmp);
+    precond.unscale_primal_in_place({ proxqp::from_eigen, x_e});
+    results.info.duality_gap = x_e.dot(data.g); // contains gTx
+    rhs_duality_gap = std::abs(results.info.duality_gap);
+    T xHx = (tmp).dot(x_e) ;
+    results.info.duality_gap += xHx;
+    rhs_duality_gap = std::max(rhs_duality_gap,std::abs(xHx));
+    tmp += data.g;// contains now Hx+g
+    precond.scale_primal_in_place({ proxqp::from_eigen, x_e});
+
+    precond.unscale_dual_in_place_eq(
+          { proxsuite::proxqp::from_eigen, y_e });
+    T by = (data.b).dot(y_e);
+    results.info.duality_gap += by;
+    rhs_duality_gap = std::max(rhs_duality_gap,std::abs(by));
+    precond.scale_dual_in_place_eq(
+          { proxsuite::proxqp::from_eigen, y_e });
+    precond.unscale_dual_in_place_in(
+          { proxsuite::proxqp::from_eigen, z_e });
+    T zl = (data.l).dot(detail::negative_part(z_e));
+    results.info.duality_gap += zl;
+    rhs_duality_gap = std::max(rhs_duality_gap,std::abs(zl));
+    T zu = (data.u).dot(detail::positive_part(z_e));
+    results.info.duality_gap += zu;
+    rhs_duality_gap = std::max(rhs_duality_gap,std::abs(zu));
+    precond.scale_dual_in_place_in(
+          { proxsuite::proxqp::from_eigen, z_e });
+    results.info.duality_gap /= sqrt_max_dim; // in order to get an a-dimensional duality gap
+    rhs_duality_gap +=1.;
   }
 
   {
     auto ATy = tmp;
-    ATy.setZero();
+    ATy.setZero(); 
     primal_residual_eq_scaled.setZero();
 
     detail::noalias_gevmmv_add(
@@ -662,6 +693,7 @@ unscaled_primal_dual_residual(
 
     precond.unscale_dual_residual_in_place({ proxqp::from_eigen, ATy });
     dual_feasibility_rhs_1 = infty_norm(ATy);
+
   }
 
   {

--- a/include/proxsuite/proxqp/sparse/utils.hpp
+++ b/include/proxsuite/proxqp/sparse/utils.hpp
@@ -678,7 +678,6 @@ unscaled_primal_dual_residual(
     precond.scale_dual_in_place_in({ proxsuite::proxqp::from_eigen, z_e });
     results.info.duality_gap /=
       sqrt_max_dim; // in order to get an a-dimensional duality gap
-    rhs_duality_gap += 1.;
   }
 
   {

--- a/include/proxsuite/proxqp/sparse/utils.hpp
+++ b/include/proxsuite/proxqp/sparse/utils.hpp
@@ -641,8 +641,8 @@ unscaled_primal_dual_residual(
 {
   isize n = x_e.rows();
 
-  const isize max_dim = std::max(data.dim,std::max(data.n_eq,data.n_in));
-  const T sqrt_max_dim(std::sqrt(max_dim)); // for normalizing scalar products 
+  const isize max_dim = std::max(data.dim, std::max(data.n_eq, data.n_in));
+  const T sqrt_max_dim(std::sqrt(max_dim)); // for normalizing scalar products
 
   LDLT_TEMP_VEC_UNINIT(T, tmp, n, stack);
   dual_residual_scaled = qp_scaled.g.to_eigen();


### PR DESCRIPTION
Add duality gap measure to dense and sparse backends:

- the measure is a-dimensional (i.e., the duality gap is divided by the max of primal and dual dimensions),
- it is integrated as a relative stopping criterion,
- it is unit-tested in c++ and python.
