### PR TITLE
ci/linux-wheels: fix naming for artifacts

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -21,7 +21,7 @@ jobs:
       - run: python -m pip install -U pip
       - run: python -m pip install cibuildwheel
       - run: touch setup.py
-      - run: python -m cibuildwheel --output-dir wh
+      - run: python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD: cp37-*manylinux*_x86_64 cp38-*manylinux*_x86_64 cp39-*manylinux*_x86_64 cp310-*manylinux*_x86_64 cp311-*manylinux*_x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
@@ -29,7 +29,8 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          path: wh
+          name: dist
+          path: dist
 
   release:
     needs: "build-wheel"


### PR DESCRIPTION
The step to upload the artifacts to pypi expects the wheels in a folder called `dist`. I uploaded the ubuntu wheels for `v0.3.5` manually to pypi after the workflow [failed](https://github.com/Simple-Robotics/proxsuite/actions/runs/4346463866/jobs/7593621507#step:6:20) due to a naming mismatch. This here will fix it for future releases.