### PR TITLE
ROS-CI: Debug and Release builds, fix warnings

### DIFF
--- a/.github/workflows/ci-linux-ros.yml
+++ b/.github/workflows/ci-linux-ros.yml
@@ -6,7 +6,8 @@ jobs:
     strategy:
       matrix:
         env:
-          - {ROS_DISTRO: noetic}
+          - {ROS_DISTRO: noetic, CMAKE_BUILD_TYPE: Debug}
+          - {ROS_DISTRO: noetic, CMAKE_BUILD_TYPE: Release}
     env:
       CCACHE_DIR: /github/home/.ccache # Enable ccache
       CMAKE_ARGS: -DBUILD_WITH_VECTORIZATION_SUPPORT=OFF  # Simde is not available yet

--- a/examples/cpp/first_example_sparse.cpp
+++ b/examples/cpp/first_example_sparse.cpp
@@ -25,7 +25,8 @@ main()
   // random utils to generate sparse matrix
   std::random_device rd;  // obtain a random number from hardware
   std::mt19937 gen(rd()); // seed the generator
-  std::uniform_int_distribution<> int_distr(0, static_cast<int>(dim) - 1); // define the range
+  std::uniform_int_distribution<> int_distr(
+    0, static_cast<int>(dim) - 1); // define the range
   std::uniform_real_distribution<> double_distr(0, 1);
 
   // cost H: first way to define sparse matrix from triplet list

--- a/examples/cpp/first_example_sparse.cpp
+++ b/examples/cpp/first_example_sparse.cpp
@@ -25,7 +25,7 @@ main()
   // random utils to generate sparse matrix
   std::random_device rd;  // obtain a random number from hardware
   std::mt19937 gen(rd()); // seed the generator
-  std::uniform_int_distribution<> int_distr(0, dim - 1); // define the range
+  std::uniform_int_distribution<> int_distr(0, static_cast<int>(dim) - 1); // define the range
   std::uniform_real_distribution<> double_distr(0, 1);
 
   // cost H: first way to define sparse matrix from triplet list

--- a/test/src/sparse_qp_wrapper.cpp
+++ b/test/src/sparse_qp_wrapper.cpp
@@ -6009,10 +6009,6 @@ TEST_CASE("ProxQP::sparse: init must be called before update")
                               qp_random.C.cast<bool>());
   qp.settings.eps_abs = eps_abs;
 
-  T rho(1.e-7);
-  T mu_eq(1.e-4);
-  bool compute_preconditioner = true;
-
   qp.settings.eps_abs = eps_abs;
   qp.settings.eps_rel = 0;
   qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;


### PR DESCRIPTION
Follow-up to #158:
1. Enables Debug and Release configurations for the ROS-CI
2. Fixes warnings highlighted during CI: unused variables and narrowing conversion