### PR TITLE
Add dense LP interface

### DIFF
--- a/bindings/python/src/expose-settings.hpp
+++ b/bindings/python/src/expose-settings.hpp
@@ -35,6 +35,10 @@ exposeSettings(pybind11::module_ m)
     .value("GPDAL", MeritFunctionType::GPDAL)
     .value("PDAL", MeritFunctionType::PDAL)
     .export_values();
+  ::pybind11::enum_<ProblemType>(m, "problem_type", pybind11::module_local())
+    .value("QP", ProblemType::QP)
+    .value("LP", ProblemType::LP)
+    .export_values();
 
   ::pybind11::enum_<SparseBackend>(m, "SparseBackend", pybind11::module_local())
     .value("Automatic", SparseBackend::Automatic)
@@ -83,6 +87,7 @@ exposeSettings(pybind11::module_ m)
     .def_readwrite("bcl_update", &Settings<T>::bcl_update)
     .def_readwrite("merit_function_type", &Settings<T>::merit_function_type)
     .def_readwrite("alpha_gpdal", &Settings<T>::alpha_gpdal)
+    .def_readwrite("problem_type", &Settings<T>::problem_type)
     .def(pybind11::self == pybind11::self)
     .def(pybind11::self != pybind11::self)
     .def(pybind11::pickle(

--- a/doc/2-PROXQP_API/2-ProxQP_api.md
+++ b/doc/2-PROXQP_API/2-ProxQP_api.md
@@ -340,6 +340,7 @@ In this table you have on the three columns from left to right: the name of the 
 | safe_guard                          | 1.E4                               | Safeguard parameter ensuring global convergence of the scheme. More precisely, if the total number of iteration is superior to safe_guard, the BCL scheme accept always the multipliers (hence the scheme is a pure proximal point algorithm).
 | preconditioner_max_iter             | 10                                 | Maximal number of authorized iterations for the preconditioner.
 | preconditioner_accuracy             | 1.E-3                              | Accuracy level of the preconditioner.
+| problem_type                        | QP                                 | Defines the type of problem solved (QP or LP). In case LP option is used, the solver does not perform internally linear algebra operations involving the Hessian H.
 
 \subsection OverviewInitialGuess The different initial guesses
 

--- a/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
+++ b/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
@@ -66,7 +66,13 @@ ruiz_scale_qp_in_place( //
   LDLT_TEMP_VEC(T, delta, n + n_eq + n_in, stack);
 
   i64 iter = 1;
-
+  switch (problem_type) {
+    case ProblemType::LP:
+      delta.head(n).setOnes();
+      break;
+    case ProblemType::QP:
+      break;
+  }
   while (infty_norm((1 - delta.array()).matrix()) > epsilon) {
     if (logger_ptr != nullptr) {
       *logger_ptr                                   //
@@ -86,7 +92,6 @@ ruiz_scale_qp_in_place( //
     {
       switch (problem_type) {
         case ProblemType::LP:
-          delta.head(n).setOnes();
           break;
         case ProblemType::QP:
           for (isize k = 0; k < n; ++k) {

--- a/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
+++ b/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
@@ -10,6 +10,7 @@
 #include "proxsuite/proxqp/dense/views.hpp"
 #include "proxsuite/proxqp/dense/fwd.hpp"
 #include <proxsuite/linalg/dense/core.hpp>
+#include <proxsuite/proxqp/settings.hpp>
 #include <ostream>
 
 #include <Eigen/Core>
@@ -34,12 +35,12 @@ ruiz_scale_qp_in_place( //
   T epsilon,
   isize max_iter,
   Symmetry sym,
+  ProblemType problem_type,
   proxsuite::linalg::veg::dynstack::DynStackMut stack) -> T
 {
 
   T c(1);
   auto S = delta_.to_eigen();
-
   auto H = qp.H.to_eigen();
   auto g = qp.g.to_eigen();
   auto A = qp.A.to_eigen();
@@ -83,54 +84,60 @@ ruiz_scale_qp_in_place( //
 
     // normalization vector
     {
-      for (isize k = 0; k < n; ++k) {
-        switch (sym) {
-          case Symmetry::upper: { // upper triangular part
-            T aux = sqrt(std::max({
-              infty_norm(H.col(k).head(k)),
-              infty_norm(H.row(k).tail(n - k)),
-              n_eq > 0 ? infty_norm(A.col(k)) : T(0),
-              n_in > 0 ? infty_norm(C.col(k)) : T(0),
-            }));
-            if (aux == T(0)) {
-              delta(k) = T(1);
-            } else {
-              delta(k) = T(1) / (aux + machine_eps);
-            }
-            break;
-          }
-          case Symmetry::lower: { // lower triangular part
+      switch (problem_type) {
+        case ProblemType::LP:
+          delta.head(n).setOnes();
+          break;
+        case ProblemType::QP:
+          for (isize k = 0; k < n; ++k) {
+            switch (sym) {
+              case Symmetry::upper: { // upper triangular part
+                T aux = sqrt(std::max({
+                  infty_norm(H.col(k).head(k)),
+                  infty_norm(H.row(k).tail(n - k)),
+                  n_eq > 0 ? infty_norm(A.col(k)) : T(0),
+                  n_in > 0 ? infty_norm(C.col(k)) : T(0),
+                }));
+                if (aux == T(0)) {
+                  delta(k) = T(1);
+                } else {
+                  delta(k) = T(1) / (aux + machine_eps);
+                }
+                break;
+              }
+              case Symmetry::lower: { // lower triangular part
 
-            T aux = sqrt(std::max({
-              infty_norm(H.col(k).head(k)),
-              infty_norm(H.col(k).tail(n - k)),
-              n_eq > 0 ? infty_norm(A.col(k)) : T(0),
-              n_in > 0 ? infty_norm(C.col(k)) : T(0),
-            }));
-            if (aux == T(0)) {
-              delta(k) = T(1);
-            } else {
-              delta(k) = T(1) / (aux + machine_eps);
-            }
-            break;
-          }
-          case Symmetry::general: {
+                T aux = sqrt(std::max({
+                  infty_norm(H.col(k).head(k)),
+                  infty_norm(H.col(k).tail(n - k)),
+                  n_eq > 0 ? infty_norm(A.col(k)) : T(0),
+                  n_in > 0 ? infty_norm(C.col(k)) : T(0),
+                }));
+                if (aux == T(0)) {
+                  delta(k) = T(1);
+                } else {
+                  delta(k) = T(1) / (aux + machine_eps);
+                }
+                break;
+              }
+              case Symmetry::general: {
 
-            T aux = sqrt(std::max({
-              infty_norm(H.col(k)),
-              n_eq > 0 ? infty_norm(A.col(k)) : T(0),
-              n_in > 0 ? infty_norm(C.col(k)) : T(0),
-            }));
-            if (aux == T(0)) {
-              delta(k) = T(1);
-            } else {
-              delta(k) = T(1) / (aux + machine_eps);
+                T aux = sqrt(std::max({
+                  infty_norm(H.col(k)),
+                  n_eq > 0 ? infty_norm(A.col(k)) : T(0),
+                  n_in > 0 ? infty_norm(C.col(k)) : T(0),
+                }));
+                if (aux == T(0)) {
+                  delta(k) = T(1);
+                } else {
+                  delta(k) = T(1) / (aux + machine_eps);
+                }
+                break;
+              }
             }
-            break;
           }
-        }
+          break;
       }
-
       for (isize k = 0; k < n_eq; ++k) {
         T aux = sqrt(infty_norm(A.row(k)));
         if (aux == T(0)) {
@@ -160,72 +167,77 @@ ruiz_scale_qp_in_place( //
       l.array() *= delta.tail(n_in).array();
 
       // normalize H
-      switch (sym) {
-        case Symmetry::upper: {
-          // upper triangular part
-          for (isize j = 0; j < n; ++j) {
-            H.col(j).head(j + 1) *= delta(j);
-          }
-          // normalisation des lignes
-          for (isize i = 0; i < n; ++i) {
-            H.row(i).tail(n - i) *= delta(i);
-          }
+      switch (problem_type) {
+        case ProblemType::LP:
           break;
-        }
-        case Symmetry::lower: {
-          // lower triangular part
-          for (isize j = 0; j < n; ++j) {
-            H.col(j).tail(n - j) *= delta(j);
+        case ProblemType::QP:
+          switch (sym) {
+            case Symmetry::upper: {
+              // upper triangular part
+              for (isize j = 0; j < n; ++j) {
+                H.col(j).head(j + 1) *= delta(j);
+              }
+              // normalisation des lignes
+              for (isize i = 0; i < n; ++i) {
+                H.row(i).tail(n - i) *= delta(i);
+              }
+              break;
+            }
+            case Symmetry::lower: {
+              // lower triangular part
+              for (isize j = 0; j < n; ++j) {
+                H.col(j).tail(n - j) *= delta(j);
+              }
+              // normalisation des lignes
+              for (isize i = 0; i < n; ++i) {
+                H.row(i).head(i + 1) *= delta(i);
+              }
+              break;
+            }
+            case Symmetry::general: {
+              // all matrix
+              H = delta.head(n).asDiagonal() * H * delta.head(n).asDiagonal();
+              break;
+            }
+            default:
+              break;
           }
-          // normalisation des lignes
-          for (isize i = 0; i < n; ++i) {
-            H.row(i).head(i + 1) *= delta(i);
+
+          // additional normalization for the cost function
+          switch (sym) {
+            case Symmetry::upper: {
+              // upper triangular part
+              T tmp = T(0);
+              for (isize j = 0; j < n; ++j) {
+                tmp += proxqp::dense::infty_norm(H.row(j).tail(n - j));
+              }
+              gamma = 1 / std::max(tmp / T(n), T(1));
+              break;
+            }
+            case Symmetry::lower: {
+              // lower triangular part
+              T tmp = T(0);
+              for (isize j = 0; j < n; ++j) {
+                tmp += proxqp::dense::infty_norm(H.col(j).tail(n - j));
+              }
+              gamma = 1 / std::max(tmp / T(n), T(1));
+              break;
+            }
+            case Symmetry::general: {
+              // all matrix
+              gamma =
+                1 / std::max(
+                      T(1),
+                      (H.colwise().template lpNorm<Eigen::Infinity>()).mean());
+              break;
+            }
+            default:
+              break;
           }
-          break;
-        }
-        case Symmetry::general: {
-          // all matrix
-          H = delta.head(n).asDiagonal() * H * delta.head(n).asDiagonal();
-          break;
-        }
-        default:
+          H *= gamma;
           break;
       }
-
-      // additional normalization for the cost function
-      switch (sym) {
-        case Symmetry::upper: {
-          // upper triangular part
-          T tmp = T(0);
-          for (isize j = 0; j < n; ++j) {
-            tmp += proxqp::dense::infty_norm(H.row(j).tail(n - j));
-          }
-          gamma = 1 / std::max(tmp / T(n), T(1));
-          break;
-        }
-        case Symmetry::lower: {
-          // lower triangular part
-          T tmp = T(0);
-          for (isize j = 0; j < n; ++j) {
-            tmp += proxqp::dense::infty_norm(H.col(j).tail(n - j));
-          }
-          gamma = 1 / std::max(tmp / T(n), T(1));
-          break;
-        }
-        case Symmetry::general: {
-          // all matrix
-          gamma =
-            1 /
-            std::max(T(1),
-                     (H.colwise().template lpNorm<Eigen::Infinity>()).mean());
-          break;
-        }
-        default:
-          break;
-      }
-
       g *= gamma;
-      H *= gamma;
 
       S.array() *= delta.array(); // coefficientwise product
       c *= gamma;
@@ -316,6 +328,7 @@ struct RuizEquilibration
                          bool execute_preconditioner,
                          const isize max_iter,
                          const T epsilon,
+                         const ProblemType problem_type,
                          proxsuite::linalg::veg::dynstack::DynStackMut stack)
   {
     if (execute_preconditioner) {
@@ -326,6 +339,7 @@ struct RuizEquilibration
                                          epsilon,
                                          max_iter,
                                          sym,
+                                         problem_type,
                                          stack);
     } else {
 
@@ -397,6 +411,7 @@ struct RuizEquilibration
    */
   void scale_qp(const QpViewBox<T> qp,
                 QpViewBoxMut<T> scaled_qp,
+                bool execute_preconditioner,
                 VectorViewMut<T> tmp_delta_preallocated) const
   {
 
@@ -413,7 +428,11 @@ struct RuizEquilibration
     scaled_qp.b.to_eigen() = qp.b.to_eigen();
     scaled_qp.d.to_eigen() = qp.d.to_eigen();
 
-    scale_qp_in_place(scaled_qp, tmp_delta_preallocated, epsilon, max_iter);
+    scale_qp_in_place(scaled_qp,
+                      execute_preconditioner,
+                      tmp_delta_preallocated,
+                      epsilon,
+                      max_iter);
   }
   // modifies variables in place
   /*!

--- a/include/proxsuite/proxqp/settings.hpp
+++ b/include/proxsuite/proxqp/settings.hpp
@@ -28,7 +28,12 @@ enum struct MeritFunctionType
   GPDAL, // Generalized Primal Dual Augmented Lagrangian
   PDAL,  // Primal Dual Augmented Lagrangian
 };
-
+// COST FUNCTION TYPE
+enum struct ProblemType
+{
+  LP, // Linear Program
+  QP, // Quadratic Program
+};
 inline std::ostream&
 operator<<(std::ostream& os, const SparseBackend& sparse_backend)
 {
@@ -102,6 +107,7 @@ struct Settings
   bool bcl_update;
   MeritFunctionType merit_function_type;
   T alpha_gpdal;
+  ProblemType problem_type;
 
   SparseBackend sparse_backend;
   /*!
@@ -209,6 +215,7 @@ struct Settings
     bool bcl_update = true,
     MeritFunctionType merit_function_type = MeritFunctionType::GPDAL,
     T alpha_gpdal = 0.95,
+    ProblemType problem_type = ProblemType::QP,
     SparseBackend sparse_backend = SparseBackend::Automatic)
     : default_rho(default_rho)
     , default_mu_eq(default_mu_eq)
@@ -249,6 +256,7 @@ struct Settings
     , bcl_update(bcl_update)
     , merit_function_type(merit_function_type)
     , alpha_gpdal(alpha_gpdal)
+    , problem_type(problem_type)
     , sparse_backend(sparse_backend)
   {
   }
@@ -299,6 +307,7 @@ operator==(const Settings<T>& settings1, const Settings<T>& settings2)
     settings1.bcl_update == settings2.bcl_update &&
     settings1.merit_function_type == settings2.merit_function_type &&
     settings1.alpha_gpdal == settings2.alpha_gpdal &&
+    settings1.problem_type == settings2.problem_type &&
     settings1.sparse_backend == settings2.sparse_backend;
   return value;
 }

--- a/test/src/dense_qp_eq.cpp
+++ b/test/src/dense_qp_eq.cpp
@@ -159,7 +159,7 @@ DOCTEST_TEST_CASE("linear problem with equality  with equality constraints and "
 }
 
 DOCTEST_TEST_CASE("linear problem with equality  with equality constraints and "
-                  "linar cost and increasing dimension using wrapper API using "
+                  "linear cost and increasing dimension using wrapper API and  "
                   "the dedicated LP interface")
 {
 

--- a/test/src/dense_qp_eq.cpp
+++ b/test/src/dense_qp_eq.cpp
@@ -158,7 +158,7 @@ DOCTEST_TEST_CASE("linear problem with equality  with equality constraints and "
   }
 }
 
-DOCTEST_TEST_CASE("linear problem with equality  with equality constraints and "
+DOCTEST_TEST_CASE("linear problem with equality with equality constraints and "
                   "linear cost and increasing dimension using wrapper API and  "
                   "the dedicated LP interface")
 {

--- a/test/src/dense_qp_eq.cpp
+++ b/test/src/dense_qp_eq.cpp
@@ -157,3 +157,61 @@ DOCTEST_TEST_CASE("linear problem with equality  with equality constraints and "
               << std::endl;
   }
 }
+
+DOCTEST_TEST_CASE("linear problem with equality  with equality constraints and "
+                  "linar cost and increasing dimension using wrapper API using "
+                  "the dedicated LP interface")
+{
+
+  std::cout
+    << "---testing LP interface for solving linear problem with "
+       "equality constraints and increasing dimension using wrapper API---"
+    << std::endl;
+  T sparsity_factor = 0.15;
+  T eps_abs = T(1e-9);
+  proxqp::utils::rand::set_seed(1);
+  for (proxqp::isize dim = 10; dim < 1000; dim += 100) {
+
+    proxqp::isize n_eq(dim / 2);
+    proxqp::isize n_in(0);
+    T strong_convexity_factor(1.e-2);
+    proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
+      dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
+    qp_random.H.setZero();
+    auto y_sol = proxqp::utils::rand::vector_rand<T>(
+      n_eq); // make sure the LP is bounded within the feasible set
+    qp_random.g = -qp_random.A.transpose() * y_sol;
+
+    proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.eps_rel = 0;
+    qp.settings.problem_type = proxqp::ProblemType::LP;
+    qp.init(qp_random.H,
+            qp_random.g,
+            qp_random.A,
+            qp_random.b,
+            qp_random.C,
+            qp_random.l,
+            qp_random.u);
+    qp.solve();
+
+    T pri_res = std::max(
+      (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
+      (helpers::positive_part(qp_random.C * qp.results.x - qp_random.u) +
+       helpers::negative_part(qp_random.C * qp.results.x - qp_random.l))
+        .lpNorm<Eigen::Infinity>());
+    T dua_res = (qp_random.H * qp.results.x + qp_random.g +
+                 qp_random.A.transpose() * qp.results.y +
+                 qp_random.C.transpose() * qp.results.z)
+                  .lpNorm<Eigen::Infinity>();
+    DOCTEST_CHECK(pri_res <= eps_abs);
+    DOCTEST_CHECK(dua_res <= eps_abs);
+
+    std::cout << "------using wrapper API solving qp with dim: " << dim
+              << " neq: " << n_eq << " nin: " << n_in << std::endl;
+    std::cout << "primal residual: " << pri_res << std::endl;
+    std::cout << "dual residual: " << dua_res << std::endl;
+    std::cout << "total number of iteration: " << qp.results.info.iter
+              << std::endl;
+  }
+}

--- a/test/src/sparse_ruiz_equilibration.cpp
+++ b/test/src/sparse_ruiz_equilibration.cpp
@@ -85,6 +85,7 @@ TEST_CASE("upper part")
     execute_preconditioner,
     settings.preconditioner_max_iter,
     settings.preconditioner_accuracy,
+    settings.problem_type,
     stack);
 
   CHECK(H_scaled.toDense().isApprox(H_scaled_dense));
@@ -166,6 +167,7 @@ TEST_CASE("lower part")
     execute_preconditioner,
     settings.preconditioner_max_iter,
     settings.preconditioner_accuracy,
+    settings.problem_type,
     stack);
 
   CHECK(H_scaled.toDense().isApprox(H_scaled_dense));


### PR DESCRIPTION
Add a setting option for solving more efficiently Linear Programs with ProxQP, as suggested by #173 (i.e., all linear algebra operations involving the Hessian cost are avoided).

This PR adds this feature for ProxQP dense backend. It will be added later for ProxQP sparse backend as well. 

