### PR TITLE
cmake/python: update library output paths

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -27,6 +27,10 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
     instructionset
     PROPERTIES OUTPUT_NAME instructionset
                LIBRARY_OUTPUT_DIRECTORY
+               "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}"
+               LIBRARY_OUTPUT_DIRECTORY_RELEASE
+               "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}"
+               LIBRARY_OUTPUT_DIRECTORY_DEBUG
                "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}")
   if(UNIX AND NOT APPLE)
     set_target_properties(instructionset PROPERTIES INSTALL_RPATH
@@ -51,6 +55,10 @@ function(CREATE_PYTHON_TARGET target_name COMPILE_OPTIONS dependencies)
     ${target_name}
     PROPERTIES OUTPUT_NAME ${target_name}
                LIBRARY_OUTPUT_DIRECTORY
+               "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}"
+               LIBRARY_OUTPUT_DIRECTORY_RELEASE
+               "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}"
+               LIBRARY_OUTPUT_DIRECTORY_DEBUG
                "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}")
 
   if(UNIX AND NOT APPLE)


### PR DESCRIPTION
before https://github.com/jrl-umi3218/jrl-cmakemodules/pull/569, the [path to additional modules](https://github.com/Simple-Robotics/proxsuite/blob/main/test/CMakeLists.txt#L55) specified in the test was not properly set on windows. As a results, the unittest could not import the package from this path, so it imported it from the corresponding (conda) env, we had to install the package before.
Now, the path is properly set, so the unittest is importing the package locally from the build folder, but the folder structure impedes a correct import. We have :

`build/bindings/python/proxsuite/__init__.py`
but then the modules, like instructionset/proxsuite are in 
`build/bindings/python/proxsuite/Release/instructionset`

This PR removes the intermediate per-configurations appended subfolder.