### PR TITLE
ci check all jobs pass

### DIFF
--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -189,3 +189,17 @@ jobs:
       shell: bash -l {0}
       run: |
         echo $(ccache -s)
+
+  check:
+    if: always()
+    name: check-ci-linux-osx-win-conda
+
+    needs:
+    - build-with-conda
+
+    runs-on: Ubuntu-latest
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci-linux-ros.yml
+++ b/.github/workflows/ci-linux-ros.yml
@@ -32,3 +32,18 @@ jobs:
       # Run industrial_ci
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{ matrix.env }}
+
+
+  check:
+    if: always()
+    name: check-ci-linux-ros
+
+    needs:
+    - CI
+
+    runs-on: Ubuntu-latest
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci-osx-arm64-conda.yml
+++ b/.github/workflows/ci-osx-arm64-conda.yml
@@ -72,3 +72,17 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/build
         cmake --build . --config ${{ matrix.build_type }} --target uninstall
+
+  check:
+    if: always()
+    name: check-ci-osx-arm64-conda
+
+    needs:
+    - build-with-conda
+
+    runs-on: Ubuntu-latest
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -81,3 +81,17 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
+
+  check:
+    if: always()
+    name: check-release-linux
+
+    needs:
+    - build-wheel
+
+    runs-on: Ubuntu-latest
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/release-osx-win.yml
+++ b/.github/workflows/release-osx-win.yml
@@ -120,3 +120,17 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
+
+  check:
+    if: always()
+    name: release-osx-win
+
+    needs:
+    - build-wheel
+
+    runs-on: Ubuntu-latest
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This PR adds an additional job to every one of our pipelines that is called "check-_name-of-yml-file_". This job is dependent on all jobs created by the matrix (os, std, compile-mode), and only passes if all of them pass. 

This is very useful for auto-merge, as we can add only the 5 "check-_name-of-yml-file_" jobs to the branch protection rules. And it will still work, even though we change the name of the jobs (by adding more stuff to the matrix for example).