### PR TITLE
Set simde dependency for ROS2 Iron as well

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -26,7 +26,7 @@
   <build_depend>doxygen</build_depend>
   <depend>eigen</depend>
   <!-- simde is only available for Ubuntu 22.04 -->
-  <depend condition="$ROS_DISTRO == humble or $ROS_DISTRO == rolling">simde</depend>
+  <depend condition="$ROS_DISTRO == humble or $ROS_DISTRO == rolling or $ROS_DISTRO == iron">simde</depend>
   <depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</depend>
   <depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</depend>
   <depend condition="$ROS_PYTHON_VERSION == 2">python-scipy</depend>


### PR DESCRIPTION
ROS2 Iron is released on Ubuntu Jammy which has simde available. Adding the conditional dependency fixes the builds