### PR TITLE
fix instructionset import

### DIFF
--- a/bindings/python/proxsuite/__init__.py
+++ b/bindings/python/proxsuite/__init__.py
@@ -1,10 +1,6 @@
 import platform
 
-if (
-    "i386" in platform.processor()
-    or "x86_64" in platform.processor()
-    or "Intel64" in platform.processor()
-):
+if "arm" not in platform.processor():
     from . import instructionset
 
 


### PR DESCRIPTION
Currently, we are not importing the instructionset if `platform.processor()` returns an empty string, like it was observed in #119.