### PR TITLE
transposeInPlace only if eigen >= 3.4.0

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -52,7 +52,7 @@ function(CREATE_PYTHON_TARGET target_name COMPILE_OPTIONS dependencies)
   target_compile_definitions(${target_name}
                              PRIVATE PYTHON_MODULE_NAME=${target_name})
   target_include_directories(
-    ${target_name} PRIVATE ${PROJECT_SOURCE_DIR}/external/cereal/include)
+    ${target_name} SYSTEM PRIVATE ${PROJECT_SOURCE_DIR}/external/cereal/include)
   set_target_properties(
     ${target_name}
     PROPERTIES OUTPUT_NAME ${target_name}

--- a/include/proxsuite/serialization/eigen.hpp
+++ b/include/proxsuite/serialization/eigen.hpp
@@ -30,9 +30,15 @@ save(
 {
   Eigen::Index rows = m.rows();
   Eigen::Index cols = m.cols();
-  ar(rows);
-  ar(cols);
-  ar(_Options);
+  ar(CEREAL_NVP(rows));
+  ar(CEREAL_NVP(cols));
+  int storage_order;
+  if (m.IsRowMajor) {
+    storage_order = 1;
+  } else {
+    storage_order = 0;
+  }
+  ar(CEREAL_NVP(storage_order));
 
   for (Eigen::Index i = 0; i < m.size(); i++)
     ar(m.data()[i]);
@@ -51,10 +57,10 @@ load(Archive& ar,
 {
   Eigen::Index rows;
   Eigen::Index cols;
-  int _OptionsLoaded;
-  ar(rows);
-  ar(cols);
-  ar(_OptionsLoaded);
+  int storage_order;
+  ar(CEREAL_NVP(rows));
+  ar(CEREAL_NVP(cols));
+  ar(CEREAL_NVP(storage_order));
 
   m.resize(rows, cols);
 
@@ -62,7 +68,7 @@ load(Archive& ar,
     ar(m.data()[i]);
 
   // Account for different storage orders
-  if (!(_OptionsLoaded == _Options)) {
+  if (!(storage_order == m.IsRowMajor)) {
 #if EIGEN_VERSION_AT_LEAST(3, 4, 0)
     m.transposeInPlace();
 #else

--- a/include/proxsuite/serialization/eigen.hpp
+++ b/include/proxsuite/serialization/eigen.hpp
@@ -66,8 +66,7 @@ load(Archive& ar,
 #if EIGEN_VERSION_AT_LEAST(3, 4, 0)
     m.transposeInPlace();
 #else
-    Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> m_t;
-    m_t = m.transpose();
+    Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> m_t(m.transpose());
     m = m_t;
 #endif
   }

--- a/include/proxsuite/serialization/eigen.hpp
+++ b/include/proxsuite/serialization/eigen.hpp
@@ -63,7 +63,13 @@ load(Archive& ar,
 
   // Account for different storage orders
   if (!(_OptionsLoaded == _Options)) {
+#if EIGEN_VERSION_AT_LEAST(3, 4, 0)
     m.transposeInPlace();
+#else
+    Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> m_t;
+    m_t = m.transpose();
+    m = m_t;
+#endif
   }
 }
 

--- a/include/proxsuite/serialization/eigen.hpp
+++ b/include/proxsuite/serialization/eigen.hpp
@@ -66,7 +66,8 @@ load(Archive& ar,
 #if EIGEN_VERSION_AT_LEAST(3, 4, 0)
     m.transposeInPlace();
 #else
-    Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> m_t(m.transpose());
+    Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> m_t(
+      m.transpose());
     m = m_t;
 #endif
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,8 +51,6 @@ endmacro(ADD_TEST_CFLAGS)
 
 make_directory("${CMAKE_CURRENT_BINARY_DIR}/serialization-data")
 proxsuite_test(serialization src/serialization.cpp)
-target_compile_definitions(test-cpp-serialization
-                           PRIVATE PROXSUITE_WITH_SERIALIZATION)
 add_test_cflags(
   test-cpp-serialization
   "-DTEST_SERIALIZATION_FOLDER=\\\\\"${CMAKE_CURRENT_BINARY_DIR}/serialization-data\\\\\""

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,7 +56,8 @@ add_test_cflags(
   "-DTEST_SERIALIZATION_FOLDER=\\\\\"${CMAKE_CURRENT_BINARY_DIR}/serialization-data\\\\\""
 )
 target_include_directories(
-  test-cpp-serialization PRIVATE ${PROJECT_SOURCE_DIR}/external/cereal/include)
+  test-cpp-serialization SYSTEM
+  PRIVATE ${PROJECT_SOURCE_DIR}/external/cereal/include)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT MSVC)
   proxsuite_test(dense_maros_meszaros src/dense_maros_meszaros.cpp)

--- a/test/src/serialization.cpp
+++ b/test/src/serialization.cpp
@@ -113,7 +113,6 @@ DOCTEST_TEST_CASE("test serialization of qp model, results and settings")
 {
   std::cout << "--- serialization ---" << std::endl;
   double sparsity_factor = 0.15;
-  T eps_abs = T(1e-9);
   utils::rand::set_seed(1);
   dense::isize dim = 10;
 


### PR DESCRIPTION
leading to problems otherwise: https://github.com/Simple-Robotics/proxsuite/actions/runs/3750814032/jobs/6371012995#step:5:123 (here we use eigen [3.3.7](https://github.com/Simple-Robotics/proxsuite/actions/runs/3750814032/jobs/6371012995#step:3:57)) although I don't really understand why after checking eigen 3.3 should already include [transposeInPlace](https://eigen.tuxfamily.org/dox-3.3/classEigen_1_1DenseBase.html#ac501bd942994af7a95d95bee7a16ad2a).

