### PR TITLE
Allow macOS Debug pipeline to fail -> checking for memory alloc

### DIFF
--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -8,7 +8,6 @@ jobs:
   build-with-conda:
     name: '[conda:${{ matrix.os }}:${{ matrix.build_type }}:c++${{ matrix.cxx_std }}]'
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.continue_on_error }}
 
     strategy:
       fail-fast: false
@@ -102,6 +101,7 @@ jobs:
 
     - name: Configure [Conda/Windows-2019]
       if: contains(matrix.os, 'windows-2019')
+      continue-on-error: ${{ matrix.continue_on_error }}
       shell: bash -l {0}
       run: |
         echo $(where ccache)

--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -8,12 +8,15 @@ jobs:
   build-with-conda:
     name: '[conda:${{ matrix.os }}:${{ matrix.build_type }}:c++${{ matrix.cxx_std }}]'
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.continue-on-error }}
+
     strategy:
       fail-fast: false
       matrix:
         build_type: [Release, Debug]
         name: [ubuntu-latest, macos-latest, windows-2019-clang-cl, windows-latest]
         cxx_std: [17]
+        continue-on-error: [false]
 
         include:
           - name: ubuntu-latest
@@ -29,6 +32,11 @@ jobs:
             os: macos-latest
             build_type: Release
             cxx_std: 14
+          - name: macos-latest
+            os: macos-latest
+            build_type: Debug
+            cxx_std: 17
+            continue-on-error: true
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -37,6 +37,12 @@ jobs:
             cxx_std: 17
             continue_on_error: true
 
+        exclude:
+          - name: macos-latest
+            build_type: Debug
+            cxx_std: 17
+            continue_on_error: false
+
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -13,24 +13,25 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release, Debug]
-        name: [ubuntu-latest, macos-latest, windows-2019-clang-cl, windows-latest]
+        # name: [ubuntu-latest, macos-latest, windows-2019-clang-cl, windows-latest]
+        name: [macos-latest]
         cxx_std: [17]
         continue_on_error: [false]
 
         include:
-          - name: ubuntu-latest
-            os: ubuntu-latest
+          # - name: ubuntu-latest
+          #   os: ubuntu-latest
           - name: macos-latest
             os: macos-latest
-          - name: windows-2019-clang-cl
-            os: windows-2019
-            compiler: clang-cl
-          - name: windows-latest
-            os: windows-latest
-          - name: macos-latest
-            os: macos-latest
-            build_type: Release
-            cxx_std: 14
+          # - name: windows-2019-clang-cl
+          #   os: windows-2019
+          #   compiler: clang-cl
+          # - name: windows-latest
+          #   os: windows-latest
+          # - name: macos-latest
+          #   os: macos-latest
+          #   build_type: Release
+          #   cxx_std: 14
           - name: macos-latest
             os: macos-latest
             build_type: Debug

--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -1,5 +1,4 @@
 name: CI - Linux/OSX/Windows - Conda
-
 on:
   push:
   pull_request:
@@ -108,7 +107,6 @@ jobs:
 
     - name: Configure [Conda/Windows-2019]
       if: contains(matrix.os, 'windows-2019')
-      continue-on-error: ${{ matrix.continue_on_error }}
       shell: bash -l {0}
       run: |
         echo $(where ccache)
@@ -146,6 +144,7 @@ jobs:
         cmake --install . --config ${{ matrix.build_type }}
 
     - name: Test [Conda]
+      continue-on-error: ${{ matrix.continue_on_error }}
       shell: bash -l {0}
       run: |
         find $CONDA_PREFIX -name proxsuite*

--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -8,7 +8,7 @@ jobs:
   build-with-conda:
     name: '[conda:${{ matrix.os }}:${{ matrix.build_type }}:c++${{ matrix.cxx_std }}]'
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.continue-on-error }}
+    continue-on-error: ${{ matrix.continue_on_error }}
 
     strategy:
       fail-fast: false
@@ -16,7 +16,7 @@ jobs:
         build_type: [Release, Debug]
         name: [ubuntu-latest, macos-latest, windows-2019-clang-cl, windows-latest]
         cxx_std: [17]
-        continue-on-error: [false]
+        continue_on_error: [false]
 
         include:
           - name: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
             os: macos-latest
             build_type: Debug
             cxx_std: 17
-            continue-on-error: true
+            continue_on_error: true
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -1,4 +1,5 @@
 name: CI - Linux/OSX/Windows - Conda
+
 on:
   push:
   pull_request:
@@ -12,25 +13,24 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release, Debug]
-        # name: [ubuntu-latest, macos-latest, windows-2019-clang-cl, windows-latest]
-        name: [macos-latest]
+        name: [ubuntu-latest, macos-latest, windows-2019-clang-cl, windows-latest]
         cxx_std: [17]
         continue_on_error: [false]
 
         include:
-          # - name: ubuntu-latest
-          #   os: ubuntu-latest
+          - name: ubuntu-latest
+            os: ubuntu-latest
           - name: macos-latest
             os: macos-latest
-          # - name: windows-2019-clang-cl
-          #   os: windows-2019
-          #   compiler: clang-cl
-          # - name: windows-latest
-          #   os: windows-latest
-          # - name: macos-latest
-          #   os: macos-latest
-          #   build_type: Release
-          #   cxx_std: 14
+          - name: windows-2019-clang-cl
+            os: windows-2019
+            compiler: clang-cl
+          - name: windows-latest
+            os: windows-latest
+          - name: macos-latest
+            os: macos-latest
+            build_type: Release
+            cxx_std: 14
           - name: macos-latest
             os: macos-latest
             build_type: Debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release on GitHub & PyPI
 
 on:
-  # pull_request:
+  pull_request:
   release:
     types:
       - published

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release on GitHub & PyPI
 
 on:
-  pull_request:
+  # pull_request:
   release:
     types:
       - published


### PR DESCRIPTION
- currently we check for runtime memory allocations in this one specific pipeline
- we still observe a few during the dense solve, but we don't want to PRs to be marked as failed, it's a way to keep track of mem allocs but no critical failure