### PR TITLE
set compute_timings = true

### DIFF
--- a/examples/cpp/benchmark_dense_qp.cpp
+++ b/examples/cpp/benchmark_dense_qp.cpp
@@ -68,6 +68,7 @@ main()
 
     for (int i = 0; i < N; i++) {
       dense::QP<T> qp(dim, n_eq, n_in);
+      qp.settings.compute_timings = true; // compute all timings
       qp.settings.max_iter = 10000;
       qp.settings.max_iter_in = 1000;
       qp.settings.eps_abs = 1e-5;


### PR DESCRIPTION
after setting `compute_timings = false` by default, we have to manually turn it on when we want to compute them, see #190.