### PR TITLE
ci/linux: fix linux wheel compatibility

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,0 +1,51 @@
+name: Release on PyPI [Linux]
+
+on:
+  pull_request:
+  release:
+    types:
+      - published
+
+jobs:
+  build-wheel:
+    name: "Build ubuntu wheels"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - run: python -m pip install -U pip
+      - run: python -m pip install cibuildwheel
+      - run: touch setup.py
+      - run: python -m cibuildwheel --output-dir wh
+        env:
+          CIBW_BUILD: cp37-*manylinux*_x86_64 cp38-*manylinux*_x86_64 cp39-*manylinux*_x86_64 cp310-*manylinux*_x86_64 cp311-*manylinux*_x86_64
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_REPAIR_WHEEL_COMMAND: ""
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: wh
+
+  release:
+    needs: "build-wheel"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - uses: actions/download-artifact@v3
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: |
+          github.repository == 'Simple-Robotics/proxsuite' &&
+          (github.event_name == 'release' && github.event.action == 'published')
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release-osx-win.yml
+++ b/.github/workflows/release-osx-win.yml
@@ -1,4 +1,4 @@
-name: Release on GitHub & PyPI
+name: Release on PyPI [Windows, Mac]
 
 on:
   pull_request:
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        os: [ubuntu-latest, macos-latest, self-hosted-arm64, windows-2019, windows-latest]
+        os: [macos-latest, self-hosted-arm64, windows-2019, windows-latest]
         include:
           - os: windows-2019
             toolset: ClangCl
@@ -23,10 +23,6 @@ jobs:
           - os: self-hosted-arm64
             python-version: 3.7
     steps:
-      - name: Set docker for linux
-        if: contains(matrix.os, 'ubuntu')
-        uses: docker://quay.io/pypa/manylinux_2_24_x86_64
-
       - uses: actions/checkout@v2
         with:
           submodules: recursive
@@ -39,7 +35,7 @@ jobs:
           git submodule update
 
       - name: Setup conda
-        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos') || contains(matrix.os, 'windows')
+        if: contains(matrix.os, 'macos') || contains(matrix.os, 'windows')
         uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-variant: Mambaforge
@@ -49,7 +45,7 @@ jobs:
           activate-environment: proxsuite
 
       - name: Install dependencies [Conda]
-        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos') || contains(matrix.os, 'windows')
+        if: contains(matrix.os, 'macos') || contains(matrix.os, 'windows')
         shell: bash -l {0}
         run: |
           # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
@@ -57,7 +53,7 @@ jobs:
           mamba install doxygen graphviz eigen simde cmake compilers
 
       - name: Print environment [Conda]
-        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos') || contains(matrix.os, 'windows')
+        if: contains(matrix.os, 'macos') || contains(matrix.os, 'windows')
         shell: bash -l {0}
         run: |
           conda info
@@ -65,7 +61,7 @@ jobs:
           env
 
       - name: Build wheel
-        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
+        if: contains(matrix.os, 'macos')
         shell: bash -l {0}
         run: |
           pip wheel . -w dist

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,3 +1,6 @@
+if(UNIX)
+  set(PYTHON_COMPONENTS Development.Module)
+endif()
 include(../../cmake-module/python.cmake)
 
 findpython(REQUIRED Development.Module)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ homepage = "https://github.com/Simple-Robotics/proxsuite"
 repository = "https://github.com/Simple-Robotics/proxsuite.git"
 
 [build-system]
-requires = ["cmeel[build]"]
+requires = [
+    "cmeel[build]",
+    "cmeel-eigen",
+    "cmeel-simde",
+    ]
 build-backend = "cmeel.build"
 configure-args = ["-DBUILD_TESTING:BOOL=OFF","-DBUILD_PYTHON_INTERFACE:BOOL=ON","-DBUILD_WITH_VECTORIZATION_SUPPORT:BOOL=ON","-DINSTALL_DOCUMENTATION:BOOL=OFF"]


### PR DESCRIPTION
use another release workflow for Linux wheels to support `manylinux_2_17` instead of `manylinux_2_35`. This is possible using `cibuildwheel`, thanks to @nim65s who released `cmeel-simde` today. This should solve the problems observed in #194.