### PR TITLE
Define PROXSUITE_AS_SUBPROJECT as ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 if(DEFINED PROJECT_NAME)
-  set(PROXSUITE_AS_SUBPROJECT)
+  set(PROXSUITE_AS_SUBPROJECT ON)
 endif()
 
 set(PROJECT_NAME proxsuite)


### PR DESCRIPTION
As-is, at least on CMake 3.25, `set(PROXSUITE_AS_SUBPROJECT)` does not
cause it to evaluate as true in the below tests

Topic: proxsuite-as-subproject