### PR TITLE
Add simple cpp example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ This approach is available on Linux and Mac OS X.
 
 Installation from source is presented [here](https://github.com/Simple-Robotics/proxsuite/blob/main/doc/5-installation.md).
 
-### Compiling a program
-For the fastest performance use the following command to enable vectorization
+### Compiling a first example program
+For the fastest performance use the following command to enable vectorization when compiling the simple [example](https://github.com/Simple-Robotics/proxsuite/blob/main/examples/cpp/first_example.cpp).
 ```bash
-g++ -O3 -march=native -DNDEBUG -std=gnu++17 -DPROXSUITE_VECTORIZE examples/benchmark_dense_qp.cpp -o benchmark_dense_qp $(pkg-config --cflags proxsuite)
+g++ -O3 -march=native -DNDEBUG -std=gnu++17 -DPROXSUITE_VECTORIZE examples/first_example.cpp -o first_example $(pkg-config --cflags proxsuite)
 ```
 ### Using ProxSuite with CMake
 If you want to use ProxSuite with CMake, the following tiny example should help you:

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ This approach is available on Linux and Mac OS X.
 Installation from source is presented [here](https://github.com/Simple-Robotics/proxsuite/blob/main/doc/5-installation.md).
 
 ### Compiling a first example program
-For the fastest performance use the following command to enable vectorization when compiling the simple [example](https://github.com/Simple-Robotics/proxsuite/blob/main/examples/cpp/first_example.cpp).
+For the fastest performance use the following command to enable vectorization when compiling the simple [example](https://github.com/Simple-Robotics/proxsuite/blob/main/examples/cpp/first_example_dense.cpp).
 ```bash
-g++ -O3 -march=native -DNDEBUG -std=gnu++17 -DPROXSUITE_VECTORIZE examples/first_example.cpp -o first_example $(pkg-config --cflags proxsuite)
+g++ -O3 -march=native -DNDEBUG -std=gnu++17 -DPROXSUITE_VECTORIZE examples/first_example_dense.cpp -o first_example_dense $(pkg-config --cflags proxsuite)
 ```
 ### Using ProxSuite with CMake
 If you want to use ProxSuite with CMake, the following tiny example should help you:

--- a/examples/cpp/first_example.cpp
+++ b/examples/cpp/first_example.cpp
@@ -1,0 +1,63 @@
+//
+// Copyright (c) 2022 INRIA
+//
+#include <Eigen/Core>
+#include <proxsuite/proxqp/dense/dense.hpp>
+
+using namespace proxsuite::proxqp;
+
+int
+main()
+{
+  std::cout
+    << "Solve a simple example with inequality constraints using dense ProxQP"
+    << std::endl;
+
+  // define the problem
+  double eps_abs = 1e-9;
+  dense::isize dim = 3, n_eq = 0, n_in = 3;
+
+  // cost H
+  Eigen::MatrixXd H = Eigen::MatrixXd(dim, dim);
+  H << 13.0, 12.0, -2.0, 12.0, 17.0, 6.0, -2.0, 6.0, 12.0;
+
+  Eigen::VectorXd g = Eigen::VectorXd(dim);
+  g << -22.0, -14.5, 13.0;
+
+  // inequality constraints C
+  Eigen::MatrixXd C = Eigen::MatrixXd(dim, dim);
+  C << 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0;
+
+  Eigen::VectorXd l = Eigen::VectorXd(dim);
+  l << -1.0, -1.0, -1.0;
+
+  Eigen::VectorXd u = Eigen::VectorXd(dim);
+  u << 1.0, 1.0, 1.0;
+
+  std::cout << "H:\n" << H << std::endl;
+  std::cout << "g.T:" << g.transpose() << std::endl;
+  std::cout << "C:\n" << C << std::endl;
+  std::cout << "l.T:" << l.transpose() << std::endl;
+  std::cout << "u.T:" << u.transpose() << std::endl;
+
+  // create qp object and pass some settings
+  dense::QP<double> qp(dim, n_eq, n_in);
+
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp.settings.verbose = true;
+
+  // initialize qp with matrices describing the problem
+  // note: it is also possible to use update here
+  qp.init(H, g, std::nullopt, std::nullopt, C, l, u);
+
+  qp.solve();
+
+  std::cout << "primal residual: " << qp.results.info.pri_res << std::endl;
+  std::cout << "dual residual: " << qp.results.info.dua_res << std::endl;
+  std::cout << "total number of iteration: " << qp.results.info.iter
+            << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
+  return 0;
+}

--- a/examples/cpp/first_example_dense.cpp
+++ b/examples/cpp/first_example_dense.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2022 INRIA
 //
+#include <optional>
 #include <Eigen/Core>
 #include <proxsuite/proxqp/dense/dense.hpp>
 

--- a/examples/cpp/first_example_dense.cpp
+++ b/examples/cpp/first_example_dense.cpp
@@ -1,11 +1,13 @@
 //
 // Copyright (c) 2022 INRIA
 //
-#include <optional>
+#include <iostream>
 #include <Eigen/Core>
+#include <proxsuite/helpers/optional.hpp> // for c++14
 #include <proxsuite/proxqp/dense/dense.hpp>
 
 using namespace proxsuite::proxqp;
+using proxsuite::nullopt; // c++17 simply use std::nullopt
 
 int
 main()
@@ -26,13 +28,13 @@ main()
   g << -22.0, -14.5, 13.0;
 
   // inequality constraints C
-  Eigen::MatrixXd C = Eigen::MatrixXd(dim, dim);
+  Eigen::MatrixXd C = Eigen::MatrixXd(n_in, dim);
   C << 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0;
 
-  Eigen::VectorXd l = Eigen::VectorXd(dim);
+  Eigen::VectorXd l = Eigen::VectorXd(n_in);
   l << -1.0, -1.0, -1.0;
 
-  Eigen::VectorXd u = Eigen::VectorXd(dim);
+  Eigen::VectorXd u = Eigen::VectorXd(n_in);
   u << 1.0, 1.0, 1.0;
 
   std::cout << "H:\n" << H << std::endl;
@@ -50,7 +52,7 @@ main()
 
   // initialize qp with matrices describing the problem
   // note: it is also possible to use update here
-  qp.init(H, g, std::nullopt, std::nullopt, C, l, u);
+  qp.init(H, g, nullopt, nullopt, C, l, u);
 
   qp.solve();
 

--- a/examples/cpp/first_example_sparse.cpp
+++ b/examples/cpp/first_example_sparse.cpp
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2022 INRIA
+//
+#include <optional>
+#include <random>
+#include <Eigen/Core>
+#include <proxsuite/proxqp/sparse/sparse.hpp>
+
+using namespace proxsuite::proxqp;
+
+int
+main()
+{
+
+  std::cout
+    << "Solve a simple example with inequality constraints using sparse ProxQP"
+    << std::endl;
+
+  // define the problem
+  double eps_abs = 1e-9;
+  sparse::isize dim = 3, n_eq = 0, n_in = 3, nnz = 2;
+
+  // random utils to generate sparse matrix
+  std::random_device rd;  // obtain a random number from hardware
+  std::mt19937 gen(rd()); // seed the generator
+  std::uniform_int_distribution<> int_distr(0, dim - 1); // define the range
+  std::uniform_real_distribution<> double_distr(0, 1);
+
+  // cost H: first way to define sparse matrix from triplet list
+  std::vector<Eigen::Triplet<double>>
+    coefficients; // list of non-zeros coefficients
+  coefficients.reserve(nnz);
+
+  for (sparse::isize k = 0; k < nnz; k++) {
+    int col = int_distr(gen);
+    int row = int_distr(gen);
+    double val = double_distr(gen);
+    coefficients.push_back(Eigen::Triplet<double>(col, row, val));
+  }
+  Eigen::SparseMatrix<double> H_spa(dim, dim);
+  H_spa.setFromTriplets(coefficients.begin(), coefficients.end());
+
+  Eigen::VectorXd g = Eigen::VectorXd::Random(dim);
+
+  // inequality constraints C: other way to define sparse matrix from  dense
+  // matrix using sparseView
+  Eigen::MatrixXd C = Eigen::MatrixXd(n_in, n_in);
+  C << 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0;
+  Eigen::SparseMatrix<double> C_spa(n_in, dim);
+  C_spa = C.sparseView();
+
+  Eigen::VectorXd l = Eigen::VectorXd(dim);
+  l << -1.0, -1.0, -1.0;
+
+  Eigen::VectorXd u = Eigen::VectorXd(dim);
+  u << 1.0, 1.0, 1.0;
+
+  std::cout << "H:\n" << H_spa << std::endl;
+  std::cout << "g.T:" << g.transpose() << std::endl;
+  std::cout << "C:\n" << C_spa << std::endl;
+  std::cout << "l.T:" << l.transpose() << std::endl;
+  std::cout << "u.T:" << u.transpose() << std::endl;
+
+  // create qp object and pass some settings
+  sparse::QP<double, long long> qp(dim, n_eq, n_in);
+
+  qp.settings.eps_abs = eps_abs;
+  qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+  qp.settings.verbose = true;
+
+  // initialize qp with matrices describing the problem
+  // note: it is also possible to use update here
+  qp.init(H_spa, g, std::nullopt, std::nullopt, C_spa, l, u);
+
+  qp.solve();
+
+  std::cout << "primal residual: " << qp.results.info.pri_res << std::endl;
+  std::cout << "dual residual: " << qp.results.info.dua_res << std::endl;
+  std::cout << "total number of iteration: " << qp.results.info.iter
+            << std::endl;
+  std::cout << "setup timing " << qp.results.info.setup_time << " solve time "
+            << qp.results.info.solve_time << std::endl;
+  return 0;
+}

--- a/examples/cpp/first_example_sparse.cpp
+++ b/examples/cpp/first_example_sparse.cpp
@@ -1,12 +1,14 @@
 //
 // Copyright (c) 2022 INRIA
 //
-#include <optional>
 #include <random>
+#include <iostream>
 #include <Eigen/Core>
+#include <proxsuite/helpers/optional.hpp> // for c++14
 #include <proxsuite/proxqp/sparse/sparse.hpp>
 
 using namespace proxsuite::proxqp;
+using proxsuite::nullopt; // c++17 simply use std::nullopt
 
 int
 main()
@@ -44,15 +46,15 @@ main()
 
   // inequality constraints C: other way to define sparse matrix from  dense
   // matrix using sparseView
-  Eigen::MatrixXd C = Eigen::MatrixXd(n_in, n_in);
+  Eigen::MatrixXd C = Eigen::MatrixXd(n_in, dim);
   C << 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0;
   Eigen::SparseMatrix<double> C_spa(n_in, dim);
   C_spa = C.sparseView();
 
-  Eigen::VectorXd l = Eigen::VectorXd(dim);
+  Eigen::VectorXd l = Eigen::VectorXd(n_in);
   l << -1.0, -1.0, -1.0;
 
-  Eigen::VectorXd u = Eigen::VectorXd(dim);
+  Eigen::VectorXd u = Eigen::VectorXd(n_in);
   u << 1.0, 1.0, 1.0;
 
   std::cout << "H:\n" << H_spa << std::endl;
@@ -70,7 +72,7 @@ main()
 
   // initialize qp with matrices describing the problem
   // note: it is also possible to use update here
-  qp.init(H_spa, g, std::nullopt, std::nullopt, C_spa, l, u);
+  qp.init(H_spa, g, nullopt, nullopt, C_spa, l, u);
 
   qp.solve();
 


### PR DESCRIPTION
After discussing with @lmontaut, we think it could be helpful for users getting started with proxqp in c++ to have a very simple example showing how you use Eigen to setup a small problem with your own values. All our examples/unittests either use a function to generate a random qp or read in a mat file.

This simple first example can then also be used in the readme section explaining how to compile a program.