### PR TITLE
Devel

### DIFF
--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -8,12 +8,14 @@ jobs:
   build-with-conda:
     name: '[conda:${{ matrix.os }}:${{ matrix.build_type }}:c++${{ matrix.cxx_std }}]'
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       matrix:
         build_type: [Release, Debug]
         name: [ubuntu-latest, macos-latest, windows-2019-clang-cl, windows-latest]
         cxx_std: [17]
+        continue_on_error: [false]
 
         include:
           - name: ubuntu-latest
@@ -29,6 +31,17 @@ jobs:
             os: macos-latest
             build_type: Release
             cxx_std: 14
+          - name: macos-latest
+            os: macos-latest
+            build_type: Debug
+            cxx_std: 17
+            continue_on_error: true
+
+        exclude:
+          - name: macos-latest
+            build_type: Debug
+            cxx_std: 17
+            continue_on_error: false
 
     steps:
     - uses: actions/checkout@v2
@@ -131,6 +144,7 @@ jobs:
         cmake --install . --config ${{ matrix.build_type }}
 
     - name: Test [Conda]
+      continue-on-error: ${{ matrix.continue_on_error }}
       shell: bash -l {0}
       run: |
         find $CONDA_PREFIX -name proxsuite*


### PR DESCRIPTION
* CI: allow macOS Debug to fail -> checking for memory alloc

- currently we check for runtime memory allocations in this one specific pipeline
- we still observe a few during the dense solve, but we dont want to PRs to be marked as failed, it's a way to keep track of mem allocs but no critical failure

* update naming to use underscore

* move continue-on-error from job to specific step

* exclude macos debug with continue-on-error True

- due to our include structure we have to specifically exclude this cfg otherwise we have two macOS Debug c++17

* debug: deactivate linux/windows pipelines to check

* fix continue-on-error

* enable back all pipelines