### PR TITLE
linalg/ldlt : mark p() and pt() permutation matrix getters const

### DIFF
--- a/include/proxsuite/linalg/dense/ldlt.hpp
+++ b/include/proxsuite/linalg/dense/ldlt.hpp
@@ -678,7 +678,7 @@ public:
       Eigen::InnerStride<DYN>{ stride + 1 },
     };
   }
-  auto d_mut() noexcept -> DView
+  auto d_mut() noexcept -> DViewMut
   {
     return {
       ld_storage.ptr_mut(),

--- a/include/proxsuite/linalg/dense/ldlt.hpp
+++ b/include/proxsuite/linalg/dense/ldlt.hpp
@@ -687,8 +687,8 @@ public:
       Eigen::InnerStride<DYN>{ stride + 1 },
     };
   }
-  auto p() -> Perm { return { VecMapISize(perm.ptr(), dim()) }; }
-  auto pt() -> Perm { return { VecMapISize(perm_inv.ptr(), dim()) }; }
+  auto p() const -> Perm { return { VecMapISize(perm.ptr(), dim()) }; }
+  auto pt() const -> Perm { return { VecMapISize(perm_inv.ptr(), dim()) }; }
 
   /*!
    * Returns the memory storage requirements for a factorization of a matrix


### PR DESCRIPTION
In order to interface with the backend's `Lldt` class we need to be able to grab the permutation matrices on a `const Ldlt` pointer or reference. This PR fixes constness on the getters.