### PR TITLE
add generalized primal dual augmented Lagrangian (gpdal) for dense backend

### DIFF
--- a/bindings/python/src/expose-settings.hpp
+++ b/bindings/python/src/expose-settings.hpp
@@ -30,6 +30,12 @@ exposeSettings(pybind11::module_ m)
            InitialGuessStatus::COLD_START_WITH_PREVIOUS_RESULT)
     .export_values();
 
+  ::pybind11::enum_<MeritFunctionType>(
+    m, "MeritFunctionType", pybind11::module_local())
+    .value("GPDAL", MeritFunctionType::GPDAL)
+    .value("PDAL", MeritFunctionType::PDAL)
+    .export_values();
+
   ::pybind11::enum_<SparseBackend>(m, "SparseBackend", pybind11::module_local())
     .value("Automatic", SparseBackend::Automatic)
     .value("MatrixFree", SparseBackend::MatrixFree)
@@ -75,7 +81,7 @@ exposeSettings(pybind11::module_ m)
     .def_readwrite("eps_duality_gap_rel", &Settings<T>::eps_duality_gap_rel)
     .def_readwrite("verbose", &Settings<T>::verbose)
     .def_readwrite("bcl_update", &Settings<T>::bcl_update)
-    .def_readwrite("gpdal_merit_function", &Settings<T>::gpdal_merit_function)
+    .def_readwrite("merit_function_type", &Settings<T>::merit_function_type)
     .def_readwrite("alpha_gpdal", &Settings<T>::alpha_gpdal)
     .def(pybind11::self == pybind11::self)
     .def(pybind11::self != pybind11::self)

--- a/bindings/python/src/expose-settings.hpp
+++ b/bindings/python/src/expose-settings.hpp
@@ -75,6 +75,8 @@ exposeSettings(pybind11::module_ m)
     .def_readwrite("eps_duality_gap_rel", &Settings<T>::eps_duality_gap_rel)
     .def_readwrite("verbose", &Settings<T>::verbose)
     .def_readwrite("bcl_update", &Settings<T>::bcl_update)
+    .def_readwrite("gpdal_merit_function", &Settings<T>::gpdal_merit_function)
+    .def_readwrite("alpha_gpdal", &Settings<T>::alpha_gpdal)
     .def(pybind11::self == pybind11::self)
     .def(pybind11::self != pybind11::self)
     .def(pybind11::pickle(

--- a/include/proxsuite/proxqp/dense/linesearch.hpp
+++ b/include/proxsuite/proxqp/dense/linesearch.hpp
@@ -36,7 +36,136 @@ struct PrimalDualDerivativeResult
   T grad;
   VEG_REFLECT(PrimalDualDerivativeResult, a, b, grad);
 };
+/*!
+ * Stores first derivative and coefficient of the univariate second order
+ * polynomial merit function to be canceled by the exact generalized primal-dual
+ * linesearch.
+ *
+ * @param a second order polynomial coefficient of the merit function used in
+ * the linesearch.
+ * @param b first order polynomial coefficient of the merit function used in the
+ * linesearch.
+ * @param grad derivative of the merit function used in the linesearch.
+ */
+template<typename T>
+auto
+gpdal_derivative_results(const Model<T>& qpmodel,
+                         Results<T>& qpresults,
+                         Workspace<T>& qpwork,
+                         const Settings<T>& qpsettings,
+                         T alpha) -> PrimalDualDerivativeResult<T>
+{
 
+  /*
+   * the function computes the first derivative of phi(alpha) at outer step k
+   * and inner step l
+   *
+   * phi(alpha) = f(x_l+alpha dx) + rho/2 |x_l + alpha dx - x_k|**2
+   *              + mu_eq_inv/2 (|A(x_l+alpha dx)-d+y_k * mu_eq|**2)
+   *              + mu_eq_inv * nu /2 (|A(x_l+alpha dx)-d+y_k * mu_eq -
+   * (y_l+alpha dy)
+   * |**2)
+   *              + mu_in_inv/2 ( | [C(x_l+alpha dx) - u + z_k * mu_in]_+ |**2
+   *                         +| [C(x_l+alpha dx) - l + z_k * mu_in]_- |**2
+   *                         )
+   * 				+ mu_in_inv * nu / 2 ( | [C(x_l+alpha dx) - u +
+   * z_k
+   * * mu_in]_+
+   * + [C(x_l+alpha dx) - l + z_k * mu_in]_- - (z+alpha dz) * mu_in |**2 with
+   * f(x) = 0.5 * x^THx + g^Tx phi is a second order polynomial in alpha. Below
+   * are computed its coefficients a0 and b0 in order to compute the desired
+   * gradient a0 * alpha + b0
+   */
+
+  qpwork.primal_residual_in_scaled_up_plus_alphaCdx =
+    qpwork.primal_residual_in_scaled_up + qpwork.Cdx * alpha;
+  qpwork.primal_residual_in_scaled_low_plus_alphaCdx =
+    qpwork.primal_residual_in_scaled_low + qpwork.Cdx * alpha;
+
+  T a(qpwork.dw_aug.head(qpmodel.dim).dot(qpwork.Hdx) +
+      qpresults.info.mu_eq_inv * (qpwork.Adx).squaredNorm() +
+      qpresults.info.rho *
+        qpwork.dw_aug.head(qpmodel.dim)
+          .squaredNorm()); // contains now: a = dx.dot(H.dot(dx)) + rho *
+                           // norm(dx)**2 + (mu_eq_inv) * norm(Adx)**2
+
+  qpwork.err.segment(qpmodel.dim, qpmodel.n_eq) =
+    qpwork.Adx -
+    qpwork.dw_aug.segment(qpmodel.dim, qpmodel.n_eq) * qpresults.info.mu_eq;
+  a +=
+    qpwork.err.segment(qpmodel.dim, qpmodel.n_eq).squaredNorm() *
+    qpresults.info
+      .mu_eq_inv; // contains now: a = dx.dot(H.dot(dx)) + rho * norm(dx)**2 +
+  // (mu_eq_inv) * norm(Adx)**2 + mu_eq_inv * norm(Adx-dy*mu_eq)**2
+  qpwork.err.head(qpmodel.dim) =
+    qpresults.info.rho * (qpresults.x - qpwork.x_prev) + qpwork.g_scaled;
+  T b(qpresults.x.dot(qpwork.Hdx) +
+      (qpwork.err.head(qpmodel.dim)).dot(qpwork.dw_aug.head(qpmodel.dim)) +
+      qpresults.info.mu_eq_inv *
+        (qpwork.Adx)
+          .dot(qpwork.primal_residual_eq_scaled +
+               qpresults.y * qpresults.info.mu_eq)); // contains now: b =
+                                                     // dx.dot(H.dot(x) +
+                                                     // rho*(x-xe) +  g)  +
+  // mu_eq_inv * Adx.dot(res_eq)
+
+  qpwork.rhs.segment(qpmodel.dim, qpmodel.n_eq) =
+    qpwork.primal_residual_eq_scaled;
+  b += qpresults.info.mu_eq_inv *
+       qpwork.err.segment(qpmodel.dim, qpmodel.n_eq)
+         .dot(qpwork.rhs.segment(
+           qpmodel.dim,
+           qpmodel.n_eq)); // contains now: b = dx.dot(H.dot(x) + rho*(x-xe)
+  // +  g)  + mu_eq_inv * Adx.dot(res_eq) + nu*mu_eq_inv *
+  // (Adx-dy*mu_eq).dot(res_eq-y*mu_eq)
+
+  // derive Cdx_act
+  qpwork.err.tail(qpmodel.n_in) =
+    ((qpwork.primal_residual_in_scaled_up_plus_alphaCdx.array() > T(0.)) ||
+     (qpwork.primal_residual_in_scaled_low_plus_alphaCdx.array() < T(0.)))
+      .select(qpwork.Cdx,
+              Eigen::Matrix<T, Eigen::Dynamic, 1>::Zero(qpmodel.n_in));
+
+  a += qpresults.info.mu_in_inv * qpwork.err.tail(qpmodel.n_in).squaredNorm() /
+       qpsettings.alpha_gpdal; // contains now: a = dx.dot(H.dot(dx)) + rho *
+  // norm(dx)**2 + (mu_eq_inv) * norm(Adx)**2 + nu*mu_eq_inv *
+  // norm(Adx-dy*mu_eq)**2 +
+  // norm(dw_act)**2 / (mu_in * (alpha_gpdal))
+  a += qpresults.info.mu_in * (1. - qpsettings.alpha_gpdal) *
+       qpwork.dw_aug.tail(qpmodel.n_in).squaredNorm();
+  // add norm(z)**2 * mu_in * (1-alpha)
+
+  // derive vector [w-u]_+ + [w-l]--
+  qpwork.active_part_z =
+    (qpwork.primal_residual_in_scaled_up_plus_alphaCdx.array() > T(0.))
+      .select(qpwork.primal_residual_in_scaled_up,
+              Eigen::Matrix<T, Eigen::Dynamic, 1>::Zero(qpmodel.n_in)) +
+    (qpwork.primal_residual_in_scaled_low_plus_alphaCdx.array() < T(0.))
+      .select(qpwork.primal_residual_in_scaled_low,
+              Eigen::Matrix<T, Eigen::Dynamic, 1>::Zero(qpmodel.n_in));
+
+  b +=
+    qpresults.info.mu_in_inv *
+    qpwork.active_part_z.dot(qpwork.err.tail(qpmodel.n_in)) /
+    qpsettings.alpha_gpdal; // contains now: b = dx.dot(H.dot(x) + rho*(x-xe) +
+  // g)  + mu_eq_inv * Adx.dot(res_eq) + nu*mu_eq_inv *
+  // (Adx-dy*mu_eq).dot(res_eq-y*mu_eq) + mu_in
+  // * dw_act.dot([w-u]_+ + [w-l]--) / alpha_gpdal
+
+  // contains now b =  dx.dot(H.dot(x) + rho*(x-xe) +  g)  + mu_eq_inv *
+  // Adx.dot(res_eq) + nu*mu_eq_inv * (Adx-dy*mu_eq).dot(res_eq-y*mu_eq) +
+  // mu_in_inv
+  // * Cdx_act.dot([Cx-u+ze*mu_in]_+ + [Cx-l+ze*mu_in]--) + nu*mu_in_inv
+  // (Cdx_act-dz*mu_in).dot([Cx-u+ze*mu_in]_+ + [Cx-l+ze*mu_in]-- - z*mu_in)
+  b += qpresults.info.mu_in * (1. - qpsettings.alpha_gpdal) *
+       qpwork.dw_aug.tail(qpmodel.n_in).dot(qpresults.z);
+
+  return {
+    a,
+    b,
+    a * alpha + b,
+  };
+}
 /*!
  * Stores first derivative and coefficient of the univariate second order
  * polynomial merit function to be canceled by the exact primal-dual linesearch.
@@ -173,7 +302,6 @@ primal_dual_derivative_results(const Model<T>& qpmodel,
     a * alpha + b,
   };
 }
-
 /*!
  * Performs the exact primaldual linesearch algorithm.
  *
@@ -186,7 +314,8 @@ template<typename T>
 void
 primal_dual_ls(const Model<T>& qpmodel,
                Results<T>& qpresults,
-               Workspace<T>& qpwork)
+               Workspace<T>& qpwork,
+               const Settings<T>& qpsettings)
 {
 
   /*
@@ -298,8 +427,15 @@ primal_dual_ls(const Model<T>& qpmodel,
      * (noted first_grad_pos) and alpha (first_alpha_pos), and
      * break the loop
      */
-    T gr =
-      primal_dual_derivative_results(qpmodel, qpresults, qpwork, alpha_).grad;
+    T gr(0);
+    if (qpsettings.gpdal_merit_function) {
+      gr =
+        gpdal_derivative_results(qpmodel, qpresults, qpwork, qpsettings, alpha_)
+          .grad;
+    } else {
+      gr =
+        primal_dual_derivative_results(qpmodel, qpresults, qpwork, alpha_).grad;
+    }
 
     if (gr < T(0)) {
       alpha_last_neg = alpha_;
@@ -319,9 +455,15 @@ primal_dual_ls(const Model<T>& qpmodel,
    * "gradient_norm"
    */
   if (alpha_last_neg == T(0)) {
-    last_neg_grad =
-      primal_dual_derivative_results(qpmodel, qpresults, qpwork, alpha_last_neg)
-        .grad;
+    if (qpsettings.gpdal_merit_function) {
+      last_neg_grad = gpdal_derivative_results(
+                        qpmodel, qpresults, qpwork, qpsettings, alpha_last_neg)
+                        .grad;
+    } else {
+      last_neg_grad = primal_dual_derivative_results(
+                        qpmodel, qpresults, qpwork, alpha_last_neg)
+                        .grad;
+    }
   }
   if (alpha_first_pos == infty) {
     /*
@@ -329,13 +471,23 @@ primal_dual_ls(const Model<T>& qpmodel,
      * the optimal alpha is within the interval
      * [last_alpha_neg, +∞)
      */
-    PrimalDualDerivativeResult<T> res = primal_dual_derivative_results(
-      qpmodel, qpresults, qpwork, 2 * alpha_last_neg + 1);
-    auto& a = res.a;
-    auto& b = res.b;
-    // grad = a * alpha + b
-    // grad = 0 => alpha = -b/a
-    qpwork.alpha = -b / a;
+    if (qpsettings.gpdal_merit_function) {
+      PrimalDualDerivativeResult<T> res = gpdal_derivative_results(
+        qpmodel, qpresults, qpwork, qpsettings, 2 * alpha_last_neg + 1);
+      auto& a = res.a;
+      auto& b = res.b;
+      // grad = a * alpha + b
+      // grad = 0 => alpha = -b/a
+      qpwork.alpha = -b / a;
+    } else {
+      PrimalDualDerivativeResult<T> res = primal_dual_derivative_results(
+        qpmodel, qpresults, qpwork, 2 * alpha_last_neg + 1);
+      auto& a = res.a;
+      auto& b = res.b;
+      // grad = a * alpha + b
+      // grad = 0 => alpha = -b/a
+      qpwork.alpha = -b / a;
+    }
   } else {
     /*
      * 2.3

--- a/include/proxsuite/proxqp/settings.hpp
+++ b/include/proxsuite/proxqp/settings.hpp
@@ -22,6 +22,12 @@ enum struct SparseBackend
   SparseCholesky, // sparse cholesky backend.
   MatrixFree,     // iterative matrix free sparse backend.
 };
+// MERIT FUNCTION
+enum struct MeritFunctionType
+{
+  GPDAL, // Generalized Primal Dual Augmented Lagrangian
+  PDAL,  // Primal Dual Augmented Lagrangian
+};
 
 inline std::ostream&
 operator<<(std::ostream& os, const SparseBackend& sparse_backend)
@@ -94,7 +100,7 @@ struct Settings
   T eps_primal_inf;
   T eps_dual_inf;
   bool bcl_update;
-  bool gpdal_merit_function;
+  MeritFunctionType merit_function_type;
   T alpha_gpdal;
 
   SparseBackend sparse_backend;
@@ -201,8 +207,8 @@ struct Settings
     T eps_primal_inf = 1.E-4,
     T eps_dual_inf = 1.E-4,
     bool bcl_update = true,
-    bool gpdal_merit_function = false,
-    T alpha_gpdal = 0.5,
+    MeritFunctionType merit_function_type = MeritFunctionType::PDAL,
+    T alpha_gpdal = 0.9,
     SparseBackend sparse_backend = SparseBackend::Automatic)
     : default_rho(default_rho)
     , default_mu_eq(default_mu_eq)
@@ -241,7 +247,7 @@ struct Settings
     , eps_primal_inf(eps_primal_inf)
     , eps_dual_inf(eps_dual_inf)
     , bcl_update(bcl_update)
-    , gpdal_merit_function(gpdal_merit_function)
+    , merit_function_type(merit_function_type)
     , alpha_gpdal(alpha_gpdal)
     , sparse_backend(sparse_backend)
   {
@@ -291,7 +297,7 @@ operator==(const Settings<T>& settings1, const Settings<T>& settings2)
     settings1.eps_primal_inf == settings2.eps_primal_inf &&
     settings1.eps_dual_inf == settings2.eps_dual_inf &&
     settings1.bcl_update == settings2.bcl_update &&
-    settings1.gpdal_merit_function == settings2.gpdal_merit_function &&
+    settings1.merit_function_type == settings2.merit_function_type &&
     settings1.alpha_gpdal == settings2.alpha_gpdal &&
     settings1.sparse_backend == settings2.sparse_backend;
   return value;

--- a/include/proxsuite/proxqp/settings.hpp
+++ b/include/proxsuite/proxqp/settings.hpp
@@ -207,8 +207,8 @@ struct Settings
     T eps_primal_inf = 1.E-4,
     T eps_dual_inf = 1.E-4,
     bool bcl_update = true,
-    MeritFunctionType merit_function_type = MeritFunctionType::PDAL,
-    T alpha_gpdal = 0.9,
+    MeritFunctionType merit_function_type = MeritFunctionType::GPDAL,
+    T alpha_gpdal = 0.999,
     SparseBackend sparse_backend = SparseBackend::Automatic)
     : default_rho(default_rho)
     , default_mu_eq(default_mu_eq)

--- a/include/proxsuite/proxqp/settings.hpp
+++ b/include/proxsuite/proxqp/settings.hpp
@@ -94,6 +94,8 @@ struct Settings
   T eps_primal_inf;
   T eps_dual_inf;
   bool bcl_update;
+  bool gpdal_merit_function;
+  T alpha_gpdal;
 
   SparseBackend sparse_backend;
   /*!
@@ -199,6 +201,8 @@ struct Settings
     T eps_primal_inf = 1.E-4,
     T eps_dual_inf = 1.E-4,
     bool bcl_update = true,
+    bool gpdal_merit_function = false,
+    T alpha_gpdal = 0.5,
     SparseBackend sparse_backend = SparseBackend::Automatic)
     : default_rho(default_rho)
     , default_mu_eq(default_mu_eq)
@@ -237,6 +241,8 @@ struct Settings
     , eps_primal_inf(eps_primal_inf)
     , eps_dual_inf(eps_dual_inf)
     , bcl_update(bcl_update)
+    , gpdal_merit_function(gpdal_merit_function)
+    , alpha_gpdal(alpha_gpdal)
     , sparse_backend(sparse_backend)
   {
   }
@@ -285,6 +291,8 @@ operator==(const Settings<T>& settings1, const Settings<T>& settings2)
     settings1.eps_primal_inf == settings2.eps_primal_inf &&
     settings1.eps_dual_inf == settings2.eps_dual_inf &&
     settings1.bcl_update == settings2.bcl_update &&
+    settings1.gpdal_merit_function == settings2.gpdal_merit_function &&
+    settings1.alpha_gpdal == settings2.alpha_gpdal &&
     settings1.sparse_backend == settings2.sparse_backend;
   return value;
 }

--- a/include/proxsuite/proxqp/sparse/solver.hpp
+++ b/include/proxsuite/proxqp/sparse/solver.hpp
@@ -135,6 +135,14 @@ ldl_iter_solve_noalias(
     if (solve_iter > 0) {
       T mu_eq_neg = -results.info.mu_eq;
       T mu_in_neg = -results.info.mu_in;
+      // switch (settings.merit_function_type) {
+      //   case MeritFunctionType::GPDAL:
+      //     mu_in_neg = -settings.alpha_gpdal*results.info.mu_in;
+      //     break;
+      //   case MeritFunctionType::PDAL:
+      //     mu_in_neg = -results.info.mu_in;
+      //     break;
+      // }
       detail::noalias_symhiv_add(err, kkt_active.to_eigen(), sol_e);
       err_x += results.info.rho * sol_x;
       err_y += mu_eq_neg * sol_y;
@@ -678,7 +686,7 @@ qp_solve(Results<T>& results,
   auto y_e = y.to_eigen();
   auto z_e = z.to_eigen();
   sparse::refactorize<T, I>(
-    work, results, kkt_active, active_constraints, data, stack, xtag);
+    work, results, settings, kkt_active, active_constraints, data, stack, xtag);
   switch (settings.initial_guess) {
     case InitialGuessStatus::EQUALITY_CONSTRAINED_INITIAL_GUESS: {
       LDLT_TEMP_VEC_UNINIT(T, rhs, n_tot, stack);
@@ -870,14 +878,14 @@ qp_solve(Results<T>& results,
 
       // Cx + 1/mu_in * z_prev
       primal_residual_in_scaled_up += results.info.mu_in * z_prev_e;
-      switch (settings.merit_function_type) {
-        case MeritFunctionType::GPDAL:
-          primal_residual_in_scaled_up +=
-            (settings.alpha_gpdal - 1.) * results.info.mu_in * z_e;
-          break;
-        case MeritFunctionType::PDAL:
-          break;
-      }
+      // switch (settings.merit_function_type) { NOT activated for the moment
+      //   case MeritFunctionType::GPDAL:
+      //     primal_residual_in_scaled_up +=
+      //       (settings.alpha_gpdal - 1.) * results.info.mu_in * results.z;
+      //     break;
+      //   case MeritFunctionType::PDAL:
+      //     break;
+      // }
       primal_residual_in_scaled_lo = primal_residual_in_scaled_up;
 
       // Cx - l + 1/mu_in * z_prev
@@ -936,15 +944,18 @@ qp_solve(Results<T>& results,
                       kkt.row_indices() + zx(kkt.col_start(usize(idx))),
                       kkt.values() + zx(kkt.col_start(usize(idx))),
                     };
-
-                    ldl =
-                      proxsuite::linalg::sparse::add_row(ldl,
-                                                         etree,
-                                                         perm_inv,
-                                                         idx,
-                                                         new_col,
-                                                         -results.info.mu_in,
-                                                         stack);
+                    T mu_in_neg = -results.info.mu_in;
+                    // switch (settings.merit_function_type)
+                    // {
+                    // case MeritFunctionType::GPDAL:
+                    //   mu_in_neg = -settings.alpha_gpdal * results.info.mu_in;
+                    //   break;
+                    // case MeritFunctionType::PDAL:
+                    //   mu_in_neg = -results.info.mu_in;
+                    //   break;
+                    // }
+                    ldl = proxsuite::linalg::sparse::add_row(
+                      ldl, etree, perm_inv, idx, new_col, mu_in_neg, stack);
                   }
                   active_constraints[i] = new_active_constraints[i];
 
@@ -964,6 +975,7 @@ qp_solve(Results<T>& results,
                 if (removed || added) {
                   refactorize(work,
                               results,
+                              settings,
                               kkt_active,
                               active_constraints,
                               data,
@@ -972,41 +984,53 @@ qp_solve(Results<T>& results,
                 }
               }
             }
-
+            rhs.setZero();
             rhs.head(n) = -dual_residual_scaled;
             rhs.segment(n, n_eq) = -primal_residual_eq_scaled;
-            switch (settings.merit_function_type) {
-              case MeritFunctionType::GPDAL:
-                for (isize i = 0; i < n_in; ++i) {
-                  if (work.active_set_up(i)) {
-                    rhs(n + n_eq + i) =
-                      -primal_residual_in_scaled_up(i) +
-                      z_e(i) * results.info.mu_in * settings.alpha_gpdal;
-                  } else if (work.active_set_low(i)) {
-                    rhs(n + n_eq + i) =
-                      -primal_residual_in_scaled_lo(i) +
-                      z_e(i) * results.info.mu_in * settings.alpha_gpdal;
-                  } else {
-                    rhs(n + n_eq + i) = -z_e(i);
-                    rhs.head(n) += z_e(i) * CT_scaled.to_eigen().col(i);
-                  }
-                }
-                break;
-              case MeritFunctionType::PDAL:
-                for (isize i = 0; i < n_in; ++i) {
-                  if (work.active_set_up(i)) {
-                    rhs(n + n_eq + i) = results.info.mu_in * z_e(i) -
-                                        primal_residual_in_scaled_up(i);
-                  } else if (work.active_set_low(i)) {
-                    rhs(n + n_eq + i) = results.info.mu_in * z_e(i) -
-                                        primal_residual_in_scaled_lo(i);
-                  } else {
-                    rhs(n + n_eq + i) = -z_e(i);
-                    rhs.head(n) += z_e(i) * CT_scaled.to_eigen().col(i);
-                  }
-                }
-                break;
+            for (isize i = 0; i < n_in; ++i) {
+              if (work.active_set_up(i)) {
+                rhs(n + n_eq + i) =
+                  results.info.mu_in * z_e(i) - primal_residual_in_scaled_up(i);
+              } else if (work.active_set_low(i)) {
+                rhs(n + n_eq + i) =
+                  results.info.mu_in * z_e(i) - primal_residual_in_scaled_lo(i);
+              } else {
+                rhs(n + n_eq + i) = -z_e(i);
+                rhs.head(n) += z_e(i) * CT_scaled.to_eigen().col(i);
+              }
             }
+            // switch (settings.merit_function_type) {
+            //   case MeritFunctionType::GPDAL:
+            //     for (isize i = 0; i < n_in; ++i) {
+            //       if (work.active_set_up(i)) {
+            //         rhs(n + n_eq + i) =
+            //           -primal_residual_in_scaled_up(i) +
+            //           z_e(i) * results.info.mu_in * settings.alpha_gpdal;
+            //       } else if (work.active_set_low(i)) {
+            //         rhs(n + n_eq + i) =
+            //           -primal_residual_in_scaled_lo(i) +
+            //           z_e(i) * results.info.mu_in * settings.alpha_gpdal;
+            //       } else {
+            //         rhs(n + n_eq + i) = -z_e(i);
+            //         rhs.head(n) += z_e(i) * CT_scaled.to_eigen().col(i);
+            //       }
+            //     }
+            //     break;
+            //   case MeritFunctionType::PDAL:
+            //     for (isize i = 0; i < n_in; ++i) {
+            //       if (work.active_set_up(i)) {
+            //         rhs(n + n_eq + i) = results.info.mu_in * z_e(i) -
+            //                             primal_residual_in_scaled_up(i);
+            //       } else if (work.active_set_low(i)) {
+            //         rhs(n + n_eq + i) = results.info.mu_in * z_e(i) -
+            //                             primal_residual_in_scaled_lo(i);
+            //       } else {
+            //         rhs(n + n_eq + i) = -z_e(i);
+            //         rhs.head(n) += z_e(i) * CT_scaled.to_eigen().col(i);
+            //       }
+            //     }
+            //     break;
+            // }
             ldl_solve_in_place(
               { proxqp::from_eigen, rhs },
               { proxqp::from_eigen,
@@ -1041,14 +1065,14 @@ qp_solve(Results<T>& results,
           detail::noalias_symhiv_add(Hdx, H_scaled.to_eigen(), dx);
           detail::noalias_gevmmv_add(Adx, ATdy, AT_scaled.to_eigen(), dx, dy);
           detail::noalias_gevmmv_add(Cdx, CTdz, CT_scaled.to_eigen(), dx, dz);
-          switch (settings.merit_function_type) {
-            case MeritFunctionType::GPDAL:
-              Cdx.noalias() +=
-                (settings.alpha_gpdal - 1.) * results.info.mu_in * dz;
-              break;
-            case MeritFunctionType::PDAL:
-              break;
-          }
+          // switch (settings.merit_function_type) {
+          //   case MeritFunctionType::GPDAL:
+          //     Cdx.noalias() +=
+          //       (settings.alpha_gpdal - 1.) * results.info.mu_in * dz;
+          //     break;
+          //   case MeritFunctionType::PDAL:
+          //     break;
+          // }
           T alpha = 1;
           // primal dual line search
           if (n_in > 0) {
@@ -1100,66 +1124,69 @@ qp_solve(Results<T>& results,
               };
             };
 
-            auto gpdal_derivative_results =
-              [&](T alpha_cur) -> PrimalDualGradResult<T> {
-              LDLT_TEMP_VEC_UNINIT(T, Cdx_active, n_in, stack);
-              LDLT_TEMP_VEC_UNINIT(T, active_part_z, n_in, stack);
-              {
-                LDLT_TEMP_VEC_UNINIT(T, tmp_lo, n_in, stack);
-                LDLT_TEMP_VEC_UNINIT(T, tmp_up, n_in, stack);
+            // auto gpdal_derivative_results =
+            //   [&](T alpha_cur) -> PrimalDualGradResult<T> {
+            //   LDLT_TEMP_VEC_UNINIT(T, Cdx_active, n_in, stack);
+            //   LDLT_TEMP_VEC_UNINIT(T, active_part_z, n_in, stack);
+            //   {
+            //     LDLT_TEMP_VEC_UNINIT(T, tmp_lo, n_in, stack);
+            //     LDLT_TEMP_VEC_UNINIT(T, tmp_up, n_in, stack);
 
-                auto zero = Eigen::Matrix<T, Eigen::Dynamic, 1>::Zero(n_in);
+            //     auto zero = Eigen::Matrix<T, Eigen::Dynamic, 1>::Zero(n_in);
 
-                tmp_lo = primal_residual_in_scaled_lo + alpha_cur * Cdx;
-                tmp_up = primal_residual_in_scaled_up + alpha_cur * Cdx;
-                Cdx_active =
-                  (tmp_lo.array() < 0 || tmp_up.array() > 0).select(Cdx, zero);
-                active_part_z = (tmp_lo.array() < 0)
-                                  .select(primal_residual_in_scaled_lo, zero) +
-                                (tmp_up.array() > 0)
-                                  .select(primal_residual_in_scaled_up, zero);
-              }
+            //     tmp_lo = primal_residual_in_scaled_lo + alpha_cur * Cdx;
+            //     tmp_up = primal_residual_in_scaled_up + alpha_cur * Cdx;
+            //     Cdx_active =
+            //       (tmp_lo.array() < 0 || tmp_up.array() > 0).select(Cdx,
+            //       zero);
+            //     active_part_z = (tmp_lo.array() < 0)
+            //                       .select(primal_residual_in_scaled_lo, zero)
+            //                       +
+            //                     (tmp_up.array() > 0)
+            //                       .select(primal_residual_in_scaled_up,
+            //                       zero);
+            //   }
 
-              T a = dx.dot(Hdx) +                         //
-                    results.info.rho * dx.squaredNorm() + //
-                    results.info.mu_eq_inv * Adx.squaredNorm() +
-                    +results.info.mu_in_inv * Cdx_active.squaredNorm() /
-                      settings.alpha_gpdal +
-                    results.info.mu_eq *
-                      (results.info.mu_eq_inv * Adx - dy).squaredNorm() +
-                    results.info.mu_in * (1. - settings.alpha_gpdal) *
-                      (dz).squaredNorm();
+            //   T a = dx.dot(Hdx) +                         //
+            //         results.info.rho * dx.squaredNorm() + //
+            //         results.info.mu_eq_inv * Adx.squaredNorm() +
+            //         +results.info.mu_in_inv * Cdx_active.squaredNorm() /
+            //           settings.alpha_gpdal + results.info.mu_eq_inv *
+            //           (Adx - results.info.mu_eq *dy).squaredNorm() +
+            //         results.info.mu_in * (1. - settings.alpha_gpdal) *
+            //           (dz).squaredNorm();
 
-              T b =
-                x_e.dot(Hdx) +                                               //
-                (results.info.rho * (x_e - x_prev_e) + g_scaled_e).dot(dx) + //
-                Adx.dot(results.info.mu_eq_inv * primal_residual_eq_scaled +
-                        y_e) + //
-                results.info.mu_in_inv * Cdx_active.dot(active_part_z) /
-                  settings.alpha_gpdal + //
-                primal_residual_eq_scaled.dot(results.info.mu_eq_inv * Adx -
-                                              dy) + //
-                (z_e).dot(dz) * results.info.mu_in *
-                  (1. - settings.alpha_gpdal);
+            //   T b =
+            //     x_e.dot(Hdx) + // (results.info.rho * (x_e - x_prev_e) +
+            //     g_scaled_e).dot(dx) + // results.info.mu_eq_inv * Adx.dot(
+            //     primal_residual_eq_scaled +
+            //             y_e * results.info.mu_eq) + //
+            //     results.info.mu_in_inv * Cdx_active.dot(active_part_z) /
+            //       settings.alpha_gpdal + //
+            //     results.info.mu_eq_inv * primal_residual_eq_scaled.dot( Adx -
+            //                                   dy * results.info.mu_eq) + //
+            //     (z_e).dot(dz) * results.info.mu_in *
+            //       (1. - settings.alpha_gpdal);
 
-              return {
-                a,
-                b,
-                a * alpha_cur + b,
-              };
-            };
+            //   return {
+            //     a,
+            //     b,
+            //     a * alpha_cur + b,
+            //   };
+            // };
 
             LDLT_TEMP_VEC_UNINIT(T, alphas, 2 * n_in, stack);
             isize alphas_count = 0;
+            const T machine_eps = std::numeric_limits<T>::epsilon();
 
             for (isize i = 0; i < n_in; ++i) {
               T alpha_candidates[2] = {
-                -primal_residual_in_scaled_lo(i) / (Cdx(i)),
-                -primal_residual_in_scaled_up(i) / (Cdx(i)),
+                -primal_residual_in_scaled_lo(i) / (Cdx(i) + machine_eps),
+                -primal_residual_in_scaled_up(i) / (Cdx(i) + machine_eps),
               };
 
               for (auto alpha_candidate : alpha_candidates) {
-                if (alpha_candidate > 0) {
+                if (alpha_candidate > machine_eps) {
                   alphas[alphas_count] = alpha_candidate;
                   ++alphas_count;
                 }
@@ -1169,27 +1196,25 @@ qp_solve(Results<T>& results,
             alphas_count =
               std::unique(alphas.data(), alphas.data() + alphas_count) -
               alphas.data();
-
-            if (alphas_count > 0 && alphas[0] <= 1) {
+            if (alphas_count > 0) { //&& alphas[0] <= 1
               auto infty = std::numeric_limits<T>::infinity();
 
               T last_neg_grad = 0;
               T alpha_last_neg = 0;
               T first_pos_grad = 0;
               T alpha_first_pos = infty;
-
               {
                 for (isize i = 0; i < alphas_count; ++i) {
                   T alpha_cur = alphas[i];
-                  T gr(0);
-                  switch (settings.merit_function_type) {
-                    case MeritFunctionType::GPDAL:
-                      gr = gpdal_derivative_results(alpha_cur).grad;
-                      break;
-                    case MeritFunctionType::PDAL:
-                      gr = primal_dual_gradient_norm(alpha_cur).grad;
-                      break;
-                  }
+                  T gr = primal_dual_gradient_norm(alpha_cur).grad;
+                  // switch (settings.merit_function_type) {
+                  //   case MeritFunctionType::GPDAL:
+                  //     gr = gpdal_derivative_results(alpha_cur).grad;
+                  //     break;
+                  //   case MeritFunctionType::PDAL:
+                  //     gr = primal_dual_gradient_norm(alpha_cur).grad;
+                  //     break;
+                  // }
 
                   if (gr < 0) {
                     alpha_last_neg = alpha_cur;
@@ -1202,30 +1227,34 @@ qp_solve(Results<T>& results,
                 }
 
                 if (alpha_last_neg == 0) {
-                  switch (settings.merit_function_type) {
-                    case MeritFunctionType::GPDAL:
-                      last_neg_grad =
-                        gpdal_derivative_results(alpha_last_neg).grad;
-                      break;
-                    case MeritFunctionType::PDAL:
-                      last_neg_grad =
-                        primal_dual_gradient_norm(alpha_last_neg).grad;
-                      break;
-                  }
+                  last_neg_grad =
+                    primal_dual_gradient_norm(alpha_last_neg).grad;
+                  // switch (settings.merit_function_type) {
+                  //   case MeritFunctionType::GPDAL:
+                  //     last_neg_grad =
+                  //       gpdal_derivative_results(alpha_last_neg).grad;
+                  //     break;
+                  //   case MeritFunctionType::PDAL:
+                  //     last_neg_grad =
+                  //       primal_dual_gradient_norm(alpha_last_neg).grad;
+                  //     break;
+                  // }
                 }
                 if (alpha_first_pos == infty) {
-                  switch (settings.merit_function_type) {
-                    case MeritFunctionType::GPDAL: {
-                      auto res =
-                        gpdal_derivative_results(2 * alpha_last_neg + 1);
-                      alpha = -res.b / res.a;
-                    } break;
-                    case MeritFunctionType::PDAL: {
-                      auto res =
-                        primal_dual_gradient_norm(2 * alpha_last_neg + 1);
-                      alpha = -res.b / res.a;
-                    } break;
-                  }
+                  auto res = primal_dual_gradient_norm(2 * alpha_last_neg + 1);
+                  alpha = -res.b / res.a;
+                  // switch (settings.merit_function_type) {
+                  //   case MeritFunctionType::GPDAL: {
+                  //     auto res =
+                  //       gpdal_derivative_results(2 * alpha_last_neg + 1);
+                  //     alpha = -res.b / res.a;
+                  //   } break;
+                  //   case MeritFunctionType::PDAL: {
+                  //     auto res =
+                  //       primal_dual_gradient_norm(2 * alpha_last_neg + 1);
+                  //     alpha = -res.b / res.a;
+                  //   } break;
+                  // }
                 } else {
                   alpha = alpha_last_neg -
                           last_neg_grad * (alpha_first_pos - alpha_last_neg) /
@@ -1233,16 +1262,18 @@ qp_solve(Results<T>& results,
                 }
               }
             } else {
-              switch (settings.merit_function_type) {
-                case MeritFunctionType::GPDAL: {
-                  auto res = gpdal_derivative_results(T(0));
-                  alpha = -res.b / res.a;
-                } break;
-                case MeritFunctionType::PDAL: {
-                  auto res = primal_dual_gradient_norm(T(0));
-                  alpha = -res.b / res.a;
-                } break;
-              }
+              auto res = primal_dual_gradient_norm(T(0));
+              alpha = -res.b / res.a;
+              // switch (settings.merit_function_type) {
+              //   case MeritFunctionType::GPDAL: {
+              //     auto res = gpdal_derivative_results(T(0));
+              //     alpha = -res.b / res.a;
+              //   } break;
+              //   case MeritFunctionType::PDAL: {
+              //     auto res = primal_dual_gradient_norm(T(0));
+              //     alpha = -res.b / res.a;
+              //   } break;
+              // }
             }
           }
           if (alpha * infty_norm(dw) < T(1e-11) && iter_inner > 0) {
@@ -1259,29 +1290,35 @@ qp_solve(Results<T>& results,
           primal_residual_in_scaled_lo += alpha * Cdx;
           primal_residual_in_scaled_up += alpha * Cdx;
 
-          T err_in(0);
-          switch (settings.merit_function_type) {
-            case MeritFunctionType::GPDAL:
-              err_in = std::max({
-                (infty_norm(
-                  helpers::negative_part(primal_residual_in_scaled_lo) +
-                  helpers::positive_part(primal_residual_in_scaled_up) -
-                  settings.alpha_gpdal * results.info.mu_in * z_e)),
-                (infty_norm(primal_residual_eq_scaled)),
-                (infty_norm(dual_residual_scaled)),
-              });
-              break;
-            case MeritFunctionType::PDAL:
-              err_in = std::max({
-                (infty_norm(
-                  helpers::negative_part(primal_residual_in_scaled_lo) +
-                  helpers::positive_part(primal_residual_in_scaled_up) -
-                  results.info.mu_in * z_e)),
-                (infty_norm(primal_residual_eq_scaled)),
-                (infty_norm(dual_residual_scaled)),
-              });
-              break;
-          }
+          T err_in = std::max({
+            (infty_norm(helpers::negative_part(primal_residual_in_scaled_lo) +
+                        helpers::positive_part(primal_residual_in_scaled_up) -
+                        results.info.mu_in * z_e)),
+            (infty_norm(primal_residual_eq_scaled)),
+            (infty_norm(dual_residual_scaled)),
+          });
+          // switch (settings.merit_function_type) {
+          //   case MeritFunctionType::GPDAL:
+          //     err_in = std::max({
+          //       (infty_norm(
+          //         helpers::negative_part(primal_residual_in_scaled_lo) +
+          //         helpers::positive_part(primal_residual_in_scaled_up) -
+          //         settings.alpha_gpdal * results.info.mu_in * z_e)),
+          //       (infty_norm(primal_residual_eq_scaled)),
+          //       (infty_norm(dual_residual_scaled)),
+          //     });
+          //     break;
+          //   case MeritFunctionType::PDAL:
+          //     err_in = std::max({
+          //       (infty_norm(
+          //         helpers::negative_part(primal_residual_in_scaled_lo) +
+          //         helpers::positive_part(primal_residual_in_scaled_up) -
+          //         results.info.mu_in * z_e)),
+          //       (infty_norm(primal_residual_eq_scaled)),
+          //       (infty_norm(dual_residual_scaled)),
+          //     });
+          //     break;
+          // }
           /* put in debug mode
           if (settings.verbose) {
                   std::cout << "--inner iter " << iter_inner << " iner error "
@@ -1480,6 +1517,15 @@ qp_solve(Results<T>& results,
               continue;
             }
             alpha = results.info.mu_in - new_bcl_mu_in;
+            // switch (settings.merit_function_type)
+            // {
+            // case MeritFunctionType::GPDAL:
+            //   alpha = settings.alpha_gpdal * (results.info.mu_in -
+            //   new_bcl_mu_in); break;
+            // case MeritFunctionType::PDAL:
+            //   alpha = results.info.mu_in - new_bcl_mu_in;
+            //   break;
+            // }
           }
           T value = 1;
           proxsuite::linalg::sparse::VecRef<T, I> w{
@@ -1492,8 +1538,14 @@ qp_solve(Results<T>& results,
           ldl = rank1_update(ldl, etree, perm_inv, w, alpha, stack);
         }
       } else {
-        refactorize(
-          work, results, kkt_active, active_constraints, data, stack, xtag);
+        refactorize(work,
+                    results,
+                    settings,
+                    kkt_active,
+                    active_constraints,
+                    data,
+                    stack,
+                    xtag);
       }
     }
 

--- a/include/proxsuite/proxqp/sparse/workspace.hpp
+++ b/include/proxsuite/proxqp/sparse/workspace.hpp
@@ -32,6 +32,7 @@ template<typename T, typename I>
 void
 refactorize(Workspace<T, I>& work,
             Results<T> const& results,
+            Settings<T> const& settings,
             proxsuite::linalg::sparse::MatMut<T, I> kkt_active,
             proxsuite::linalg::veg::SliceMut<bool> active_constraints,
             Model<T, I> const& data,
@@ -40,7 +41,15 @@ refactorize(Workspace<T, I>& work,
 {
   isize n_tot = kkt_active.nrows();
   T mu_eq_neg = -results.info.mu_eq;
-  T mu_in_neg = -results.info.mu_in;
+  T mu_in_neg(0);
+  switch (settings.merit_function_type) {
+    case MeritFunctionType::GPDAL:
+      mu_in_neg = -settings.alpha_gpdal * results.info.mu_in;
+      break;
+    case MeritFunctionType::PDAL:
+      mu_in_neg = -results.info.mu_in;
+      break;
+  }
 
   if (work.internal.do_ldlt) {
     proxsuite::linalg::sparse::factorize_symbolic_non_zeros(

--- a/test/src/dense_maros_meszaros.cpp
+++ b/test/src/dense_maros_meszaros.cpp
@@ -119,7 +119,6 @@ TEST_CASE("dense maros meszaros using the api")
       proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
       qp.init(H, g, A, b, C, l, u);
 
-      qp.settings.verbose = false;
       qp.settings.eps_abs = 2e-8;
       qp.settings.eps_rel = 0;
       auto& eps = qp.settings.eps_abs;

--- a/test/src/sparse_maros_meszaros.cpp
+++ b/test/src/sparse_maros_meszaros.cpp
@@ -144,14 +144,11 @@ TEST_CASE("sparse maros meszaros using the API")
       proxsuite::proxqp::sparse::QP<T, I> qp(H.cast<bool>(),
                                              AT.transpose().cast<bool>(),
                                              CT.transpose().cast<bool>());
-      qp.settings.max_iter = 1.E6;
-      qp.settings.verbose = false;
-
       qp.settings.eps_abs = eps_abs_no_duality_gap;
       qp.settings.eps_rel = 0;
       qp.init(H, g, AT.transpose(), b, CT.transpose(), l, u);
 
-      for (isize iter = 0; iter < 10; ++iter) {
+      for (isize iter = 0; iter < 2; ++iter) {
         if (iter > 0)
           qp.settings.initial_guess = proxsuite::proxqp::InitialGuessStatus::
             WARM_START_WITH_PREVIOUS_RESULT;
@@ -170,7 +167,6 @@ TEST_CASE("sparse maros meszaros using the API")
 
         std::cout << "primal residual " << primal_feasibility << std::endl;
       }
-
       {
         qp.solve();
 

--- a/test/src/sparse_maros_meszaros.cpp
+++ b/test/src/sparse_maros_meszaros.cpp
@@ -35,7 +35,6 @@ compute_primal_dual_feasibility(const PreprocessedQpSparse& preprocessed,
 }
 
 char const* files[] = {
-
   MAROS_MESZAROS_DIR "AUG2D.mat",    MAROS_MESZAROS_DIR "AUG2DC.mat",
   MAROS_MESZAROS_DIR "AUG2DCQP.mat", MAROS_MESZAROS_DIR "AUG2DQP.mat",
   MAROS_MESZAROS_DIR "AUG3D.mat",    MAROS_MESZAROS_DIR "AUG3DC.mat",


### PR DESCRIPTION
Add a switch option for choosing another primal dual augmented Lagrangian merit function with ProxQP dense backend (named GPDAL, the current one is called PDAL).

The code is unit tested in C++ and python. 

The new merit function changes are for the moment only commented for ProxQP sparse backend and will be added after further changes regarding the sparse linear solver. 