### PR TITLE
Improve dense backend and simplify calculus when using a Diagonal Hessian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ elseif(UNIX)
     set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/find-external/OpenMP
                           ${CMAKE_MODULE_PATH})
   endif()
-endif(APPLE)
+endif(APPLE OR WIN32)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake-module/julia.cmake)
 include(CMakeDependentOption)
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We are ready to integrate **ProxSuite** within other optimization ecosystems.
 
    - dense, sparse and matrix-free matrix factorization backends,
    - advanced warm-starting options (e.g., equality-constrained initial guess, warm-start or cold-start options from previous results),
-   - dedicated features for handling more efficiently box constraints, or linear programs.
+   - dedicated features for handling more efficiently box constraints, linear programs, QP with diagonal Hessian, or with far more constraints than primal variables.
 
 **Proxsuite** is flexible:
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -17,6 +17,8 @@ endmacro(proxsuite_benchmark)
 
 proxsuite_benchmark(timings-lp)
 proxsuite_benchmark(timings-box-constraints)
+proxsuite_benchmark(timings-dense-backend)
+proxsuite_benchmark(timings-diagonal-hessian)
 
 if(BUILD_WITH_OPENMP_SUPPORT)
   proxsuite_benchmark(timings-parallel)

--- a/benchmark/timings-dense-backend.cpp
+++ b/benchmark/timings-dense-backend.cpp
@@ -1,0 +1,167 @@
+//
+// Copyright (c) 2023 INRIA
+//
+#include <iostream>
+#include <proxsuite/proxqp/dense/dense.hpp>
+#include <proxsuite/proxqp/utils/random_qp_problems.hpp>
+
+using T = double;
+using I = long long;
+
+using namespace proxsuite;
+using namespace proxsuite::proxqp;
+
+int
+main(int /*argc*/, const char** /*argv*/)
+{
+  Timer<T> timer;
+  int smooth = 10;
+
+  T sparsity_factor = 0.75;
+  T eps_abs = T(1e-9);
+  T elapsed_time = 0.0;
+  proxqp::utils::rand::set_seed(1);
+  std::cout << "Dense QP" << std::endl;
+  for (proxqp::isize dim = 100; dim <= 1000; dim = dim + 100) {
+
+    proxqp::isize n_eq(dim * 2);
+    proxqp::isize n_in(dim * 2);
+    std::cout << "dim: " << dim << " n_eq: " << n_eq << " n_in: " << n_in
+              << " box: " << dim << std::endl;
+    T strong_convexity_factor(1.e-2);
+
+    proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
+      dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
+    Eigen::Matrix<T, Eigen::Dynamic, 1> x_sol =
+      utils::rand::vector_rand<T>(dim);
+    Eigen::Matrix<T, Eigen::Dynamic, 1> delta(n_in);
+    for (proxqp::isize i = 0; i < n_in; ++i) {
+      delta(i) = utils::rand::uniform_rand();
+    }
+    qp_random.u = qp_random.C * x_sol + delta;
+    qp_random.b = qp_random.A * x_sol;
+    Eigen::Matrix<T, Eigen::Dynamic, 1> u_box(dim);
+    u_box.setZero();
+    Eigen::Matrix<T, Eigen::Dynamic, 1> l_box(dim);
+    l_box.setZero();
+    for (proxqp::isize i = 0; i < dim; ++i) {
+      T shift = utils::rand::uniform_rand();
+      u_box(i) = x_sol(i) + shift;
+      l_box(i) = x_sol(i) - shift;
+    }
+    // using Mat =
+    //   Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>;
+    // Mat C_enlarged(dim + n_in, dim);
+    // C_enlarged.setZero();
+    // C_enlarged.topLeftCorner(n_in, dim) = qp_random.C;
+    // C_enlarged.bottomLeftCorner(dim, dim).diagonal().array() += 1.;
+    // Eigen::Matrix<T, Eigen::Dynamic, 1> u_enlarged(n_in + dim);
+    // Eigen::Matrix<T, Eigen::Dynamic, 1> l_enlarged(n_in + dim);
+    // u_enlarged.head(n_in) = qp_random.u;
+    // u_enlarged.tail(dim) = u_box;
+    // l_enlarged.head(n_in) = qp_random.l;
+    // l_enlarged.tail(dim) = l_box;
+
+    elapsed_time = 0.0;
+    timer.stop();
+    proxqp::dense::QP<T> qp{ dim, n_eq, n_in, true, DenseBackend::PrimalLdl };
+    qp.settings.eps_abs = eps_abs;
+    qp.settings.eps_rel = 0;
+    // qp.settings.verbose = true;
+    qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+    for (int j = 0; j < smooth; j++) {
+      timer.start();
+      qp.init(qp_random.H,
+              qp_random.g,
+              qp_random.A,
+              qp_random.b,
+              qp_random.C,
+              qp_random.l,
+              qp_random.u,
+              l_box,
+              u_box);
+      qp.solve();
+      timer.stop();
+      elapsed_time += timer.elapsed().user;
+      if (qp.results.info.pri_res > eps_abs ||
+          qp.results.info.dua_res > eps_abs) {
+        std::cout << "dual residual " << qp.results.info.dua_res
+                  << "; primal residual " << qp.results.info.pri_res
+                  << std::endl;
+        std::cout << "total number of iteration: " << qp.results.info.iter
+                  << std::endl;
+      }
+    }
+    std::cout << "timings QP PrimalLdl backend : \t"
+              << elapsed_time * 1e-3 / smooth << "ms" << std::endl;
+
+    elapsed_time = 0.0;
+    proxqp::dense::QP<T> qp_compare{
+      dim, n_eq, n_in, true, DenseBackend::PrimalDualLdl
+    };
+    qp_compare.settings.eps_abs = eps_abs;
+    qp_compare.settings.eps_rel = 0;
+    qp_compare.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+    // qp_compare.settings.verbose = true;
+    for (int j = 0; j < smooth; j++) {
+      timer.start();
+      qp_compare.init(qp_random.H,
+                      qp_random.g,
+                      qp_random.A,
+                      qp_random.b,
+                      qp_random.C,
+                      qp_random.l,
+                      qp_random.u,
+                      l_box,
+                      u_box);
+      qp_compare.solve();
+      timer.stop();
+      elapsed_time += timer.elapsed().user;
+
+      if (qp_compare.results.info.pri_res > eps_abs ||
+          qp_compare.results.info.dua_res > eps_abs) {
+        std::cout << "dual residual " << qp_compare.results.info.dua_res
+                  << "; primal residual " << qp_compare.results.info.pri_res
+                  << std::endl;
+        std::cout << "total number of iteration: "
+                  << qp_compare.results.info.iter << std::endl;
+      }
+    }
+    std::cout << "timings QP PrimalDualLdl             : \t"
+              << elapsed_time * 1e-3 / smooth << "ms" << std::endl;
+    elapsed_time = 0.0;
+    proxqp::dense::QP<T> qp_compare_bis{
+      dim, n_eq, n_in, true, DenseBackend::Automatic
+    };
+    qp_compare_bis.settings.eps_abs = eps_abs;
+    qp_compare_bis.settings.eps_rel = 0;
+    qp_compare_bis.settings.initial_guess =
+      InitialGuessStatus::NO_INITIAL_GUESS;
+    for (int j = 0; j < smooth; j++) {
+      timer.start();
+      qp_compare_bis.init(qp_random.H,
+                          qp_random.g,
+                          qp_random.A,
+                          qp_random.b,
+                          qp_random.C,
+                          qp_random.l,
+                          qp_random.u,
+                          l_box,
+                          u_box);
+      qp_compare_bis.solve();
+      timer.stop();
+      elapsed_time += timer.elapsed().user;
+
+      if (qp_compare_bis.results.info.pri_res > eps_abs ||
+          qp_compare_bis.results.info.dua_res > eps_abs) {
+        std::cout << "dual residual " << qp_compare_bis.results.info.dua_res
+                  << "; primal residual " << qp_compare_bis.results.info.pri_res
+                  << std::endl;
+        std::cout << "total number of iteration: "
+                  << qp_compare_bis.results.info.iter << std::endl;
+      }
+    }
+    std::cout << "timings QP Automatic             : \t"
+              << elapsed_time * 1e-3 / smooth << "ms" << std::endl;
+  }
+}

--- a/benchmark/timings-dense-backend.cpp
+++ b/benchmark/timings-dense-backend.cpp
@@ -15,7 +15,7 @@ int
 main(int /*argc*/, const char** /*argv*/)
 {
   Timer<T> timer;
-  int smooth = 10;
+  int smooth = 100;
 
   T sparsity_factor = 0.75;
   T eps_abs = T(1e-9);
@@ -127,8 +127,8 @@ main(int /*argc*/, const char** /*argv*/)
                   << qp_compare.results.info.iter << std::endl;
       }
     }
-    std::cout << "timings QP PrimalDualLdl             : \t"
-              << elapsed_time * 1e-3 / smooth << "ms" << std::endl;
+    std::cout << "timings QP PrimalDualLdl : \t" << elapsed_time * 1e-3 / smooth
+              << "ms" << std::endl;
     elapsed_time = 0.0;
     proxqp::dense::QP<T> qp_compare_bis{
       dim, n_eq, n_in, true, DenseBackend::Automatic
@@ -161,7 +161,7 @@ main(int /*argc*/, const char** /*argv*/)
                   << qp_compare_bis.results.info.iter << std::endl;
       }
     }
-    std::cout << "timings QP Automatic             : \t"
-              << elapsed_time * 1e-3 / smooth << "ms" << std::endl;
+    std::cout << "timings QP Automatic : \t" << elapsed_time * 1e-3 / smooth
+              << "ms" << std::endl;
   }
 }

--- a/benchmark/timings-dense-backend.cpp
+++ b/benchmark/timings-dense-backend.cpp
@@ -64,7 +64,7 @@ main(int /*argc*/, const char** /*argv*/)
 
     elapsed_time = 0.0;
     timer.stop();
-    proxqp::dense::QP<T> qp{ dim, n_eq, n_in, true, DenseBackend::PrimalLdl };
+    proxqp::dense::QP<T> qp{ dim, n_eq, n_in, true, DenseBackend::PrimalLDLT };
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;
     // qp.settings.verbose = true;
@@ -92,12 +92,12 @@ main(int /*argc*/, const char** /*argv*/)
                   << std::endl;
       }
     }
-    std::cout << "timings QP PrimalLdl backend : \t"
+    std::cout << "timings QP PrimalLDLT backend : \t"
               << elapsed_time * 1e-3 / smooth << "ms" << std::endl;
 
     elapsed_time = 0.0;
     proxqp::dense::QP<T> qp_compare{
-      dim, n_eq, n_in, true, DenseBackend::PrimalDualLdl
+      dim, n_eq, n_in, true, DenseBackend::PrimalDualLDLT
     };
     qp_compare.settings.eps_abs = eps_abs;
     qp_compare.settings.eps_rel = 0;
@@ -127,8 +127,8 @@ main(int /*argc*/, const char** /*argv*/)
                   << qp_compare.results.info.iter << std::endl;
       }
     }
-    std::cout << "timings QP PrimalDualLdl : \t" << elapsed_time * 1e-3 / smooth
-              << "ms" << std::endl;
+    std::cout << "timings QP PrimalDualLDLT : \t"
+              << elapsed_time * 1e-3 / smooth << "ms" << std::endl;
     elapsed_time = 0.0;
     proxqp::dense::QP<T> qp_compare_bis{
       dim, n_eq, n_in, true, DenseBackend::Automatic

--- a/benchmark/timings-diagonal-hessian.cpp
+++ b/benchmark/timings-diagonal-hessian.cpp
@@ -22,10 +22,10 @@ main(int /*argc*/, const char** /*argv*/)
   T elapsed_time = 0.0;
   proxqp::utils::rand::set_seed(1);
   std::cout << "Dense QP" << std::endl;
-  for (proxqp::isize dim = 100; dim <= 300; dim = dim + 100) {
+  for (proxqp::isize dim = 100; dim <= 500; dim = dim + 100) {
 
-    proxqp::isize n_eq(dim * 2);
-    proxqp::isize n_in(dim * 2);
+    proxqp::isize n_eq(dim / 2);
+    proxqp::isize n_in(dim / 2);
     std::cout << "dim: " << dim << " n_eq: " << n_eq << " n_in: " << n_in
               << " box: " << dim << std::endl;
     T strong_convexity_factor(1.e-2);

--- a/benchmark/timings-diagonal-hessian.cpp
+++ b/benchmark/timings-diagonal-hessian.cpp
@@ -15,41 +15,69 @@ int
 main(int /*argc*/, const char** /*argv*/)
 {
   Timer<T> timer;
-  int smooth = 0;
+  int smooth = 1000;
 
   T sparsity_factor = 0.75;
   T eps_abs = T(1e-9);
   T elapsed_time = 0.0;
   proxqp::utils::rand::set_seed(1);
   std::cout << "Dense QP" << std::endl;
-  for (proxqp::isize dim = 10; dim <= 1000;
-       dim = (dim == 10) ? 100 : dim + 100) {
+  for (proxqp::isize dim = 100; dim <= 300; dim = dim + 100) {
 
-    if (dim == 10 || dim == 100) {
-      smooth = 1000;
-    } else {
-      smooth = 100;
-    }
-
-    proxqp::isize n_eq(dim / 2);
-    proxqp::isize n_in(dim / 2);
-    T strong_convexity_factor(1.e-2);
+    proxqp::isize n_eq(dim * 2);
+    proxqp::isize n_in(dim * 2);
     std::cout << "dim: " << dim << " n_eq: " << n_eq << " n_in: " << n_in
-              << std::endl;
+              << " box: " << dim << std::endl;
+    T strong_convexity_factor(1.e-2);
 
     proxqp::dense::Model<T> qp_random = proxqp::utils::dense_strongly_convex_qp(
       dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
+    Eigen::Matrix<T, Eigen::Dynamic, 1> x_sol =
+      utils::rand::vector_rand<T>(dim);
+    Eigen::Matrix<T, Eigen::Dynamic, 1> delta(n_in);
+    for (proxqp::isize i = 0; i < n_in; ++i) {
+      delta(i) = utils::rand::uniform_rand();
+    }
+    qp_random.u = qp_random.C * x_sol + delta;
+    qp_random.b = qp_random.A * x_sol;
+    Eigen::Matrix<T, Eigen::Dynamic, 1> u_box(dim);
+    u_box.setZero();
+    Eigen::Matrix<T, Eigen::Dynamic, 1> l_box(dim);
+    l_box.setZero();
+    for (proxqp::isize i = 0; i < dim; ++i) {
+      T shift = utils::rand::uniform_rand();
+      u_box(i) = x_sol(i) + shift;
+      l_box(i) = x_sol(i) - shift;
+    }
     qp_random.H.setZero();
-    auto y_sol = proxqp::utils::rand::vector_rand<T>(n_eq);
-    qp_random.g = -qp_random.A.transpose() * y_sol;
+    qp_random.H.diagonal().setOnes();
+    for (isize i = 0; i < dim; ++i) {
+      qp_random.H(i, i) = T(i);
+    }
+    // using Mat =
+    //   Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>;
+    // Mat C_enlarged(dim + n_in, dim);
+    // C_enlarged.setZero();
+    // C_enlarged.topLeftCorner(n_in, dim) = qp_random.C;
+    // C_enlarged.bottomLeftCorner(dim, dim).diagonal().array() += 1.;
+    // Eigen::Matrix<T, Eigen::Dynamic, 1> u_enlarged(n_in + dim);
+    // Eigen::Matrix<T, Eigen::Dynamic, 1> l_enlarged(n_in + dim);
+    // u_enlarged.head(n_in) = qp_random.u;
+    // u_enlarged.tail(dim) = u_box;
+    // l_enlarged.head(n_in) = qp_random.l;
+    // l_enlarged.tail(dim) = l_box;
 
     elapsed_time = 0.0;
     timer.stop();
-    proxqp::dense::QP<T> qp{
-      dim, n_eq, n_in, false, proxqp::ProblemType::LinearProgram
-    };
+    proxqp::dense::QP<T> qp{ dim,
+                             n_eq,
+                             n_in,
+                             true,
+                             proxsuite::proxqp::DenseBackend::PrimalDualLdl,
+                             proxsuite::proxqp::ProblemType::DiagonalHessian };
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;
+    // qp.settings.verbose = true;
     qp.settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
     for (int j = 0; j < smooth; j++) {
       timer.start();
@@ -59,7 +87,9 @@ main(int /*argc*/, const char** /*argv*/)
               qp_random.b,
               qp_random.C,
               qp_random.l,
-              qp_random.u);
+              qp_random.u,
+              l_box,
+              u_box);
       qp.solve();
       timer.stop();
       elapsed_time += timer.elapsed().user;
@@ -72,12 +102,17 @@ main(int /*argc*/, const char** /*argv*/)
                   << std::endl;
       }
     }
-    std::cout << "timings LP with primal dual backend: \t"
+    std::cout << "timings QP with diagonal hessian feature : \t"
               << elapsed_time * 1e-3 / smooth << "ms" << std::endl;
 
     elapsed_time = 0.0;
     proxqp::dense::QP<T> qp_compare{
-      dim, n_eq, n_in, false, proxqp::ProblemType::QuadraticProgram
+      dim,
+      n_eq,
+      n_in,
+      true,
+      proxsuite::proxqp::DenseBackend::PrimalDualLdl,
+      proxsuite::proxqp::ProblemType::QuadraticProgram
     };
     qp_compare.settings.eps_abs = eps_abs;
     qp_compare.settings.eps_rel = 0;
@@ -90,7 +125,9 @@ main(int /*argc*/, const char** /*argv*/)
                       qp_random.b,
                       qp_random.C,
                       qp_random.l,
-                      qp_random.u);
+                      qp_random.u,
+                      l_box,
+                      u_box);
       qp_compare.solve();
       timer.stop();
       elapsed_time += timer.elapsed().user;
@@ -104,7 +141,7 @@ main(int /*argc*/, const char** /*argv*/)
                   << qp_compare.results.info.iter << std::endl;
       }
     }
-    std::cout << "timings QP with primal dual backend: \t"
+    std::cout << "timings QP without diagonal hessian feature : \t"
               << elapsed_time * 1e-3 / smooth << "ms" << std::endl;
   }
 }

--- a/benchmark/timings-diagonal-hessian.cpp
+++ b/benchmark/timings-diagonal-hessian.cpp
@@ -74,7 +74,7 @@ main(int /*argc*/, const char** /*argv*/)
                              n_in,
                              true,
                              proxsuite::proxqp::DenseBackend::PrimalDualLDLT,
-                             proxsuite::proxqp::HESSIAN_TYPE::DIAGONAL };
+                             proxsuite::proxqp::HessianType::Diagonal };
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;
     // qp.settings.verbose = true;
@@ -112,7 +112,7 @@ main(int /*argc*/, const char** /*argv*/)
       n_in,
       true,
       proxsuite::proxqp::DenseBackend::PrimalDualLDLT,
-      proxsuite::proxqp::HESSIAN_TYPE::DENSE
+      proxsuite::proxqp::HessianType::Dense
     };
     qp_compare.settings.eps_abs = eps_abs;
     qp_compare.settings.eps_rel = 0;

--- a/benchmark/timings-diagonal-hessian.cpp
+++ b/benchmark/timings-diagonal-hessian.cpp
@@ -73,8 +73,8 @@ main(int /*argc*/, const char** /*argv*/)
                              n_eq,
                              n_in,
                              true,
-                             proxsuite::proxqp::DenseBackend::PrimalDualLdl,
-                             proxsuite::proxqp::ProblemType::DiagonalHessian };
+                             proxsuite::proxqp::DenseBackend::PrimalDualLDLT,
+                             proxsuite::proxqp::HESSIAN_TYPE::DIAGONAL };
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;
     // qp.settings.verbose = true;
@@ -111,8 +111,8 @@ main(int /*argc*/, const char** /*argv*/)
       n_eq,
       n_in,
       true,
-      proxsuite::proxqp::DenseBackend::PrimalDualLdl,
-      proxsuite::proxqp::ProblemType::QuadraticProgram
+      proxsuite::proxqp::DenseBackend::PrimalDualLDLT,
+      proxsuite::proxqp::HESSIAN_TYPE::DENSE
     };
     qp_compare.settings.eps_abs = eps_abs;
     qp_compare.settings.eps_rel = 0;

--- a/benchmark/timings-lp.cpp
+++ b/benchmark/timings-lp.cpp
@@ -46,7 +46,7 @@ main(int /*argc*/, const char** /*argv*/)
     elapsed_time = 0.0;
     timer.stop();
     proxqp::dense::QP<T> qp{
-      dim, n_eq, n_in, false, proxqp::HESSIAN_TYPE::ZERO
+      dim, n_eq, n_in, false, proxqp::HessianType::Zero
     };
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;
@@ -77,7 +77,7 @@ main(int /*argc*/, const char** /*argv*/)
 
     elapsed_time = 0.0;
     proxqp::dense::QP<T> qp_compare{
-      dim, n_eq, n_in, false, proxqp::HESSIAN_TYPE::DENSE
+      dim, n_eq, n_in, false, proxqp::HessianType::Dense
     };
     qp_compare.settings.eps_abs = eps_abs;
     qp_compare.settings.eps_rel = 0;

--- a/benchmark/timings-lp.cpp
+++ b/benchmark/timings-lp.cpp
@@ -46,7 +46,7 @@ main(int /*argc*/, const char** /*argv*/)
     elapsed_time = 0.0;
     timer.stop();
     proxqp::dense::QP<T> qp{
-      dim, n_eq, n_in, false, proxqp::ProblemType::LinearProgram
+      dim, n_eq, n_in, false, proxqp::HESSIAN_TYPE::ZERO
     };
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;
@@ -77,7 +77,7 @@ main(int /*argc*/, const char** /*argv*/)
 
     elapsed_time = 0.0;
     proxqp::dense::QP<T> qp_compare{
-      dim, n_eq, n_in, false, proxqp::ProblemType::QuadraticProgram
+      dim, n_eq, n_in, false, proxqp::HESSIAN_TYPE::DENSE
     };
     qp_compare.settings.eps_abs = eps_abs;
     qp_compare.settings.eps_rel = 0;

--- a/bindings/python/src/expose-qpobject.hpp
+++ b/bindings/python/src/expose-qpobject.hpp
@@ -30,7 +30,7 @@ exposeQpObjectDense(pybind11::module_ m)
     .value("PrimalLDLT", DenseBackend::PrimalLDLT)
     .export_values();
 
-  ::pybind11::enum_<HESSIAN_TYPE>(m, "problem_type", pybind11::module_local())
+  ::pybind11::enum_<HESSIAN_TYPE>(m, "hessian_type", pybind11::module_local())
     .value("DENSE", proxsuite::proxqp::HESSIAN_TYPE::DENSE)
     .value("ZERO", proxsuite::proxqp::HESSIAN_TYPE::ZERO)
     .value("DIAGONAL", proxsuite::proxqp::HESSIAN_TYPE::DIAGONAL)
@@ -51,7 +51,7 @@ exposeQpObjectDense(pybind11::module_ m)
         "box_constraints",
         false,
         "specify or not that the QP has box inequality constraints."),
-      pybind11::arg_v("problem_type",
+      pybind11::arg_v("hessian_type",
                       proxsuite::proxqp::HESSIAN_TYPE::DENSE,
                       "specify  the problem type to be solved."),
       pybind11::arg_v("dense_backend",
@@ -71,8 +71,8 @@ exposeQpObjectDense(pybind11::module_ m)
     .def("is_box_constrained",
          &dense::QP<T>::is_box_constrained,
          "precise whether or not the QP is designed with box constraints.")
-    .def("which_problem_type",
-         &dense::QP<T>::which_problem_type,
+    .def("which_hessian_type",
+         &dense::QP<T>::which_hessian_type,
          "precise which problem type is to be solved.")
     .def("which_dense_backend",
          &dense::QP<T>::which_dense_backend,

--- a/bindings/python/src/expose-qpobject.hpp
+++ b/bindings/python/src/expose-qpobject.hpp
@@ -30,10 +30,10 @@ exposeQpObjectDense(pybind11::module_ m)
     .value("PrimalLDLT", DenseBackend::PrimalLDLT)
     .export_values();
 
-  ::pybind11::enum_<HESSIAN_TYPE>(m, "hessian_type", pybind11::module_local())
-    .value("DENSE", proxsuite::proxqp::HESSIAN_TYPE::DENSE)
-    .value("ZERO", proxsuite::proxqp::HESSIAN_TYPE::ZERO)
-    .value("DIAGONAL", proxsuite::proxqp::HESSIAN_TYPE::DIAGONAL)
+  ::pybind11::enum_<HessianType>(m, "HessianType", pybind11::module_local())
+    .value("Dense", proxsuite::proxqp::HessianType::Dense)
+    .value("Zero", proxsuite::proxqp::HessianType::Zero)
+    .value("Diagonal", proxsuite::proxqp::HessianType::Diagonal)
     .export_values();
 
   ::pybind11::class_<dense::QP<T>>(m, "QP")
@@ -42,7 +42,7 @@ exposeQpObjectDense(pybind11::module_ m)
                        i64,
                        i64,
                        bool,
-                       proxsuite::proxqp::HESSIAN_TYPE,
+                       proxsuite::proxqp::HessianType,
                        proxsuite::proxqp::DenseBackend>(),
       pybind11::arg_v("n", 0, "primal dimension."),
       pybind11::arg_v("n_eq", 0, "number of equality constraints."),
@@ -52,8 +52,8 @@ exposeQpObjectDense(pybind11::module_ m)
         false,
         "specify or not that the QP has box inequality constraints."),
       pybind11::arg_v("hessian_type",
-                      proxsuite::proxqp::HESSIAN_TYPE::DENSE,
-                      "specify  the problem type to be solved."),
+                      proxsuite::proxqp::HessianType::Dense,
+                      "specify the problem type to be solved."),
       pybind11::arg_v("dense_backend",
                       proxsuite::proxqp::DenseBackend::Automatic,
                       "specify which backend using for solving the problem."),

--- a/bindings/python/src/expose-qpobject.hpp
+++ b/bindings/python/src/expose-qpobject.hpp
@@ -38,7 +38,12 @@ exposeQpObjectDense(pybind11::module_ m)
 
   ::pybind11::class_<dense::QP<T>>(m, "QP")
     .def(
-      ::pybind11::init<i64, i64, i64, bool, proxsuite::proxqp::ProblemType>(),
+      ::pybind11::init<i64,
+                       i64,
+                       i64,
+                       bool,
+                       proxsuite::proxqp::ProblemType,
+                       proxsuite::proxqp::DenseBackend>(),
       pybind11::arg_v("n", 0, "primal dimension."),
       pybind11::arg_v("n_eq", 0, "number of equality constraints."),
       pybind11::arg_v("n_in", 0, "number of inequality constraints."),
@@ -49,6 +54,9 @@ exposeQpObjectDense(pybind11::module_ m)
       pybind11::arg_v("problem_type",
                       proxsuite::proxqp::ProblemType::QuadraticProgram,
                       "specify  the problem type to be solved."),
+      pybind11::arg_v("dense_backend",
+                      proxsuite::proxqp::DenseBackend::Automatic,
+                      "specify which backend using for solving the problem."),
       "Default constructor using QP model dimensions.") // constructor
     .def_readwrite(
       "results",

--- a/bindings/python/src/expose-qpobject.hpp
+++ b/bindings/python/src/expose-qpobject.hpp
@@ -26,14 +26,14 @@ exposeQpObjectDense(pybind11::module_ m)
 {
   ::pybind11::enum_<DenseBackend>(m, "DenseBackend", pybind11::module_local())
     .value("Automatic", DenseBackend::Automatic)
-    .value("PrimalDualLdl", DenseBackend::PrimalDualLdl)
-    .value("PrimalLdl", DenseBackend::PrimalLdl)
+    .value("PrimalDualLDLT", DenseBackend::PrimalDualLDLT)
+    .value("PrimalLDLT", DenseBackend::PrimalLDLT)
     .export_values();
 
-  ::pybind11::enum_<ProblemType>(m, "problem_type", pybind11::module_local())
-    .value("QuadraticProgram", proxsuite::proxqp::ProblemType::QuadraticProgram)
-    .value("LinearProgram", proxsuite::proxqp::ProblemType::LinearProgram)
-    .value("DiagonalHessian", proxsuite::proxqp::ProblemType::DiagonalHessian)
+  ::pybind11::enum_<HESSIAN_TYPE>(m, "problem_type", pybind11::module_local())
+    .value("DENSE", proxsuite::proxqp::HESSIAN_TYPE::DENSE)
+    .value("ZERO", proxsuite::proxqp::HESSIAN_TYPE::ZERO)
+    .value("DIAGONAL", proxsuite::proxqp::HESSIAN_TYPE::DIAGONAL)
     .export_values();
 
   ::pybind11::class_<dense::QP<T>>(m, "QP")
@@ -42,7 +42,7 @@ exposeQpObjectDense(pybind11::module_ m)
                        i64,
                        i64,
                        bool,
-                       proxsuite::proxqp::ProblemType,
+                       proxsuite::proxqp::HESSIAN_TYPE,
                        proxsuite::proxqp::DenseBackend>(),
       pybind11::arg_v("n", 0, "primal dimension."),
       pybind11::arg_v("n_eq", 0, "number of equality constraints."),
@@ -52,7 +52,7 @@ exposeQpObjectDense(pybind11::module_ m)
         false,
         "specify or not that the QP has box inequality constraints."),
       pybind11::arg_v("problem_type",
-                      proxsuite::proxqp::ProblemType::QuadraticProgram,
+                      proxsuite::proxqp::HESSIAN_TYPE::DENSE,
                       "specify  the problem type to be solved."),
       pybind11::arg_v("dense_backend",
                       proxsuite::proxqp::DenseBackend::Automatic,

--- a/bindings/python/src/expose-qpobject.hpp
+++ b/bindings/python/src/expose-qpobject.hpp
@@ -24,16 +24,31 @@ template<typename T>
 void
 exposeQpObjectDense(pybind11::module_ m)
 {
+  ::pybind11::enum_<DenseBackend>(m, "DenseBackend", pybind11::module_local())
+    .value("Automatic", DenseBackend::Automatic)
+    .value("PrimalDualLdl", DenseBackend::PrimalDualLdl)
+    .value("PrimalLdl", DenseBackend::PrimalLdl)
+    .export_values();
+
+  ::pybind11::enum_<ProblemType>(m, "problem_type", pybind11::module_local())
+    .value("QuadraticProgram", proxsuite::proxqp::ProblemType::QuadraticProgram)
+    .value("LinearProgram", proxsuite::proxqp::ProblemType::LinearProgram)
+    .value("DiagonalHessian", proxsuite::proxqp::ProblemType::DiagonalHessian)
+    .export_values();
 
   ::pybind11::class_<dense::QP<T>>(m, "QP")
     .def(
-      ::pybind11::init<i64, i64, i64, bool>(),
+      ::pybind11::init<i64, i64, i64, bool, proxsuite::proxqp::ProblemType>(),
       pybind11::arg_v("n", 0, "primal dimension."),
       pybind11::arg_v("n_eq", 0, "number of equality constraints."),
       pybind11::arg_v("n_in", 0, "number of inequality constraints."),
-      pybind11::arg_v("box_constraints",
-                      false,
-                      "specify or not a QP with box inequality constraints."),
+      pybind11::arg_v(
+        "box_constraints",
+        false,
+        "specify or not that the QP has box inequality constraints."),
+      pybind11::arg_v("problem_type",
+                      proxsuite::proxqp::ProblemType::QuadraticProgram,
+                      "specify  the problem type to be solved."),
       "Default constructor using QP model dimensions.") // constructor
     .def_readwrite(
       "results",
@@ -48,6 +63,12 @@ exposeQpObjectDense(pybind11::module_ m)
     .def("is_box_constrained",
          &dense::QP<T>::is_box_constrained,
          "precise whether or not the QP is designed with box constraints.")
+    .def("which_problem_type",
+         &dense::QP<T>::which_problem_type,
+         "precise which problem type is to be solved.")
+    .def("which_dense_backend",
+         &dense::QP<T>::which_dense_backend,
+         "precise which dense backend is chosen.")
     .def("init",
          static_cast<void (dense::QP<T>::*)(optional<dense::MatRef<T>>,
                                             optional<dense::VecRef<T>>,

--- a/bindings/python/src/expose-settings.hpp
+++ b/bindings/python/src/expose-settings.hpp
@@ -35,10 +35,6 @@ exposeSettings(pybind11::module_ m)
     .value("GPDAL", MeritFunctionType::GPDAL)
     .value("PDAL", MeritFunctionType::PDAL)
     .export_values();
-  ::pybind11::enum_<ProblemType>(m, "problem_type", pybind11::module_local())
-    .value("QP", ProblemType::QP)
-    .value("LP", ProblemType::LP)
-    .export_values();
 
   ::pybind11::enum_<SparseBackend>(m, "SparseBackend", pybind11::module_local())
     .value("Automatic", SparseBackend::Automatic)
@@ -87,7 +83,6 @@ exposeSettings(pybind11::module_ m)
     .def_readwrite("bcl_update", &Settings<T>::bcl_update)
     .def_readwrite("merit_function_type", &Settings<T>::merit_function_type)
     .def_readwrite("alpha_gpdal", &Settings<T>::alpha_gpdal)
-    .def_readwrite("problem_type", &Settings<T>::problem_type)
     .def(pybind11::self == pybind11::self)
     .def(pybind11::self != pybind11::self)
     .def(pybind11::pickle(

--- a/doc/2-PROXQP_API/2-ProxQP_api.md
+++ b/doc/2-PROXQP_API/2-ProxQP_api.md
@@ -126,6 +126,26 @@ The dense backend has also a specific feature for handling more efficiently box 
   </tr>
 </table>
 
+Furthermore, the dense version of ProxQP has two different backends with different advantages:
+* PrimalDualLdl: it factorizes a regularized version of the KKT system and benefits from great accuracy and stability. Nethertheless if the primal dimension (i.e., the one of x) is far smaller than the dimensions of the constraints, it will be slower than PrimalLdl backend.
+* PrimalLdl: it factorizes at the beginning the matrix $$H+\rho I+\frac{1}{\mu_{eq}} A^\top A$$ and goes on then with rank one updates. It is less accurate than PrimalDualLdl backend, but it will be far quicker if it happens that the primal dimension if much smaller than the ones of the constraints.
+
+The QP constructor uses by default an automatic choice for deciding which backend suits a priori bests user's needs. It is based on a heuristic comparing a priori computational complexity of each backends. However, if you have more insights of your needs (e.g., accuracy specifications, primal dimension is known to be far larger than the one of the constraints etc.), we encourage you to specify directly in the constructor which backend to use. It is as simple as following:
+
+<table class="manual">
+  <tr>
+    <th>examples/cpp/loading_dense_qp_with_different_backend_choice.cpp</th>
+    <th>examples/python/loading_dense_qp_with_different_backend_choice.py</th>
+  </tr>
+  <tr>
+    <td valign="top">
+      \include loading_dense_qp_with_different_backend_choice.cpp
+    </td>
+    <td valign="top">
+      \include loading_dense_qp_with_different_backend_choice.py
+    </td>
+  </tr>
+</table>
 
 For loading ProxQP with sparse backend they are two possibilities:
 * one can use as before the dimensions of the QP problem (i.e., n, n_eq and n_in)
@@ -375,7 +395,7 @@ In this table you have on the three columns from left to right: the name of the 
 | safe_guard                          | 1.E4                               | Safeguard parameter ensuring global convergence of the scheme. More precisely, if the total number of iteration is superior to safe_guard, the BCL scheme accept always the multipliers (hence the scheme is a pure proximal point algorithm).
 | preconditioner_max_iter             | 10                                 | Maximal number of authorized iterations for the preconditioner.
 | preconditioner_accuracy             | 1.E-3                              | Accuracy level of the preconditioner.
-| problem_type                        | QP                                 | Defines the type of problem solved (QP or LP). In case LP option is used, the solver does not perform internally linear algebra operations involving the Hessian H.
+| problem_type                        | QuadraticProgram                   | Defines the type of problem solved (QuadraticProgram, LinearProrgram or DiagonalHessian). In case LinearProgram or DiagonalHessian option are used, the solver optimize perform internally linear algebra operations involving the Hessian H.
 
 \subsection OverviewInitialGuess The different initial guesses
 

--- a/doc/2-PROXQP_API/2-ProxQP_api.md
+++ b/doc/2-PROXQP_API/2-ProxQP_api.md
@@ -127,8 +127,8 @@ The dense backend has also a specific feature for handling more efficiently box 
 </table>
 
 Furthermore, the dense version of ProxQP has two different backends with different advantages:
-* PrimalDualLdl: it factorizes a regularized version of the KKT system and benefits from great accuracy and stability. Nethertheless if the primal dimension (i.e., the one of x) is far smaller than the dimensions of the constraints, it will be slower than PrimalLdl backend.
-* PrimalLdl: it factorizes at the beginning the matrix $$H+\rho I+\frac{1}{\mu_{eq}} A^\top A$$ and goes on then with rank one updates. It is less accurate than PrimalDualLdl backend, but it will be far quicker if it happens that the primal dimension if much smaller than the ones of the constraints.
+* PrimalDualLDLT: it factorizes a regularized version of the KKT system and benefits from great accuracy and stability. Nethertheless if the primal dimension (i.e., the one of x) is far smaller than the dimensions of the constraints, it will be slower than PrimalLDLT backend.
+* PrimalLDLT: it factorizes at the beginning the matrix $$H+\rho I+\frac{1}{\mu_{eq}} A^\top A$$ and goes on then with rank one updates. It is less accurate than PrimalDualLDLT backend, but it will be far quicker if it happens that the primal dimension if much smaller than the ones of the constraints.
 
 The QP constructor uses by default an automatic choice for deciding which backend suits a priori bests user's needs. It is based on a heuristic comparing a priori computational complexity of each backends. However, if you have more insights of your needs (e.g., accuracy specifications, primal dimension is known to be far larger than the one of the constraints etc.), we encourage you to specify directly in the constructor which backend to use. It is as simple as following:
 
@@ -395,7 +395,7 @@ In this table you have on the three columns from left to right: the name of the 
 | safe_guard                          | 1.E4                               | Safeguard parameter ensuring global convergence of the scheme. More precisely, if the total number of iteration is superior to safe_guard, the BCL scheme accept always the multipliers (hence the scheme is a pure proximal point algorithm).
 | preconditioner_max_iter             | 10                                 | Maximal number of authorized iterations for the preconditioner.
 | preconditioner_accuracy             | 1.E-3                              | Accuracy level of the preconditioner.
-| problem_type                        | QuadraticProgram                   | Defines the type of problem solved (QuadraticProgram, LinearProrgram or DiagonalHessian). In case LinearProgram or DiagonalHessian option are used, the solver optimize perform internally linear algebra operations involving the Hessian H.
+| problem_type                        | DENSE                              | Defines the type of problem solved (DENSE, ZERO or DIAGONAL). In case ZERO or DIAGONAL option are used, the solver optimize perform internally linear algebra operations involving the Hessian H.
 
 \subsection OverviewInitialGuess The different initial guesses
 

--- a/doc/2-PROXQP_API/2-ProxQP_api.md
+++ b/doc/2-PROXQP_API/2-ProxQP_api.md
@@ -395,7 +395,7 @@ In this table you have on the three columns from left to right: the name of the 
 | safe_guard                          | 1.E4                               | Safeguard parameter ensuring global convergence of the scheme. More precisely, if the total number of iteration is superior to safe_guard, the BCL scheme accept always the multipliers (hence the scheme is a pure proximal point algorithm).
 | preconditioner_max_iter             | 10                                 | Maximal number of authorized iterations for the preconditioner.
 | preconditioner_accuracy             | 1.E-3                              | Accuracy level of the preconditioner.
-| problem_type                        | DENSE                              | Defines the type of problem solved (DENSE, ZERO or DIAGONAL). In case ZERO or DIAGONAL option are used, the solver optimize perform internally linear algebra operations involving the Hessian H.
+| HESSIAN_TYPE                        | DENSE                              | Defines the type of problem solved (DENSE, ZERO or DIAGONAL). In case ZERO or DIAGONAL option are used, the solver optimize perform internally linear algebra operations involving the Hessian H.
 
 \subsection OverviewInitialGuess The different initial guesses
 

--- a/doc/2-PROXQP_API/2-ProxQP_api.md
+++ b/doc/2-PROXQP_API/2-ProxQP_api.md
@@ -395,7 +395,7 @@ In this table you have on the three columns from left to right: the name of the 
 | safe_guard                          | 1.E4                               | Safeguard parameter ensuring global convergence of the scheme. More precisely, if the total number of iteration is superior to safe_guard, the BCL scheme accept always the multipliers (hence the scheme is a pure proximal point algorithm).
 | preconditioner_max_iter             | 10                                 | Maximal number of authorized iterations for the preconditioner.
 | preconditioner_accuracy             | 1.E-3                              | Accuracy level of the preconditioner.
-| HESSIAN_TYPE                        | DENSE                              | Defines the type of problem solved (DENSE, ZERO or DIAGONAL). In case ZERO or DIAGONAL option are used, the solver optimize perform internally linear algebra operations involving the Hessian H.
+| HessianType                         | Dense                               | Defines the type of problem solved (Dense, Zero or Diagonal). In case Zero or Diagonal option are used, the solver optimize perform internally linear algebra operations involving the Hessian H.
 
 \subsection OverviewInitialGuess The different initial guesses
 

--- a/examples/cpp/loading_dense_qp_with_different_backend_choice.cpp
+++ b/examples/cpp/loading_dense_qp_with_different_backend_choice.cpp
@@ -12,9 +12,9 @@ main()
   // n_eq equality constraints
   // n_in generic type of inequality constraints
   // and dim box inequality constraints
-  // we specify PrimalDualLdl backend
+  // we specify PrimalDualLDLT backend
   dense::QP<T> qp(
-    dim, n_eq, n_in, true, proxsuite::proxqp::DenseBackend::PrimalDualLdl);
+    dim, n_eq, n_in, true, proxsuite::proxqp::DenseBackend::PrimalDualLDLT);
   // true specifies we take into accounts box constraints
   // n_in are any other type of inequality constraints
 
@@ -24,9 +24,9 @@ main()
   // n_eq equality constraints
   // O generic type of inequality constraints
   // and dim box inequality constraints
-  // we specify PrimalLdl backend
+  // we specify PrimalLDLT backend
   dense::QP<T> qp2(
-    dim, n_eq, 0, true, proxsuite::proxqp::DenseBackend::PrimalLdl);
+    dim, n_eq, 0, true, proxsuite::proxqp::DenseBackend::PrimalLDLT);
   // true specifies we take into accounts box constraints
   // we don't need to precise n_in = dim, it is taken
   // into account internally

--- a/examples/cpp/loading_dense_qp_with_different_backend_choice.cpp
+++ b/examples/cpp/loading_dense_qp_with_different_backend_choice.cpp
@@ -1,0 +1,39 @@
+#include "proxsuite/proxqp/dense/dense.hpp"
+
+using namespace proxsuite::proxqp;
+using T = double;
+int
+main()
+{
+  dense::isize dim = 10;
+  dense::isize n_eq(dim / 4);
+  dense::isize n_in(dim / 4);
+  // we load here a QP model with
+  // n_eq equality constraints
+  // n_in generic type of inequality constraints
+  // and dim box inequality constraints
+  // we specify PrimalDualLdl backend
+  dense::QP<T> qp(
+    dim, n_eq, n_in, true, proxsuite::proxqp::DenseBackend::PrimalDualLdl);
+  // true specifies we take into accounts box constraints
+  // n_in are any other type of inequality constraints
+
+  // Other examples
+
+  // we load here a QP model with
+  // n_eq equality constraints
+  // O generic type of inequality constraints
+  // and dim box inequality constraints
+  // we specify PrimalLdl backend
+  dense::QP<T> qp2(
+    dim, n_eq, 0, true, proxsuite::proxqp::DenseBackend::PrimalLdl);
+  // true specifies we take into accounts box constraints
+  // we don't need to precise n_in = dim, it is taken
+  // into account internally
+
+  // we let here the solver decide with Automatic
+  // backend choice.
+  dense::QP<T> qp3(
+    dim, n_eq, 0, true, proxsuite::proxqp::DenseBackend::Automatic);
+  // Note that it is the default choice
+}

--- a/examples/python/loading_dense_qp_with_different_backend_choice.py
+++ b/examples/python/loading_dense_qp_with_different_backend_choice.py
@@ -1,0 +1,34 @@
+import proxsuite
+
+n = 10
+n_eq = 2
+n_in = 2
+# we load here a QP model with
+# n_eq equality constraints
+# n_in generic type of inequality constraints
+# and dim box inequality constraints
+#  we specify PrimalDualLdl backend
+qp = proxsuite.proxqp.dense.QP(
+    n, n_eq, n_in, True, dense_backend=proxsuite.proxqp.dense.DenseBackend.PrimalDualLdl
+)
+# true specifies we take into accounts box constraints
+# n_in are any other type of inequality constraints
+
+# Other examples
+
+# we load here a QP model with
+# n_eq equality constraints
+# O generic type of inequality constraints
+# and dim box inequality constraints
+#  we specify PrimalLdl backend
+qp2 = proxsuite.proxqp.dense.QP(
+    n, n_eq, 0, True, dense_backend=proxsuite.proxqp.dense.DenseBackend.PrimalLdl
+)
+# true specifies we take into accounts box constraints
+# we don't need to precise n_in = dim, it is taken
+# into account internally
+# We let finally the solver decide
+qp3 = proxsuite.proxqp.dense.QP(
+    n, n_eq, 0, True, dense_backend=proxsuite.proxqp.dense.DenseBackend.Automatic
+)
+# Note that it is the default choice

--- a/examples/python/loading_dense_qp_with_different_backend_choice.py
+++ b/examples/python/loading_dense_qp_with_different_backend_choice.py
@@ -7,9 +7,13 @@ n_in = 2
 # n_eq equality constraints
 # n_in generic type of inequality constraints
 # and dim box inequality constraints
-#  we specify PrimalDualLdl backend
+#  we specify PrimalDualLDLT backend
 qp = proxsuite.proxqp.dense.QP(
-    n, n_eq, n_in, True, dense_backend=proxsuite.proxqp.dense.DenseBackend.PrimalDualLdl
+    n,
+    n_eq,
+    n_in,
+    True,
+    dense_backend=proxsuite.proxqp.dense.DenseBackend.PrimalDualLDLT,
 )
 # true specifies we take into accounts box constraints
 # n_in are any other type of inequality constraints
@@ -20,9 +24,9 @@ qp = proxsuite.proxqp.dense.QP(
 # n_eq equality constraints
 # O generic type of inequality constraints
 # and dim box inequality constraints
-#  we specify PrimalLdl backend
+#  we specify PrimalLDLT backend
 qp2 = proxsuite.proxqp.dense.QP(
-    n, n_eq, 0, True, dense_backend=proxsuite.proxqp.dense.DenseBackend.PrimalLdl
+    n, n_eq, 0, True, dense_backend=proxsuite.proxqp.dense.DenseBackend.PrimalLDLT
 )
 # true specifies we take into accounts box constraints
 # we don't need to precise n_in = dim, it is taken

--- a/examples/python/solve_dense_lp.py
+++ b/examples/python/solve_dense_lp.py
@@ -19,9 +19,13 @@ C = np.array(
 u = np.array([4.0, 1.0, 3.0, 2.0])
 
 # Initialize ProxQP problem
-problem = proxsuite.proxqp.dense.QP(n=g.shape[0], n_eq=0, n_in=u.shape[0])
+problem = proxsuite.proxqp.dense.QP(
+    n=g.shape[0],
+    n_eq=0,
+    n_in=u.shape[0],
+    problem_type=proxsuite.proxqp.dense.problem_type.LinearProgram,
+)
 problem.settings.eps_abs = 1.0e-9
-problem.settings.problem_type = proxsuite.proxqp.problem_type.LP
 problem.init(None, g, None, None, C, None, u)
 
 # Solve problem and print solution

--- a/examples/python/solve_dense_lp.py
+++ b/examples/python/solve_dense_lp.py
@@ -23,7 +23,7 @@ problem = proxsuite.proxqp.dense.QP(
     n=g.shape[0],
     n_eq=0,
     n_in=u.shape[0],
-    problem_type=proxsuite.proxqp.dense.problem_type.LinearProgram,
+    problem_type=proxsuite.proxqp.dense.problem_type.ZERO,
 )
 problem.settings.eps_abs = 1.0e-9
 problem.init(None, g, None, None, C, None, u)

--- a/examples/python/solve_dense_lp.py
+++ b/examples/python/solve_dense_lp.py
@@ -23,7 +23,8 @@ problem = proxsuite.proxqp.dense.QP(
     n=g.shape[0],
     n_eq=0,
     n_in=u.shape[0],
-    hessian_type=proxsuite.proxqp.dense.hessian_type.ZERO,
+    # box_constraints = False,
+    hessian_type=proxsuite.proxqp.dense.HessianType.Zero,
 )
 problem.settings.eps_abs = 1.0e-9
 problem.init(None, g, None, None, C, None, u)

--- a/examples/python/solve_dense_lp.py
+++ b/examples/python/solve_dense_lp.py
@@ -23,7 +23,7 @@ problem = proxsuite.proxqp.dense.QP(
     n=g.shape[0],
     n_eq=0,
     n_in=u.shape[0],
-    problem_type=proxsuite.proxqp.dense.problem_type.ZERO,
+    hessian_type=proxsuite.proxqp.dense.hessian_type.ZERO,
 )
 problem.settings.eps_abs = 1.0e-9
 problem.init(None, g, None, None, C, None, u)

--- a/include/proxsuite/linalg/dense/ldlt.hpp
+++ b/include/proxsuite/linalg/dense/ldlt.hpp
@@ -737,11 +737,9 @@ public:
       proxsuite::linalg::dense::_detail::apply_permutation_tri_lower(
         ld_col_mut(), work, perm.ptr());
     }
-
     for (isize i = 0; i < n; ++i) {
       maybe_sorted_diag[i] = ld_col()(i, i);
     }
-
     proxsuite::linalg::dense::factorize(ld_col_mut(), stack);
   }
 
@@ -780,6 +778,24 @@ public:
 
     for (isize i = 0; i < n; ++i) {
       rhs[i] = work[perm_inv[i]];
+    }
+  }
+
+  void dual_solve_in_place(
+    Eigen::Ref<Vec> rhs,
+    isize n,
+    proxsuite::linalg::veg::dynstack::DynStackMut stack) const
+  {
+    isize m = rhs.rows();
+    LDLT_TEMP_VEC_UNINIT(T, work, m, stack);
+
+    for (isize i = 0; i < m; ++i) {
+      work[i] = rhs[perm[n + i] -
+                    n]; // n are the first n entries that are not considered
+    }
+    proxsuite::linalg::dense::solve(ld_col().bottomRightCorner(m, m), work);
+    for (isize i = 0; i < m; ++i) {
+      rhs[i] = work[perm_inv[n + i] - n];
     }
   }
 

--- a/include/proxsuite/proxqp/dense/helpers.hpp
+++ b/include/proxsuite/proxqp/dense/helpers.hpp
@@ -349,7 +349,7 @@ setup( //
   const bool box_constraints,
   preconditioner::RuizEquilibration<T>& ruiz,
   PreconditionerStatus preconditioner_status,
-  const ProblemType& problem_type)
+  const ProblemType problem_type)
 {
 
   switch (qpsettings.initial_guess) {

--- a/include/proxsuite/proxqp/dense/helpers.hpp
+++ b/include/proxsuite/proxqp/dense/helpers.hpp
@@ -37,7 +37,7 @@ compute_equality_constrained_initial_guess(Workspace<T>& qpwork,
                                            const Model<T>& qpmodel,
                                            const isize n_constraints,
                                            const DenseBackend& dense_backend,
-                                           const HESSIAN_TYPE& hessian_type,
+                                           const HessianType& hessian_type,
                                            Results<T>& qpresults)
 {
 
@@ -76,7 +76,7 @@ setup_factorization(Workspace<T>& qpwork,
                     const Model<T>& qpmodel,
                     Results<T>& qpresults,
                     const DenseBackend& dense_backend,
-                    const HESSIAN_TYPE& hessian_type)
+                    const HessianType& hessian_type)
 {
 
   proxsuite::linalg::veg::dynstack::DynStackMut stack{
@@ -84,13 +84,13 @@ setup_factorization(Workspace<T>& qpwork,
     qpwork.ldl_stack.as_mut(),
   };
   switch (hessian_type) {
-    case HESSIAN_TYPE::DENSE:
+    case HessianType::Dense:
       qpwork.kkt.topLeftCorner(qpmodel.dim, qpmodel.dim) = qpwork.H_scaled;
       break;
-    case HESSIAN_TYPE::ZERO:
+    case HessianType::Zero:
       qpwork.kkt.topLeftCorner(qpmodel.dim, qpmodel.dim).setZero();
       break;
-    case HESSIAN_TYPE::DIAGONAL:
+    case HessianType::Diagonal:
       qpwork.kkt.topLeftCorner(qpmodel.dim, qpmodel.dim) = qpwork.H_scaled;
       break;
   }
@@ -134,7 +134,7 @@ void
 setup_equilibration(Workspace<T>& qpwork,
                     const Settings<T>& qpsettings,
                     const bool box_constraints,
-                    const HESSIAN_TYPE hessian_type,
+                    const HessianType hessian_type,
                     preconditioner::RuizEquilibration<T>& ruiz,
                     bool execute_preconditioner)
 {
@@ -349,7 +349,7 @@ setup( //
   const bool box_constraints,
   preconditioner::RuizEquilibration<T>& ruiz,
   PreconditionerStatus preconditioner_status,
-  const HESSIAN_TYPE hessian_type)
+  const HessianType hessian_type)
 {
 
   switch (qpsettings.initial_guess) {
@@ -445,12 +445,12 @@ setup( //
     // zero shape
   assert(qpmodel.is_valid(box_constraints));
   switch (hessian_type) {
-    case HESSIAN_TYPE::ZERO:
+    case HessianType::Zero:
       break;
-    case HESSIAN_TYPE::DENSE:
+    case HessianType::Dense:
       qpwork.H_scaled = qpmodel.H;
       break;
-    case HESSIAN_TYPE::DIAGONAL:
+    case HessianType::Diagonal:
       qpwork.H_scaled = qpmodel.H;
       break;
   }

--- a/include/proxsuite/proxqp/dense/helpers.hpp
+++ b/include/proxsuite/proxqp/dense/helpers.hpp
@@ -134,7 +134,7 @@ void
 setup_equilibration(Workspace<T>& qpwork,
                     const Settings<T>& qpsettings,
                     const bool box_constraints,
-                    const ProblemType& problem_type,
+                    const ProblemType problem_type,
                     preconditioner::RuizEquilibration<T>& ruiz,
                     bool execute_preconditioner)
 {

--- a/include/proxsuite/proxqp/dense/helpers.hpp
+++ b/include/proxsuite/proxqp/dense/helpers.hpp
@@ -36,6 +36,8 @@ compute_equality_constrained_initial_guess(Workspace<T>& qpwork,
                                            const Settings<T>& qpsettings,
                                            const Model<T>& qpmodel,
                                            const isize n_constraints,
+                                           const DenseBackend& dense_backend,
+                                           const ProblemType& problem_type,
                                            Results<T>& qpresults)
 {
 
@@ -48,6 +50,8 @@ compute_equality_constrained_initial_guess(Workspace<T>& qpwork,
     qpresults,
     qpwork,
     n_constraints,
+    dense_backend,
+    problem_type,
     T(1),
     qpmodel.dim + qpmodel.n_eq);
 
@@ -70,33 +74,48 @@ template<typename T>
 void
 setup_factorization(Workspace<T>& qpwork,
                     const Model<T>& qpmodel,
-                    const Settings<T>& qpsettings,
-                    Results<T>& qpresults)
+                    Results<T>& qpresults,
+                    const DenseBackend& dense_backend,
+                    const ProblemType& problem_type)
 {
 
   proxsuite::linalg::veg::dynstack::DynStackMut stack{
     proxsuite::linalg::veg::from_slice_mut,
     qpwork.ldl_stack.as_mut(),
   };
-  switch (qpsettings.problem_type) {
-    case ProblemType::QP:
+  switch (problem_type) {
+    case ProblemType::QuadraticProgram:
       qpwork.kkt.topLeftCorner(qpmodel.dim, qpmodel.dim) = qpwork.H_scaled;
       break;
-    case ProblemType::LP:
+    case ProblemType::LinearProgram:
       qpwork.kkt.topLeftCorner(qpmodel.dim, qpmodel.dim).setZero();
+      break;
+    case ProblemType::DiagonalHessian:
+      qpwork.kkt.topLeftCorner(qpmodel.dim, qpmodel.dim) = qpwork.H_scaled;
       break;
   }
   qpwork.kkt.topLeftCorner(qpmodel.dim, qpmodel.dim).diagonal().array() +=
     qpresults.info.rho;
-  qpwork.kkt.block(0, qpmodel.dim, qpmodel.dim, qpmodel.n_eq) =
-    qpwork.A_scaled.transpose();
-  qpwork.kkt.block(qpmodel.dim, 0, qpmodel.n_eq, qpmodel.dim) = qpwork.A_scaled;
-  qpwork.kkt.bottomRightCorner(qpmodel.n_eq, qpmodel.n_eq).setZero();
-  qpwork.kkt.diagonal()
-    .segment(qpmodel.dim, qpmodel.n_eq)
-    .setConstant(-qpresults.info.mu_eq);
-
-  qpwork.ldl.factorize(qpwork.kkt.transpose(), stack);
+  switch (dense_backend) {
+    case DenseBackend::PrimalDualLdl:
+      qpwork.kkt.block(0, qpmodel.dim, qpmodel.dim, qpmodel.n_eq) =
+        qpwork.A_scaled.transpose();
+      qpwork.kkt.block(qpmodel.dim, 0, qpmodel.n_eq, qpmodel.dim) =
+        qpwork.A_scaled;
+      qpwork.kkt.bottomRightCorner(qpmodel.n_eq, qpmodel.n_eq).setZero();
+      qpwork.kkt.diagonal()
+        .segment(qpmodel.dim, qpmodel.n_eq)
+        .setConstant(-qpresults.info.mu_eq);
+      qpwork.ldl.factorize(qpwork.kkt.transpose(), stack);
+      break;
+    case DenseBackend::PrimalLdl:
+      qpwork.kkt.noalias() += qpresults.info.mu_eq_inv *
+                              (qpwork.A_scaled.transpose() * qpwork.A_scaled);
+      qpwork.ldl.factorize(qpwork.kkt.transpose(), stack);
+      break;
+    case DenseBackend::Automatic:
+      break;
+  }
 }
 /*!
  * Performs the equilibration of the QP problem for reducing its
@@ -115,6 +134,7 @@ void
 setup_equilibration(Workspace<T>& qpwork,
                     const Settings<T>& qpsettings,
                     const bool box_constraints,
+                    const ProblemType& problem_type,
                     preconditioner::RuizEquilibration<T>& ruiz,
                     bool execute_preconditioner)
 {
@@ -135,7 +155,7 @@ setup_equilibration(Workspace<T>& qpwork,
                          execute_preconditioner,
                          qpsettings.preconditioner_max_iter,
                          qpsettings.preconditioner_accuracy,
-                         qpsettings.problem_type,
+                         problem_type,
                          box_constraints,
                          stack);
   qpwork.correction_guess_rhs_g = infty_norm(qpwork.g_scaled);
@@ -328,7 +348,8 @@ setup( //
   Results<T>& qpresults,
   const bool box_constraints,
   preconditioner::RuizEquilibration<T>& ruiz,
-  PreconditionerStatus preconditioner_status)
+  PreconditionerStatus preconditioner_status,
+  const ProblemType& problem_type)
 {
 
   switch (qpsettings.initial_guess) {
@@ -423,10 +444,13 @@ setup( //
   } // else qpmodel.l_box remains initialized to a matrix with zero elements or
     // zero shape
   assert(qpmodel.is_valid(box_constraints));
-  switch (qpsettings.problem_type) {
-    case ProblemType::LP:
+  switch (problem_type) {
+    case ProblemType::LinearProgram:
       break;
-    case ProblemType::QP:
+    case ProblemType::QuadraticProgram:
+      qpwork.H_scaled = qpmodel.H;
+      break;
+    case ProblemType::DiagonalHessian:
       qpwork.H_scaled = qpmodel.H;
       break;
   }
@@ -460,14 +484,17 @@ setup( //
   qpwork.dual_feasibility_rhs_2 = infty_norm(qpmodel.g);
   switch (preconditioner_status) {
     case PreconditionerStatus::EXECUTE:
-      setup_equilibration(qpwork, qpsettings, box_constraints, ruiz, true);
+      setup_equilibration(
+        qpwork, qpsettings, box_constraints, problem_type, ruiz, true);
       break;
     case PreconditionerStatus::IDENTITY:
-      setup_equilibration(qpwork, qpsettings, box_constraints, ruiz, false);
+      setup_equilibration(
+        qpwork, qpsettings, box_constraints, problem_type, ruiz, false);
       break;
     case PreconditionerStatus::KEEP:
       // keep previous one
-      setup_equilibration(qpwork, qpsettings, box_constraints, ruiz, false);
+      setup_equilibration(
+        qpwork, qpsettings, box_constraints, problem_type, ruiz, false);
       break;
   }
 }

--- a/include/proxsuite/proxqp/dense/helpers.hpp
+++ b/include/proxsuite/proxqp/dense/helpers.hpp
@@ -37,7 +37,7 @@ compute_equality_constrained_initial_guess(Workspace<T>& qpwork,
                                            const Model<T>& qpmodel,
                                            const isize n_constraints,
                                            const DenseBackend& dense_backend,
-                                           const HESSIAN_TYPE& problem_type,
+                                           const HESSIAN_TYPE& hessian_type,
                                            Results<T>& qpresults)
 {
 
@@ -51,7 +51,7 @@ compute_equality_constrained_initial_guess(Workspace<T>& qpwork,
     qpwork,
     n_constraints,
     dense_backend,
-    problem_type,
+    hessian_type,
     T(1),
     qpmodel.dim + qpmodel.n_eq);
 
@@ -76,14 +76,14 @@ setup_factorization(Workspace<T>& qpwork,
                     const Model<T>& qpmodel,
                     Results<T>& qpresults,
                     const DenseBackend& dense_backend,
-                    const HESSIAN_TYPE& problem_type)
+                    const HESSIAN_TYPE& hessian_type)
 {
 
   proxsuite::linalg::veg::dynstack::DynStackMut stack{
     proxsuite::linalg::veg::from_slice_mut,
     qpwork.ldl_stack.as_mut(),
   };
-  switch (problem_type) {
+  switch (hessian_type) {
     case HESSIAN_TYPE::DENSE:
       qpwork.kkt.topLeftCorner(qpmodel.dim, qpmodel.dim) = qpwork.H_scaled;
       break;
@@ -134,7 +134,7 @@ void
 setup_equilibration(Workspace<T>& qpwork,
                     const Settings<T>& qpsettings,
                     const bool box_constraints,
-                    const HESSIAN_TYPE problem_type,
+                    const HESSIAN_TYPE hessian_type,
                     preconditioner::RuizEquilibration<T>& ruiz,
                     bool execute_preconditioner)
 {
@@ -155,7 +155,7 @@ setup_equilibration(Workspace<T>& qpwork,
                          execute_preconditioner,
                          qpsettings.preconditioner_max_iter,
                          qpsettings.preconditioner_accuracy,
-                         problem_type,
+                         hessian_type,
                          box_constraints,
                          stack);
   qpwork.correction_guess_rhs_g = infty_norm(qpwork.g_scaled);
@@ -349,7 +349,7 @@ setup( //
   const bool box_constraints,
   preconditioner::RuizEquilibration<T>& ruiz,
   PreconditionerStatus preconditioner_status,
-  const HESSIAN_TYPE problem_type)
+  const HESSIAN_TYPE hessian_type)
 {
 
   switch (qpsettings.initial_guess) {
@@ -444,7 +444,7 @@ setup( //
   } // else qpmodel.l_box remains initialized to a matrix with zero elements or
     // zero shape
   assert(qpmodel.is_valid(box_constraints));
-  switch (problem_type) {
+  switch (hessian_type) {
     case HESSIAN_TYPE::ZERO:
       break;
     case HESSIAN_TYPE::DENSE:
@@ -485,16 +485,16 @@ setup( //
   switch (preconditioner_status) {
     case PreconditionerStatus::EXECUTE:
       setup_equilibration(
-        qpwork, qpsettings, box_constraints, problem_type, ruiz, true);
+        qpwork, qpsettings, box_constraints, hessian_type, ruiz, true);
       break;
     case PreconditionerStatus::IDENTITY:
       setup_equilibration(
-        qpwork, qpsettings, box_constraints, problem_type, ruiz, false);
+        qpwork, qpsettings, box_constraints, hessian_type, ruiz, false);
       break;
     case PreconditionerStatus::KEEP:
       // keep previous one
       setup_equilibration(
-        qpwork, qpsettings, box_constraints, problem_type, ruiz, false);
+        qpwork, qpsettings, box_constraints, hessian_type, ruiz, false);
       break;
   }
 }

--- a/include/proxsuite/proxqp/dense/linesearch.hpp
+++ b/include/proxsuite/proxqp/dense/linesearch.hpp
@@ -633,10 +633,10 @@ active_set_change(const Model<T>& qpmodel,
     }
     std::sort(planned_to_delete, planned_to_delete + planned_to_delete_count);
     switch (dense_backend) {
-      case DenseBackend::PrimalDualLdl:
+      case DenseBackend::PrimalDualLDLT:
         qpwork.ldl.delete_at(planned_to_delete, planned_to_delete_count, stack);
         break;
-      case DenseBackend::PrimalLdl: {
+      case DenseBackend::PrimalLDLT: {
         // for (isize i=0; i < planned_to_delete_count; i++){
         //   isize index = planned_to_delete[i] - (qpmodel.dim + qpmodel.n_eq);
         //   if (index >= qpmodel.n_in){
@@ -709,7 +709,7 @@ active_set_change(const Model<T>& qpmodel,
     }
     {
       switch (dense_backend) {
-        case DenseBackend::PrimalDualLdl: {
+        case DenseBackend::PrimalDualLDLT: {
           isize n = qpmodel.dim;
           isize n_eq = qpmodel.n_eq;
           LDLT_TEMP_MAT_UNINIT(
@@ -730,7 +730,7 @@ active_set_change(const Model<T>& qpmodel,
           }
           qpwork.ldl.insert_block_at(n + n_eq + n_c, new_cols, stack);
         } break;
-        case DenseBackend::PrimalLdl: {
+        case DenseBackend::PrimalLDLT: {
           // too slow
           // for (isize i=0; i < planned_to_add_count; ++i){
           //   isize index = planned_to_add[i];

--- a/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
+++ b/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
@@ -35,7 +35,7 @@ ruiz_scale_qp_in_place( //
   T epsilon,
   isize max_iter,
   Symmetry sym,
-  HESSIAN_TYPE problem_type,
+  HESSIAN_TYPE hessian_type,
   const bool box_constraints,
   proxsuite::linalg::veg::dynstack::DynStackMut stack) -> T
 {
@@ -89,7 +89,7 @@ ruiz_scale_qp_in_place( //
     }
     // normalization vector
     {
-      switch (problem_type) {
+      switch (hessian_type) {
         case HESSIAN_TYPE::ZERO:
           for (isize k = 0; k < n; ++k) {
             T aux = sqrt(std::max({ n_eq > 0 ? infty_norm(A.col(k)) : T(0),
@@ -206,7 +206,7 @@ ruiz_scale_qp_in_place( //
       l.array() *= delta.segment(n + n_eq, n_in).array();
 
       // normalize H
-      switch (problem_type) {
+      switch (hessian_type) {
         case HESSIAN_TYPE::ZERO:
           break;
         case HESSIAN_TYPE::DENSE:
@@ -392,7 +392,7 @@ struct RuizEquilibration
                          bool execute_preconditioner,
                          const isize max_iter,
                          const T epsilon,
-                         const HESSIAN_TYPE& problem_type,
+                         const HESSIAN_TYPE& hessian_type,
                          const bool box_constraints,
                          proxsuite::linalg::veg::dynstack::DynStackMut stack)
   {
@@ -404,7 +404,7 @@ struct RuizEquilibration
                                          epsilon,
                                          max_iter,
                                          sym,
-                                         problem_type,
+                                         hessian_type,
                                          box_constraints,
                                          stack);
     } else {
@@ -429,7 +429,7 @@ struct RuizEquilibration
           delta.head(n).asDiagonal();
 
       // normalize H
-      switch (problem_type) {
+      switch (hessian_type) {
         case HESSIAN_TYPE::DENSE:
           switch (sym) {
             case Symmetry::upper: {

--- a/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
+++ b/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
@@ -35,7 +35,7 @@ ruiz_scale_qp_in_place( //
   T epsilon,
   isize max_iter,
   Symmetry sym,
-  HESSIAN_TYPE hessian_type,
+  HessianType HessianType,
   const bool box_constraints,
   proxsuite::linalg::veg::dynstack::DynStackMut stack) -> T
 {
@@ -89,8 +89,8 @@ ruiz_scale_qp_in_place( //
     }
     // normalization vector
     {
-      switch (hessian_type) {
-        case HESSIAN_TYPE::ZERO:
+      switch (HessianType) {
+        case HessianType::Zero:
           for (isize k = 0; k < n; ++k) {
             T aux = sqrt(std::max({ n_eq > 0 ? infty_norm(A.col(k)) : T(0),
                                     n_in > 0 ? infty_norm(C.col(k)) : T(0),
@@ -102,7 +102,7 @@ ruiz_scale_qp_in_place( //
             }
           }
           break;
-        case HESSIAN_TYPE::DENSE:
+        case HessianType::Dense:
           for (isize k = 0; k < n; ++k) {
             switch (sym) {
               case Symmetry::upper: { // upper triangular part
@@ -151,7 +151,7 @@ ruiz_scale_qp_in_place( //
             }
           }
           break;
-        case HESSIAN_TYPE::DIAGONAL:
+        case HessianType::Diagonal:
           for (isize k = 0; k < n; ++k) {
             T aux = sqrt(std::max({ std::abs(H(k, k)),
                                     n_eq > 0 ? infty_norm(A.col(k)) : T(0),
@@ -206,10 +206,10 @@ ruiz_scale_qp_in_place( //
       l.array() *= delta.segment(n + n_eq, n_in).array();
 
       // normalize H
-      switch (hessian_type) {
-        case HESSIAN_TYPE::ZERO:
+      switch (HessianType) {
+        case HessianType::Zero:
           break;
-        case HESSIAN_TYPE::DENSE:
+        case HessianType::Dense:
           switch (sym) {
             case Symmetry::upper: {
               // upper triangular part
@@ -273,7 +273,7 @@ ruiz_scale_qp_in_place( //
               break;
           }
           break;
-        case HESSIAN_TYPE::DIAGONAL:
+        case HessianType::Diagonal:
           // H = delta.head(n).asDiagonal() * H.asDiagonal() *
           // delta.head(n).asDiagonal();
           H.diagonal().array() *=
@@ -392,7 +392,7 @@ struct RuizEquilibration
                          bool execute_preconditioner,
                          const isize max_iter,
                          const T epsilon,
-                         const HESSIAN_TYPE& hessian_type,
+                         const HessianType& HessianType,
                          const bool box_constraints,
                          proxsuite::linalg::veg::dynstack::DynStackMut stack)
   {
@@ -404,7 +404,7 @@ struct RuizEquilibration
                                          epsilon,
                                          max_iter,
                                          sym,
-                                         hessian_type,
+                                         HessianType,
                                          box_constraints,
                                          stack);
     } else {
@@ -429,8 +429,8 @@ struct RuizEquilibration
           delta.head(n).asDiagonal();
 
       // normalize H
-      switch (hessian_type) {
-        case HESSIAN_TYPE::DENSE:
+      switch (HessianType) {
+        case HessianType::Dense:
           switch (sym) {
             case Symmetry::upper: {
               // upper triangular part
@@ -464,9 +464,9 @@ struct RuizEquilibration
           }
           break;
 
-        case HESSIAN_TYPE::ZERO:
+        case HessianType::Zero:
           break;
-        case HESSIAN_TYPE::DIAGONAL:
+        case HessianType::Diagonal:
           // H = delta.head(n).asDiagonal() * H.asDiagonal() *
           // delta.head(n).asDiagonal();
           H.diagonal().array() *=

--- a/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
+++ b/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
@@ -35,7 +35,7 @@ ruiz_scale_qp_in_place( //
   T epsilon,
   isize max_iter,
   Symmetry sym,
-  ProblemType problem_type,
+  HESSIAN_TYPE problem_type,
   const bool box_constraints,
   proxsuite::linalg::veg::dynstack::DynStackMut stack) -> T
 {
@@ -90,7 +90,7 @@ ruiz_scale_qp_in_place( //
     // normalization vector
     {
       switch (problem_type) {
-        case ProblemType::LinearProgram:
+        case HESSIAN_TYPE::ZERO:
           for (isize k = 0; k < n; ++k) {
             T aux = sqrt(std::max({ n_eq > 0 ? infty_norm(A.col(k)) : T(0),
                                     n_in > 0 ? infty_norm(C.col(k)) : T(0),
@@ -102,7 +102,7 @@ ruiz_scale_qp_in_place( //
             }
           }
           break;
-        case ProblemType::QuadraticProgram:
+        case HESSIAN_TYPE::DENSE:
           for (isize k = 0; k < n; ++k) {
             switch (sym) {
               case Symmetry::upper: { // upper triangular part
@@ -151,7 +151,7 @@ ruiz_scale_qp_in_place( //
             }
           }
           break;
-        case ProblemType::DiagonalHessian:
+        case HESSIAN_TYPE::DIAGONAL:
           for (isize k = 0; k < n; ++k) {
             T aux = sqrt(std::max({ std::abs(H(k, k)),
                                     n_eq > 0 ? infty_norm(A.col(k)) : T(0),
@@ -207,9 +207,9 @@ ruiz_scale_qp_in_place( //
 
       // normalize H
       switch (problem_type) {
-        case ProblemType::LinearProgram:
+        case HESSIAN_TYPE::ZERO:
           break;
-        case ProblemType::QuadraticProgram:
+        case HESSIAN_TYPE::DENSE:
           switch (sym) {
             case Symmetry::upper: {
               // upper triangular part
@@ -273,7 +273,7 @@ ruiz_scale_qp_in_place( //
               break;
           }
           break;
-        case ProblemType::DiagonalHessian:
+        case HESSIAN_TYPE::DIAGONAL:
           // H = delta.head(n).asDiagonal() * H.asDiagonal() *
           // delta.head(n).asDiagonal();
           H.diagonal().array() *=
@@ -392,7 +392,7 @@ struct RuizEquilibration
                          bool execute_preconditioner,
                          const isize max_iter,
                          const T epsilon,
-                         const ProblemType& problem_type,
+                         const HESSIAN_TYPE& problem_type,
                          const bool box_constraints,
                          proxsuite::linalg::veg::dynstack::DynStackMut stack)
   {
@@ -430,7 +430,7 @@ struct RuizEquilibration
 
       // normalize H
       switch (problem_type) {
-        case ProblemType::QuadraticProgram:
+        case HESSIAN_TYPE::DENSE:
           switch (sym) {
             case Symmetry::upper: {
               // upper triangular part
@@ -464,9 +464,9 @@ struct RuizEquilibration
           }
           break;
 
-        case ProblemType::LinearProgram:
+        case HESSIAN_TYPE::ZERO:
           break;
-        case ProblemType::DiagonalHessian:
+        case HESSIAN_TYPE::DIAGONAL:
           // H = delta.head(n).asDiagonal() * H.asDiagonal() *
           // delta.head(n).asDiagonal();
           H.diagonal().array() *=

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -244,21 +244,21 @@ iterative_residual(const Model<T>& qpmodel,
                    Workspace<T>& qpwork,
                    const isize n_constraints,
                    isize inner_pb_dim,
-                   const HESSIAN_TYPE& hessian_type)
+                   const HessianType& hessian_type)
 {
   auto& Hdx = qpwork.Hdx;
   auto& Adx = qpwork.Adx;
   auto& ATdy = qpwork.CTz;
   qpwork.err.head(inner_pb_dim) = qpwork.rhs.head(inner_pb_dim);
   switch (hessian_type) {
-    case HESSIAN_TYPE::ZERO:
+    case HessianType::Zero:
       break;
-    case HESSIAN_TYPE::DENSE:
+    case HessianType::Dense:
       Hdx.noalias() = qpwork.H_scaled.template selfadjointView<Eigen::Lower>() *
                       qpwork.dw_aug.head(qpmodel.dim);
       qpwork.err.head(qpmodel.dim).noalias() -= Hdx;
       break;
-    case HESSIAN_TYPE::DIAGONAL:
+    case HessianType::Diagonal:
       Hdx.array() = qpwork.H_scaled.diagonal().array() *
                     qpwork.dw_aug.head(qpmodel.dim).array();
       qpwork.err.head(qpmodel.dim).noalias() -= Hdx;
@@ -404,7 +404,7 @@ iterative_solve_with_permut_fact( //
   Workspace<T>& qpwork,
   const isize n_constraints,
   const DenseBackend& dense_backend,
-  const HESSIAN_TYPE& hessian_type,
+  const HessianType& hessian_type,
   T eps,
   isize inner_pb_dim)
 {
@@ -746,7 +746,7 @@ primal_dual_semi_smooth_newton_step(const Settings<T>& qpsettings,
                                     const bool box_constraints,
                                     const isize n_constraints,
                                     const DenseBackend& dense_backend,
-                                    const HESSIAN_TYPE& hessian_type,
+                                    const HessianType& hessian_type,
                                     T eps)
 {
 
@@ -877,7 +877,7 @@ primal_dual_newton_semi_smooth(const Settings<T>& qpsettings,
                                const isize n_constraints,
                                preconditioner::RuizEquilibration<T>& ruiz,
                                const DenseBackend& dense_backend,
-                               const HESSIAN_TYPE& hessian_type,
+                               const HessianType& hessian_type,
                                T eps_int)
 {
 
@@ -983,15 +983,15 @@ primal_dual_newton_semi_smooth(const Settings<T>& qpsettings,
     qpresults.y += alpha * dy;
     qpresults.z += alpha * dz;
     switch (hessian_type) {
-      case HESSIAN_TYPE::ZERO:
+      case HessianType::Zero:
         qpwork.dual_residual_scaled +=
           alpha * (qpresults.info.rho * dx + ATdy + CTdz);
         break;
-      case HESSIAN_TYPE::DENSE:
+      case HessianType::Dense:
         qpwork.dual_residual_scaled +=
           alpha * (qpresults.info.rho * dx + Hdx + ATdy + CTdz);
         break;
-      case HESSIAN_TYPE::DIAGONAL:
+      case HessianType::Diagonal:
         qpwork.dual_residual_scaled +=
           alpha * (qpresults.info.rho * dx + Hdx + ATdy + CTdz);
         break;
@@ -1096,7 +1096,7 @@ qp_solve( //
   Workspace<T>& qpwork,
   const bool box_constraints,
   const DenseBackend& dense_backend,
-  const HESSIAN_TYPE& hessian_type,
+  const HessianType& hessian_type,
   preconditioner::RuizEquilibration<T>& ruiz)
 {
   /*** TEST WITH MATRIX FULL OF NAN FOR DEBUG
@@ -1190,12 +1190,12 @@ qp_solve( //
     if (qpsettings.initial_guess !=
         InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT) {
       switch (hessian_type) {
-        case HESSIAN_TYPE::ZERO:
+        case HessianType::Zero:
           break;
-        case HESSIAN_TYPE::DENSE:
+        case HessianType::Dense:
           qpwork.H_scaled = qpmodel.H;
           break;
-        case HESSIAN_TYPE::DIAGONAL:
+        case HessianType::Diagonal:
           qpwork.H_scaled = qpmodel.H;
           break;
       }

--- a/include/proxsuite/proxqp/dense/utils.hpp
+++ b/include/proxsuite/proxqp/dense/utils.hpp
@@ -32,7 +32,10 @@ template<typename T>
 void
 print_setup_header(const Settings<T>& settings,
                    const Results<T>& results,
-                   const Model<T>& model)
+                   const Model<T>& model,
+                   const bool box_constraints,
+                   const DenseBackend& dense_backend,
+                   const ProblemType& problem_type)
 {
 
   proxsuite::proxqp::print_preambule();
@@ -57,7 +60,34 @@ print_setup_header(const Settings<T>& settings,
             << ", mu_in = " << results.info.mu_in << "," << std::endl;
   std::cout << "          max_iter = " << settings.max_iter
             << ", max_iter_in = " << settings.max_iter_in << "," << std::endl;
-
+  if (box_constraints) {
+    std::cout << "          box constraints: on, " << std::endl;
+  } else {
+    std::cout << "          box constraints: off, " << std::endl;
+  }
+  switch (dense_backend) {
+    case DenseBackend::PrimalDualLdl:
+      std::cout << "          dense backend: PrimalDualLdl, " << std::endl;
+      break;
+    case DenseBackend::PrimalLdl:
+      std::cout << "          dense backend: PrimalLdl, " << std::endl;
+      break;
+    case DenseBackend::Automatic:
+      break;
+  }
+  switch (problem_type) {
+    case ProblemType::QuadraticProgram:
+      std::cout << "          problem type: Quadratic Program, " << std::endl;
+      break;
+    case ProblemType::LinearProgram:
+      std::cout << "          problem type: Linear Program, " << std::endl;
+      break;
+    case ProblemType::DiagonalHessian:
+      std::cout
+        << "          problem type: Quadratic Program with diagonal Hessian, "
+        << std::endl;
+      break;
+  }
   if (settings.compute_preconditioner) {
     std::cout << "          scaling: on, " << std::endl;
   } else {
@@ -73,7 +103,7 @@ print_setup_header(const Settings<T>& settings,
       std::cout << "          initial guess: warm start. \n" << std::endl;
       break;
     case InitialGuessStatus::NO_INITIAL_GUESS:
-      std::cout << "          initial guess: initial guess. \n" << std::endl;
+      std::cout << "          initial guess: no initial guess. \n" << std::endl;
       break;
     case InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT:
       std::cout
@@ -390,7 +420,6 @@ void
 global_dual_residual(Results<T>& qpresults,
                      Workspace<T>& qpwork,
                      const Model<T>& qpmodel,
-                     const Settings<T>& qpsettings,
                      const bool box_constraints,
                      const preconditioner::RuizEquilibration<T>& ruiz,
                      T& dual_feasibility_lhs,
@@ -398,7 +427,8 @@ global_dual_residual(Results<T>& qpresults,
                      T& dual_feasibility_rhs_1,
                      T& dual_feasibility_rhs_3,
                      T& rhs_duality_gap,
-                     T& duality_gap)
+                     T& duality_gap,
+                     const ProblemType& problem_type)
 {
   // dual_feasibility_lhs = norm(dual_residual_scaled)
   // dual_feasibility_rhs_0 = norm(unscaled(Hx))
@@ -409,13 +439,21 @@ global_dual_residual(Results<T>& qpresults,
 
   qpwork.dual_residual_scaled = qpwork.g_scaled;
 
-  switch (qpsettings.problem_type) {
-    case ProblemType::LP:
+  switch (problem_type) {
+    case ProblemType::LinearProgram:
       dual_feasibility_rhs_0 = 0;
       break;
-    case ProblemType::QP:
+    case ProblemType::QuadraticProgram:
       qpwork.CTz.noalias() =
         qpwork.H_scaled.template selfadjointView<Eigen::Lower>() * qpresults.x;
+      qpwork.dual_residual_scaled += qpwork.CTz;
+      ruiz.unscale_dual_residual_in_place(
+        VectorViewMut<T>{ from_eigen, qpwork.CTz }); // contains unscaled Hx
+      dual_feasibility_rhs_0 = infty_norm(qpwork.CTz);
+      break;
+    case ProblemType::DiagonalHessian:
+      qpwork.CTz.array() =
+        qpwork.H_scaled.diagonal().array() * qpresults.x.array();
       qpwork.dual_residual_scaled += qpwork.CTz;
       ruiz.unscale_dual_residual_in_place(
         VectorViewMut<T>{ from_eigen, qpwork.CTz }); // contains unscaled Hx
@@ -425,11 +463,17 @@ global_dual_residual(Results<T>& qpresults,
   ruiz.unscale_primal_in_place(VectorViewMut<T>{ from_eigen, qpresults.x });
   duality_gap = (qpmodel.g).dot(qpresults.x);
   rhs_duality_gap = std::fabs(duality_gap);
-  switch (qpsettings.problem_type) {
-    case ProblemType::LP:
+  T xHx(0);
+  switch (problem_type) {
+    case ProblemType::LinearProgram:
       break;
-    case ProblemType::QP:
-      const T xHx = (qpwork.CTz).dot(qpresults.x);
+    case ProblemType::QuadraticProgram:
+      xHx = (qpwork.CTz).dot(qpresults.x);
+      duality_gap += xHx; // contains now xHx+g.Tx
+      rhs_duality_gap = std::max(rhs_duality_gap, std::abs(xHx));
+      break;
+    case ProblemType::DiagonalHessian:
+      xHx = (qpwork.CTz).dot(qpresults.x);
       duality_gap += xHx; // contains now xHx+g.Tx
       rhs_duality_gap = std::max(rhs_duality_gap, std::abs(xHx));
       break;

--- a/include/proxsuite/proxqp/dense/utils.hpp
+++ b/include/proxsuite/proxqp/dense/utils.hpp
@@ -35,7 +35,7 @@ print_setup_header(const Settings<T>& settings,
                    const Model<T>& model,
                    const bool box_constraints,
                    const DenseBackend& dense_backend,
-                   const HESSIAN_TYPE& hessian_type)
+                   const HessianType& hessian_type)
 {
 
   proxsuite::proxqp::print_preambule();
@@ -76,13 +76,13 @@ print_setup_header(const Settings<T>& settings,
       break;
   }
   switch (hessian_type) {
-    case HESSIAN_TYPE::DENSE:
+    case HessianType::Dense:
       std::cout << "          problem type: Quadratic Program, " << std::endl;
       break;
-    case HESSIAN_TYPE::ZERO:
+    case HessianType::Zero:
       std::cout << "          problem type: Linear Program, " << std::endl;
       break;
-    case HESSIAN_TYPE::DIAGONAL:
+    case HessianType::Diagonal:
       std::cout
         << "          problem type: Quadratic Program with diagonal Hessian, "
         << std::endl;
@@ -428,7 +428,7 @@ global_dual_residual(Results<T>& qpresults,
                      T& dual_feasibility_rhs_3,
                      T& rhs_duality_gap,
                      T& duality_gap,
-                     const HESSIAN_TYPE& hessian_type)
+                     const HessianType& hessian_type)
 {
   // dual_feasibility_lhs = norm(dual_residual_scaled)
   // dual_feasibility_rhs_0 = norm(unscaled(Hx))
@@ -440,10 +440,10 @@ global_dual_residual(Results<T>& qpresults,
   qpwork.dual_residual_scaled = qpwork.g_scaled;
 
   switch (hessian_type) {
-    case HESSIAN_TYPE::ZERO:
+    case HessianType::Zero:
       dual_feasibility_rhs_0 = 0;
       break;
-    case HESSIAN_TYPE::DENSE:
+    case HessianType::Dense:
       qpwork.CTz.noalias() =
         qpwork.H_scaled.template selfadjointView<Eigen::Lower>() * qpresults.x;
       qpwork.dual_residual_scaled += qpwork.CTz;
@@ -451,7 +451,7 @@ global_dual_residual(Results<T>& qpresults,
         VectorViewMut<T>{ from_eigen, qpwork.CTz }); // contains unscaled Hx
       dual_feasibility_rhs_0 = infty_norm(qpwork.CTz);
       break;
-    case HESSIAN_TYPE::DIAGONAL:
+    case HessianType::Diagonal:
       qpwork.CTz.array() =
         qpwork.H_scaled.diagonal().array() * qpresults.x.array();
       qpwork.dual_residual_scaled += qpwork.CTz;
@@ -465,14 +465,14 @@ global_dual_residual(Results<T>& qpresults,
   rhs_duality_gap = std::fabs(duality_gap);
   T xHx(0);
   switch (hessian_type) {
-    case HESSIAN_TYPE::ZERO:
+    case HessianType::Zero:
       break;
-    case HESSIAN_TYPE::DENSE:
+    case HessianType::Dense:
       xHx = (qpwork.CTz).dot(qpresults.x);
       duality_gap += xHx; // contains now xHx+g.Tx
       rhs_duality_gap = std::max(rhs_duality_gap, std::abs(xHx));
       break;
-    case HESSIAN_TYPE::DIAGONAL:
+    case HessianType::Diagonal:
       xHx = (qpwork.CTz).dot(qpresults.x);
       duality_gap += xHx; // contains now xHx+g.Tx
       rhs_duality_gap = std::max(rhs_duality_gap, std::abs(xHx));

--- a/include/proxsuite/proxqp/dense/utils.hpp
+++ b/include/proxsuite/proxqp/dense/utils.hpp
@@ -35,7 +35,7 @@ print_setup_header(const Settings<T>& settings,
                    const Model<T>& model,
                    const bool box_constraints,
                    const DenseBackend& dense_backend,
-                   const HESSIAN_TYPE& problem_type)
+                   const HESSIAN_TYPE& hessian_type)
 {
 
   proxsuite::proxqp::print_preambule();
@@ -75,7 +75,7 @@ print_setup_header(const Settings<T>& settings,
     case DenseBackend::Automatic:
       break;
   }
-  switch (problem_type) {
+  switch (hessian_type) {
     case HESSIAN_TYPE::DENSE:
       std::cout << "          problem type: Quadratic Program, " << std::endl;
       break;
@@ -428,7 +428,7 @@ global_dual_residual(Results<T>& qpresults,
                      T& dual_feasibility_rhs_3,
                      T& rhs_duality_gap,
                      T& duality_gap,
-                     const HESSIAN_TYPE& problem_type)
+                     const HESSIAN_TYPE& hessian_type)
 {
   // dual_feasibility_lhs = norm(dual_residual_scaled)
   // dual_feasibility_rhs_0 = norm(unscaled(Hx))
@@ -439,7 +439,7 @@ global_dual_residual(Results<T>& qpresults,
 
   qpwork.dual_residual_scaled = qpwork.g_scaled;
 
-  switch (problem_type) {
+  switch (hessian_type) {
     case HESSIAN_TYPE::ZERO:
       dual_feasibility_rhs_0 = 0;
       break;
@@ -464,7 +464,7 @@ global_dual_residual(Results<T>& qpresults,
   duality_gap = (qpmodel.g).dot(qpresults.x);
   rhs_duality_gap = std::fabs(duality_gap);
   T xHx(0);
-  switch (problem_type) {
+  switch (hessian_type) {
     case HESSIAN_TYPE::ZERO:
       break;
     case HESSIAN_TYPE::DENSE:

--- a/include/proxsuite/proxqp/dense/workspace.hpp
+++ b/include/proxsuite/proxqp/dense/workspace.hpp
@@ -11,8 +11,7 @@
 #include <proxsuite/linalg/dense/ldlt.hpp>
 #include <proxsuite/proxqp/timings.hpp>
 #include <proxsuite/linalg/veg/vec.hpp>
-// #include <proxsuite/proxqp/dense/preconditioner/ruiz.hpp>
-
+#include <proxsuite/proxqp/settings.hpp>
 namespace proxsuite {
 namespace proxqp {
 namespace dense {
@@ -107,12 +106,10 @@ struct Workspace
   Workspace(isize dim = 0,
             isize n_eq = 0,
             isize n_in = 0,
-            bool box_constraints = false)
-    : //
-      // ruiz(preconditioner::RuizEquilibration<T>{dim, n_eq + n_in}),
-    ldl{}
-    , // old version with alloc
-    H_scaled(dim, dim)
+            bool box_constraints = false,
+            DenseBackend dense_backend = DenseBackend::PrimalDualLdl)
+    : ldl{}
+    , H_scaled(dim, dim)
     , g_scaled(dim)
     , A_scaled(n_eq, dim)
     , C_scaled(n_in, dim)
@@ -121,7 +118,6 @@ struct Workspace
     , l_scaled(n_in)
     , x_prev(dim)
     , y_prev(n_eq)
-    , kkt(dim + n_eq, dim + n_eq)
     , Hdx(dim)
     , Adx(n_eq)
     , dual_residual_scaled(dim)
@@ -144,32 +140,67 @@ struct Workspace
       i_scaled.setOnes();
 
       z_prev.resize(dim + n_in);
-      ldl.reserve_uninit(dim + n_eq + n_in + dim);
-      ldl_stack.resize_for_overwrite(
-        proxsuite::linalg::veg::dynstack::StackReq(
+      // TODO appropriate heuristic for automatic choice
+      switch (dense_backend) {
+        case DenseBackend::PrimalDualLdl:
+          kkt.resize(dim + n_eq, dim + n_eq);
+          ldl.reserve_uninit(dim + n_eq + n_in + dim);
+          ldl_stack.resize_for_overwrite(
+            proxsuite::linalg::veg::dynstack::StackReq(
+              // optimize here
+              proxsuite::linalg::dense::Ldlt<T>::factorize_req(dim + n_eq +
+                                                               n_in + dim) |
 
-          proxsuite::linalg::dense::Ldlt<T>::factorize_req(dim + n_eq + n_in +
-                                                           dim) |
+              (proxsuite::linalg::dense::temp_vec_req(
+                 proxsuite::linalg::veg::Tag<T>{}, n_eq + n_in + dim) &
+               proxsuite::linalg::veg::dynstack::StackReq{
+                 isize{ sizeof(isize) } * (n_eq + n_in + dim),
+                 alignof(isize) } &
+               proxsuite::linalg::dense::Ldlt<T>::diagonal_update_req(
+                 dim + n_eq + n_in + dim, n_eq + n_in + dim)) |
 
-          (proxsuite::linalg::dense::temp_vec_req(
-             proxsuite::linalg::veg::Tag<T>{}, n_eq + n_in + dim) &
-           proxsuite::linalg::veg::dynstack::StackReq{
-             isize{ sizeof(isize) } * (n_eq + n_in + dim), alignof(isize) } &
-           proxsuite::linalg::dense::Ldlt<T>::diagonal_update_req(
-             dim + n_eq + n_in + dim, n_eq + n_in + dim)) |
+              (proxsuite::linalg::dense::temp_mat_req(
+                 proxsuite::linalg::veg::Tag<T>{},
+                 dim + n_eq + n_in + dim,
+                 n_in + dim) &
+               proxsuite::linalg::dense::Ldlt<T>::insert_block_at_req(
+                 dim + n_eq + n_in + dim, n_in + dim)) |
 
-          (proxsuite::linalg::dense::temp_mat_req(
-             proxsuite::linalg::veg::Tag<T>{},
-             dim + n_eq + n_in + dim,
-             n_in + dim) &
-           proxsuite::linalg::dense::Ldlt<T>::insert_block_at_req(
-             dim + n_eq + n_in + dim, n_in + dim)) |
+              proxsuite::linalg::dense::Ldlt<T>::solve_in_place_req(dim + n_eq +
+                                                                    n_in + dim))
+              // TODO optimize here
+              .alloc_req());
+          break;
+        case DenseBackend::PrimalLdl:
+          kkt.resize(dim, dim);
+          ldl.reserve_uninit(dim);
+          ldl_stack.resize_for_overwrite(
+            proxsuite::linalg::veg::dynstack::StackReq(
 
-          proxsuite::linalg::dense::Ldlt<T>::solve_in_place_req(dim + n_eq +
-                                                                n_in + dim))
+              proxsuite::linalg::dense::Ldlt<T>::factorize_req(dim) |
+              // check simplification possible
+              (proxsuite::linalg::dense::temp_vec_req(
+                 proxsuite::linalg::veg::Tag<T>{}, n_eq + n_in + dim) &
+               proxsuite::linalg::veg::dynstack::StackReq{
+                 isize{ sizeof(isize) } * (n_eq + n_in + dim),
+                 alignof(isize) } &
+               proxsuite::linalg::dense::Ldlt<T>::diagonal_update_req(
+                 dim + n_eq + n_in + dim, n_eq + n_in + dim)) |
 
-          .alloc_req());
+              (proxsuite::linalg::dense::temp_mat_req(
+                 proxsuite::linalg::veg::Tag<T>{},
+                 dim + n_eq + n_in + dim,
+                 n_in + dim) &
+               proxsuite::linalg::dense::Ldlt<T>::insert_block_at_req(
+                 dim + n_eq + n_in + dim, n_in + dim)) |
+              // end check
+              proxsuite::linalg::dense::Ldlt<T>::solve_in_place_req(dim))
 
+              .alloc_req());
+          break;
+        case DenseBackend::Automatic:
+          break;
+      }
       current_bijection_map.resize(n_in + dim);
       new_bijection_map.resize(n_in + dim);
       for (isize i = 0; i < n_in + dim; i++) {
@@ -191,28 +222,60 @@ struct Workspace
       alphas.reserve(2 * n_in + 2 * dim);
     } else {
       z_prev.resize(n_in);
-      ldl.reserve_uninit(dim + n_eq + n_in);
-      ldl_stack.resize_for_overwrite(
-        proxsuite::linalg::veg::dynstack::StackReq(
 
-          proxsuite::linalg::dense::Ldlt<T>::factorize_req(dim + n_eq + n_in) |
+      switch (dense_backend) {
+        case DenseBackend::PrimalDualLdl:
+          kkt.resize(dim + n_eq, dim + n_eq);
+          ldl.reserve_uninit(dim + n_eq + n_in);
+          ldl_stack.resize_for_overwrite(
+            proxsuite::linalg::veg::dynstack::StackReq(
+              // todo optimize here
+              proxsuite::linalg::dense::Ldlt<T>::factorize_req(dim + n_eq +
+                                                               n_in) |
 
-          (proxsuite::linalg::dense::temp_vec_req(
-             proxsuite::linalg::veg::Tag<T>{}, n_eq + n_in) &
-           proxsuite::linalg::veg::dynstack::StackReq{
-             isize{ sizeof(isize) } * (n_eq + n_in), alignof(isize) } &
-           proxsuite::linalg::dense::Ldlt<T>::diagonal_update_req(
-             dim + n_eq + n_in, n_eq + n_in)) |
+              (proxsuite::linalg::dense::temp_vec_req(
+                 proxsuite::linalg::veg::Tag<T>{}, n_eq + n_in) &
+               proxsuite::linalg::veg::dynstack::StackReq{
+                 isize{ sizeof(isize) } * (n_eq + n_in), alignof(isize) } &
+               proxsuite::linalg::dense::Ldlt<T>::diagonal_update_req(
+                 dim + n_eq + n_in, n_eq + n_in)) |
 
-          (proxsuite::linalg::dense::temp_mat_req(
-             proxsuite::linalg::veg::Tag<T>{}, dim + n_eq + n_in, n_in) &
-           proxsuite::linalg::dense::Ldlt<T>::insert_block_at_req(
-             dim + n_eq + n_in, n_in)) |
+              (proxsuite::linalg::dense::temp_mat_req(
+                 proxsuite::linalg::veg::Tag<T>{}, dim + n_eq + n_in, n_in) &
+               proxsuite::linalg::dense::Ldlt<T>::insert_block_at_req(
+                 dim + n_eq + n_in, n_in)) |
 
-          proxsuite::linalg::dense::Ldlt<T>::solve_in_place_req(dim + n_eq +
-                                                                n_in))
+              proxsuite::linalg::dense::Ldlt<T>::solve_in_place_req(dim + n_eq +
+                                                                    n_in))
+              // end todo optimize here
+              .alloc_req());
+          break;
+        case DenseBackend::PrimalLdl:
+          kkt.resize(dim, dim);
+          ldl.reserve_uninit(dim);
+          ldl_stack.resize_for_overwrite(
+            proxsuite::linalg::veg::dynstack::StackReq(
 
-          .alloc_req());
+              proxsuite::linalg::dense::Ldlt<T>::factorize_req(dim) |
+              // check if it can be more simplified
+              (proxsuite::linalg::dense::temp_vec_req(
+                 proxsuite::linalg::veg::Tag<T>{}, n_eq + n_in) &
+               proxsuite::linalg::veg::dynstack::StackReq{
+                 isize{ sizeof(isize) } * (n_eq + n_in), alignof(isize) } &
+               proxsuite::linalg::dense::Ldlt<T>::diagonal_update_req(
+                 dim + n_eq + n_in, n_eq + n_in)) |
+              (proxsuite::linalg::dense::temp_mat_req(
+                 proxsuite::linalg::veg::Tag<T>{}, dim + n_eq + n_in, n_in) &
+               proxsuite::linalg::dense::Ldlt<T>::insert_block_at_req(
+                 dim + n_eq + n_in, n_in)) |
+              // end check
+              proxsuite::linalg::dense::Ldlt<T>::solve_in_place_req(dim))
+
+              .alloc_req());
+          break;
+        case DenseBackend::Automatic:
+          break;
+      }
 
       current_bijection_map.resize(n_in);
       new_bijection_map.resize(n_in);

--- a/include/proxsuite/proxqp/dense/workspace.hpp
+++ b/include/proxsuite/proxqp/dense/workspace.hpp
@@ -107,7 +107,7 @@ struct Workspace
             isize n_eq = 0,
             isize n_in = 0,
             bool box_constraints = false,
-            DenseBackend dense_backend = DenseBackend::PrimalDualLdl)
+            DenseBackend dense_backend = DenseBackend::PrimalDualLDLT)
     : ldl{}
     , H_scaled(dim, dim)
     , g_scaled(dim)
@@ -142,7 +142,7 @@ struct Workspace
       z_prev.resize(dim + n_in);
       // TODO appropriate heuristic for automatic choice
       switch (dense_backend) {
-        case DenseBackend::PrimalDualLdl:
+        case DenseBackend::PrimalDualLDLT:
           kkt.resize(dim + n_eq, dim + n_eq);
           ldl.reserve_uninit(dim + n_eq + n_in + dim);
           ldl_stack.resize_for_overwrite(
@@ -171,7 +171,7 @@ struct Workspace
               // TODO optimize here
               .alloc_req());
           break;
-        case DenseBackend::PrimalLdl:
+        case DenseBackend::PrimalLDLT:
           kkt.resize(dim, dim);
           ldl.reserve_uninit(dim);
           ldl_stack.resize_for_overwrite(
@@ -224,7 +224,7 @@ struct Workspace
       z_prev.resize(n_in);
 
       switch (dense_backend) {
-        case DenseBackend::PrimalDualLdl:
+        case DenseBackend::PrimalDualLDLT:
           kkt.resize(dim + n_eq, dim + n_eq);
           ldl.reserve_uninit(dim + n_eq + n_in);
           ldl_stack.resize_for_overwrite(
@@ -250,7 +250,7 @@ struct Workspace
               // end todo optimize here
               .alloc_req());
           break;
-        case DenseBackend::PrimalLdl:
+        case DenseBackend::PrimalLDLT:
           kkt.resize(dim, dim);
           ldl.reserve_uninit(dim);
           ldl_stack.resize_for_overwrite(

--- a/include/proxsuite/proxqp/dense/wrapper.hpp
+++ b/include/proxsuite/proxqp/dense/wrapper.hpp
@@ -118,7 +118,7 @@ private:
   // not supposed to change
   DenseBackend dense_backend;
   bool box_constraints;
-  HESSIAN_TYPE problem_type;
+  HESSIAN_TYPE hessian_type;
 
 public:
   Results<T> results;
@@ -132,7 +132,7 @@ public:
    * @param _dim primal variable dimension.
    * @param _n_eq number of equality constraints.
    * @param _n_in number of inequality constraints.
-   * @param _problem_type problem type (QP, LP, DIAGONAL)
+   * @param _hessian_type problem type (QP, LP, DIAGONAL)
    * @param _box_constraints specify that there are (or not) box constraints.
    * @param _dense_backend specify which factorization is used.
    */
@@ -140,7 +140,7 @@ public:
      isize _n_eq,
      isize _n_in,
      bool _box_constraints,
-     proxsuite::proxqp::HESSIAN_TYPE _problem_type,
+     proxsuite::proxqp::HESSIAN_TYPE _hessian_type,
      DenseBackend _dense_backend)
     : dense_backend(dense_backend_choice<T>(_dense_backend,
                                             _dim,
@@ -148,7 +148,7 @@ public:
                                             _n_in,
                                             _box_constraints))
     , box_constraints(_box_constraints)
-    , problem_type(_problem_type)
+    , hessian_type(_hessian_type)
     , results(_dim, _n_eq, _n_in, _box_constraints, dense_backend)
     , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, _box_constraints)
@@ -165,7 +165,7 @@ public:
    * @param _dim primal variable dimension.
    * @param _n_eq number of equality constraints.
    * @param _n_in number of inequality constraints.
-   * @param _problem_type problem type (QP, LP, DIAGONAL)
+   * @param _hessian_type problem type (QP, LP, DIAGONAL)
    * @param _box_constraints specify that there are (or not) box constraints.
    * @param _dense_backend specify which factorization is used.
    */
@@ -174,14 +174,14 @@ public:
      isize _n_in,
      bool _box_constraints,
      DenseBackend _dense_backend,
-     proxsuite::proxqp::HESSIAN_TYPE _problem_type)
+     proxsuite::proxqp::HESSIAN_TYPE _hessian_type)
     : dense_backend(dense_backend_choice<T>(_dense_backend,
                                             _dim,
                                             _n_eq,
                                             _n_in,
                                             _box_constraints))
     , box_constraints(_box_constraints)
-    , problem_type(_problem_type)
+    , hessian_type(_hessian_type)
     , results(_dim, _n_eq, _n_in, _box_constraints, dense_backend)
     , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, _box_constraints)
@@ -198,21 +198,21 @@ public:
    * @param _dim primal variable dimension.
    * @param _n_eq number of equality constraints.
    * @param _n_in number of inequality constraints.
-   * @param _problem_type problem type (QP, LP, DIAGONAL)
+   * @param _hessian_type problem type (QP, LP, DIAGONAL)
    * @param _box_constraints specify that there are (or not) box constraints.
    */
   QP(isize _dim,
      isize _n_eq,
      isize _n_in,
      bool _box_constraints,
-     proxsuite::proxqp::HESSIAN_TYPE _problem_type)
+     proxsuite::proxqp::HESSIAN_TYPE _hessian_type)
     : dense_backend(dense_backend_choice<T>(DenseBackend::Automatic,
                                             _dim,
                                             _n_eq,
                                             _n_in,
                                             _box_constraints))
     , box_constraints(_box_constraints)
-    , problem_type(_problem_type)
+    , hessian_type(_hessian_type)
     , results(_dim, _n_eq, _n_in, _box_constraints, dense_backend)
     , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, _box_constraints)
@@ -229,7 +229,7 @@ public:
    * @param _dim primal variable dimension.
    * @param _n_eq number of equality constraints.
    * @param _n_in number of inequality constraints.
-   * @param _problem_type problem type (QP, LP, DIAGONAL)
+   * @param _hessian_type problem type (QP, LP, DIAGONAL)
    * @param _box_constraints specify that there are (or not) box constraints.
    * @param _dense_backend specify which factorization is used.
    */
@@ -244,7 +244,7 @@ public:
                                             _n_in,
                                             _box_constraints))
     , box_constraints(_box_constraints)
-    , problem_type(HESSIAN_TYPE::DENSE)
+    , hessian_type(HESSIAN_TYPE::DENSE)
     , results(_dim, _n_eq, _n_in, _box_constraints, dense_backend)
     , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, _box_constraints)
@@ -270,7 +270,7 @@ public:
                                             _n_in,
                                             _box_constraints))
     , box_constraints(_box_constraints)
-    , problem_type(proxsuite::proxqp::HESSIAN_TYPE::DENSE)
+    , hessian_type(proxsuite::proxqp::HESSIAN_TYPE::DENSE)
     , results(_dim, _n_eq, _n_in, _box_constraints, dense_backend)
     , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, _box_constraints)
@@ -287,19 +287,19 @@ public:
    * @param _dim primal variable dimension.
    * @param _n_eq number of equality constraints.
    * @param _n_in number of inequality constraints.
-   * @param _problem_type specify that there are (or not) box constraints.
+   * @param _hessian_type specify that there are (or not) box constraints.
    */
   QP(isize _dim,
      isize _n_eq,
      isize _n_in,
-     proxsuite::proxqp::HESSIAN_TYPE _problem_type)
+     proxsuite::proxqp::HESSIAN_TYPE _hessian_type)
     : dense_backend(dense_backend_choice<T>(DenseBackend::Automatic,
                                             _dim,
                                             _n_eq,
                                             _n_in,
                                             false))
     , box_constraints(false)
-    , problem_type(_problem_type)
+    , hessian_type(_hessian_type)
     , results(_dim, _n_eq, _n_in, false, dense_backend)
     , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, false)
@@ -321,7 +321,7 @@ public:
                                             _n_in,
                                             false))
     , box_constraints(false)
-    , problem_type(proxsuite::proxqp::HESSIAN_TYPE::DENSE)
+    , hessian_type(proxsuite::proxqp::HESSIAN_TYPE::DENSE)
     , results(_dim, _n_eq, _n_in, false, dense_backend)
     , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, false)
@@ -332,7 +332,7 @@ public:
   }
   bool is_box_constrained() const { return box_constraints; };
   DenseBackend which_dense_backend() const { return dense_backend; };
-  HESSIAN_TYPE which_problem_type() const { return problem_type; };
+  HESSIAN_TYPE which_hessian_type() const { return hessian_type; };
   /*!
    * Setups the QP model (with dense matrix format) and equilibrates it if
    * specified by the user.
@@ -484,7 +484,7 @@ public:
                                     box_constraints,
                                     ruiz,
                                     preconditioner_status,
-                                    problem_type);
+                                    hessian_type);
     work.is_initialized = true;
     if (settings.compute_timings) {
       results.info.setup_time = work.timer.elapsed().user; // in microseconds
@@ -684,7 +684,7 @@ public:
                                     box_constraints,
                                     ruiz,
                                     preconditioner_status,
-                                    problem_type);
+                                    hessian_type);
     work.is_initialized = true;
     if (settings.compute_timings) {
       results.info.setup_time = work.timer.elapsed().user; // in microseconds
@@ -784,7 +784,7 @@ public:
                                     box_constraints,
                                     ruiz,
                                     preconditioner_status,
-                                    problem_type);
+                                    hessian_type);
 
     if (settings.compute_timings) {
       results.info.setup_time = work.timer.elapsed().user; // in microseconds
@@ -890,7 +890,7 @@ public:
                                     box_constraints,
                                     ruiz,
                                     preconditioner_status,
-                                    problem_type);
+                                    hessian_type);
 
     if (settings.compute_timings) {
       results.info.setup_time = work.timer.elapsed().user; // in microseconds
@@ -908,7 +908,7 @@ public:
       work,
       box_constraints,
       dense_backend,
-      problem_type,
+      hessian_type,
       ruiz);
   };
   /*!
@@ -929,7 +929,7 @@ public:
       work,
       box_constraints,
       dense_backend,
-      problem_type,
+      hessian_type,
       ruiz);
   };
   /*!

--- a/include/proxsuite/proxqp/dense/wrapper.hpp
+++ b/include/proxsuite/proxqp/dense/wrapper.hpp
@@ -205,7 +205,11 @@ public:
      isize _n_in,
      bool _box_constraints,
      proxsuite::proxqp::ProblemType _problem_type)
-    : dense_backend(DenseBackend::PrimalDualLdl)
+    : dense_backend(dense_backend_choice<T>(DenseBackend::Automatic,
+                                            _dim,
+                                            _n_eq,
+                                            _n_in,
+                                            _box_constraints))
     , box_constraints(_box_constraints)
     , problem_type(_problem_type)
     , results(_dim, _n_eq, _n_in, _box_constraints, dense_backend)
@@ -259,13 +263,17 @@ public:
    * @param _box_constraints specify that there are (or not) box constraints.
    */
   QP(isize _dim, isize _n_eq, isize _n_in, bool _box_constraints)
-    : dense_backend(DenseBackend::PrimalDualLdl)
+    : dense_backend(dense_backend_choice<T>(DenseBackend::Automatic,
+                                            _dim,
+                                            _n_eq,
+                                            _n_in,
+                                            _box_constraints))
     , box_constraints(_box_constraints)
     , problem_type(proxsuite::proxqp::ProblemType::QuadraticProgram)
-    , results(_dim, _n_eq, _n_in, _box_constraints, DenseBackend::PrimalDualLdl)
-    , settings(DenseBackend::PrimalDualLdl)
+    , results(_dim, _n_eq, _n_in, _box_constraints, dense_backend)
+    , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, _box_constraints)
-    , work(_dim, _n_eq, _n_in, _box_constraints, DenseBackend::PrimalDualLdl)
+    , work(_dim, _n_eq, _n_in, _box_constraints, dense_backend)
     , ruiz(preconditioner::RuizEquilibration<T>{ _dim,
                                                  _n_eq,
                                                  _n_in,
@@ -306,13 +314,17 @@ public:
    * @param _n_in number of inequality constraints.
    */
   QP(isize _dim, isize _n_eq, isize _n_in)
-    : dense_backend(DenseBackend::PrimalDualLdl)
+    : dense_backend(dense_backend_choice<T>(DenseBackend::Automatic,
+                                            _dim,
+                                            _n_eq,
+                                            _n_in,
+                                            false))
     , box_constraints(false)
     , problem_type(proxsuite::proxqp::ProblemType::QuadraticProgram)
-    , results(_dim, _n_eq, _n_in, false, DenseBackend::PrimalDualLdl)
-    , settings(DenseBackend::PrimalDualLdl)
+    , results(_dim, _n_eq, _n_in, false, dense_backend)
+    , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, false)
-    , work(_dim, _n_eq, _n_in, false, DenseBackend::PrimalDualLdl)
+    , work(_dim, _n_eq, _n_in, false, dense_backend)
     , ruiz(preconditioner::RuizEquilibration<T>{ _dim, _n_eq, _n_in, false })
   {
     work.timer.stop();

--- a/include/proxsuite/proxqp/dense/wrapper.hpp
+++ b/include/proxsuite/proxqp/dense/wrapper.hpp
@@ -92,18 +92,19 @@ dense_backend_choice(DenseBackend _dense_backend,
     }
     T threshold(1.5);
     T frequence(0.2);
-    T PrimalDualLdlCost =
+    T PrimalDualLDLTCost =
       0.5 * std::pow(T(n_eq) / T(dim), 2) +
       0.17 * (std::pow(T(n_eq) / T(dim), 3) +
               std::pow(T(n_constraints) / T(dim), 3)) +
       frequence * std::pow(T(n_eq + n_constraints) / T(dim), 2) / T(dim);
-    T PrimalLdlCost = threshold * ((0.5 * T(n_eq) + T(n_constraints)) / T(dim) +
-                                   frequence / T(dim));
-    bool choice = PrimalDualLdlCost > PrimalLdlCost;
+    T PrimalLDLTCost =
+      threshold *
+      ((0.5 * T(n_eq) + T(n_constraints)) / T(dim) + frequence / T(dim));
+    bool choice = PrimalDualLDLTCost > PrimalLDLTCost;
     if (choice) {
-      return DenseBackend::PrimalLdl;
+      return DenseBackend::PrimalLDLT;
     } else {
-      return DenseBackend::PrimalDualLdl;
+      return DenseBackend::PrimalDualLDLT;
     }
   } else {
     return _dense_backend;
@@ -117,7 +118,7 @@ private:
   // not supposed to change
   DenseBackend dense_backend;
   bool box_constraints;
-  ProblemType problem_type;
+  HESSIAN_TYPE problem_type;
 
 public:
   Results<T> results;
@@ -131,7 +132,7 @@ public:
    * @param _dim primal variable dimension.
    * @param _n_eq number of equality constraints.
    * @param _n_in number of inequality constraints.
-   * @param _problem_type problem type (QP, LP, DiagonalHessian)
+   * @param _problem_type problem type (QP, LP, DIAGONAL)
    * @param _box_constraints specify that there are (or not) box constraints.
    * @param _dense_backend specify which factorization is used.
    */
@@ -139,7 +140,7 @@ public:
      isize _n_eq,
      isize _n_in,
      bool _box_constraints,
-     proxsuite::proxqp::ProblemType _problem_type,
+     proxsuite::proxqp::HESSIAN_TYPE _problem_type,
      DenseBackend _dense_backend)
     : dense_backend(dense_backend_choice<T>(_dense_backend,
                                             _dim,
@@ -164,7 +165,7 @@ public:
    * @param _dim primal variable dimension.
    * @param _n_eq number of equality constraints.
    * @param _n_in number of inequality constraints.
-   * @param _problem_type problem type (QP, LP, DiagonalHessian)
+   * @param _problem_type problem type (QP, LP, DIAGONAL)
    * @param _box_constraints specify that there are (or not) box constraints.
    * @param _dense_backend specify which factorization is used.
    */
@@ -173,7 +174,7 @@ public:
      isize _n_in,
      bool _box_constraints,
      DenseBackend _dense_backend,
-     proxsuite::proxqp::ProblemType _problem_type)
+     proxsuite::proxqp::HESSIAN_TYPE _problem_type)
     : dense_backend(dense_backend_choice<T>(_dense_backend,
                                             _dim,
                                             _n_eq,
@@ -197,14 +198,14 @@ public:
    * @param _dim primal variable dimension.
    * @param _n_eq number of equality constraints.
    * @param _n_in number of inequality constraints.
-   * @param _problem_type problem type (QP, LP, DiagonalHessian)
+   * @param _problem_type problem type (QP, LP, DIAGONAL)
    * @param _box_constraints specify that there are (or not) box constraints.
    */
   QP(isize _dim,
      isize _n_eq,
      isize _n_in,
      bool _box_constraints,
-     proxsuite::proxqp::ProblemType _problem_type)
+     proxsuite::proxqp::HESSIAN_TYPE _problem_type)
     : dense_backend(dense_backend_choice<T>(DenseBackend::Automatic,
                                             _dim,
                                             _n_eq,
@@ -228,7 +229,7 @@ public:
    * @param _dim primal variable dimension.
    * @param _n_eq number of equality constraints.
    * @param _n_in number of inequality constraints.
-   * @param _problem_type problem type (QP, LP, DiagonalHessian)
+   * @param _problem_type problem type (QP, LP, DIAGONAL)
    * @param _box_constraints specify that there are (or not) box constraints.
    * @param _dense_backend specify which factorization is used.
    */
@@ -243,7 +244,7 @@ public:
                                             _n_in,
                                             _box_constraints))
     , box_constraints(_box_constraints)
-    , problem_type(ProblemType::QuadraticProgram)
+    , problem_type(HESSIAN_TYPE::DENSE)
     , results(_dim, _n_eq, _n_in, _box_constraints, dense_backend)
     , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, _box_constraints)
@@ -269,7 +270,7 @@ public:
                                             _n_in,
                                             _box_constraints))
     , box_constraints(_box_constraints)
-    , problem_type(proxsuite::proxqp::ProblemType::QuadraticProgram)
+    , problem_type(proxsuite::proxqp::HESSIAN_TYPE::DENSE)
     , results(_dim, _n_eq, _n_in, _box_constraints, dense_backend)
     , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, _box_constraints)
@@ -291,7 +292,7 @@ public:
   QP(isize _dim,
      isize _n_eq,
      isize _n_in,
-     proxsuite::proxqp::ProblemType _problem_type)
+     proxsuite::proxqp::HESSIAN_TYPE _problem_type)
     : dense_backend(dense_backend_choice<T>(DenseBackend::Automatic,
                                             _dim,
                                             _n_eq,
@@ -320,7 +321,7 @@ public:
                                             _n_in,
                                             false))
     , box_constraints(false)
-    , problem_type(proxsuite::proxqp::ProblemType::QuadraticProgram)
+    , problem_type(proxsuite::proxqp::HESSIAN_TYPE::DENSE)
     , results(_dim, _n_eq, _n_in, false, dense_backend)
     , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, false)
@@ -331,7 +332,7 @@ public:
   }
   bool is_box_constrained() const { return box_constraints; };
   DenseBackend which_dense_backend() const { return dense_backend; };
-  ProblemType which_problem_type() const { return problem_type; };
+  HESSIAN_TYPE which_problem_type() const { return problem_type; };
   /*!
    * Setups the QP model (with dense matrix format) and equilibrates it if
    * specified by the user.
@@ -1017,7 +1018,7 @@ solve(
     n_in = C.value().rows();
   }
 
-  QP<T> Qp(n, n_eq, n_in, false, DenseBackend::PrimalDualLdl);
+  QP<T> Qp(n, n_eq, n_in, false, DenseBackend::PrimalDualLDLT);
   Qp.settings.initial_guess = initial_guess;
   Qp.settings.check_duality_gap = check_duality_gap;
 
@@ -1130,7 +1131,7 @@ solve(
     n_in = C.value().rows();
   }
 
-  QP<T> Qp(n, n_eq, n_in, true, DenseBackend::PrimalDualLdl);
+  QP<T> Qp(n, n_eq, n_in, true, DenseBackend::PrimalDualLDLT);
   Qp.settings.initial_guess = initial_guess;
   Qp.settings.check_duality_gap = check_duality_gap;
 

--- a/include/proxsuite/proxqp/dense/wrapper.hpp
+++ b/include/proxsuite/proxqp/dense/wrapper.hpp
@@ -118,7 +118,7 @@ private:
   // not supposed to change
   DenseBackend dense_backend;
   bool box_constraints;
-  HESSIAN_TYPE hessian_type;
+  HessianType hessian_type;
 
 public:
   Results<T> results;
@@ -140,7 +140,7 @@ public:
      isize _n_eq,
      isize _n_in,
      bool _box_constraints,
-     proxsuite::proxqp::HESSIAN_TYPE _hessian_type,
+     proxsuite::proxqp::HessianType _hessian_type,
      DenseBackend _dense_backend)
     : dense_backend(dense_backend_choice<T>(_dense_backend,
                                             _dim,
@@ -174,7 +174,7 @@ public:
      isize _n_in,
      bool _box_constraints,
      DenseBackend _dense_backend,
-     proxsuite::proxqp::HESSIAN_TYPE _hessian_type)
+     proxsuite::proxqp::HessianType _hessian_type)
     : dense_backend(dense_backend_choice<T>(_dense_backend,
                                             _dim,
                                             _n_eq,
@@ -205,7 +205,7 @@ public:
      isize _n_eq,
      isize _n_in,
      bool _box_constraints,
-     proxsuite::proxqp::HESSIAN_TYPE _hessian_type)
+     proxsuite::proxqp::HessianType _hessian_type)
     : dense_backend(dense_backend_choice<T>(DenseBackend::Automatic,
                                             _dim,
                                             _n_eq,
@@ -244,7 +244,7 @@ public:
                                             _n_in,
                                             _box_constraints))
     , box_constraints(_box_constraints)
-    , hessian_type(HESSIAN_TYPE::DENSE)
+    , hessian_type(HessianType::Dense)
     , results(_dim, _n_eq, _n_in, _box_constraints, dense_backend)
     , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, _box_constraints)
@@ -270,7 +270,7 @@ public:
                                             _n_in,
                                             _box_constraints))
     , box_constraints(_box_constraints)
-    , hessian_type(proxsuite::proxqp::HESSIAN_TYPE::DENSE)
+    , hessian_type(proxsuite::proxqp::HessianType::Dense)
     , results(_dim, _n_eq, _n_in, _box_constraints, dense_backend)
     , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, _box_constraints)
@@ -292,7 +292,7 @@ public:
   QP(isize _dim,
      isize _n_eq,
      isize _n_in,
-     proxsuite::proxqp::HESSIAN_TYPE _hessian_type)
+     proxsuite::proxqp::HessianType _hessian_type)
     : dense_backend(dense_backend_choice<T>(DenseBackend::Automatic,
                                             _dim,
                                             _n_eq,
@@ -321,7 +321,7 @@ public:
                                             _n_in,
                                             false))
     , box_constraints(false)
-    , hessian_type(proxsuite::proxqp::HESSIAN_TYPE::DENSE)
+    , hessian_type(proxsuite::proxqp::HessianType::Dense)
     , results(_dim, _n_eq, _n_in, false, dense_backend)
     , settings(dense_backend)
     , model(_dim, _n_eq, _n_in, false)
@@ -332,7 +332,7 @@ public:
   }
   bool is_box_constrained() const { return box_constraints; };
   DenseBackend which_dense_backend() const { return dense_backend; };
-  HESSIAN_TYPE which_hessian_type() const { return hessian_type; };
+  HessianType which_hessian_type() const { return hessian_type; };
   /*!
    * Setups the QP model (with dense matrix format) and equilibrates it if
    * specified by the user.

--- a/include/proxsuite/proxqp/results.hpp
+++ b/include/proxsuite/proxqp/results.hpp
@@ -82,7 +82,8 @@ struct Results
   Results(isize dim = 0,
           isize n_eq = 0,
           isize n_in = 0,
-          bool box_constraints = false)
+          bool box_constraints = false,
+          DenseBackend dense_backend = DenseBackend::PrimalDualLdl)
     : x(dim)
     , y(n_eq)
   {
@@ -94,8 +95,17 @@ struct Results
     x.setZero();
     y.setZero();
     z.setZero();
-
-    info.rho = 1e-6;
+    switch (dense_backend) {
+      case DenseBackend::PrimalDualLdl:
+        info.rho = 1e-6;
+        break;
+      case DenseBackend::PrimalLdl:
+        info.rho = 1.E-5;
+        break;
+      case DenseBackend::Automatic:
+        info.rho = 1.E-6;
+        break;
+    }
     info.mu_eq_inv = 1e3;
     info.mu_eq = 1e-3;
     info.mu_in_inv = 1e1;

--- a/include/proxsuite/proxqp/results.hpp
+++ b/include/proxsuite/proxqp/results.hpp
@@ -83,7 +83,7 @@ struct Results
           isize n_eq = 0,
           isize n_in = 0,
           bool box_constraints = false,
-          DenseBackend dense_backend = DenseBackend::PrimalDualLdl)
+          DenseBackend dense_backend = DenseBackend::PrimalDualLDLT)
     : x(dim)
     , y(n_eq)
   {
@@ -96,10 +96,10 @@ struct Results
     y.setZero();
     z.setZero();
     switch (dense_backend) {
-      case DenseBackend::PrimalDualLdl:
+      case DenseBackend::PrimalDualLDLT:
         info.rho = 1e-6;
         break;
-      case DenseBackend::PrimalLdl:
+      case DenseBackend::PrimalLDLT:
         info.rho = 1.E-5;
         break;
       case DenseBackend::Automatic:

--- a/include/proxsuite/proxqp/settings.hpp
+++ b/include/proxsuite/proxqp/settings.hpp
@@ -37,11 +37,11 @@ enum struct MeritFunctionType
   PDAL,  // Primal Dual Augmented Lagrangian
 };
 // COST FUNCTION TYPE
-enum struct HESSIAN_TYPE
+enum struct HessianType
 {
-  ZERO,    // Linear Program
-  DENSE,   // Quadratic Program
-  DIAGONAL // Quadratic Program with diagonal Hessian
+  Zero,    // Linear Program
+  Dense,   // Quadratic Program
+  Diagonal // Quadratic Program with diagonal Hessian
 };
 inline std::ostream&
 operator<<(std::ostream& os, const SparseBackend& sparse_backend)

--- a/include/proxsuite/proxqp/settings.hpp
+++ b/include/proxsuite/proxqp/settings.hpp
@@ -26,8 +26,8 @@ enum struct SparseBackend
 enum struct DenseBackend
 {
   Automatic,     // the solver will select the appropriate dense backend.
-  PrimalDualLdl, // Factorization of the regularized KKT matrix.
-  PrimalLdl,     // Factorize the H+rho I + mu_inv ATA + etc..
+  PrimalDualLDLT, // Factorization of the full regularized KKT matrix.
+  PrimalLDLT,     // Factorize only the primal Hessian corresponding to H+rho I + 1/mu AT*A.
 };
 // MERIT FUNCTION
 enum struct MeritFunctionType

--- a/include/proxsuite/proxqp/settings.hpp
+++ b/include/proxsuite/proxqp/settings.hpp
@@ -37,11 +37,11 @@ enum struct MeritFunctionType
   PDAL,  // Primal Dual Augmented Lagrangian
 };
 // COST FUNCTION TYPE
-enum struct ProblemType
+enum struct HESSIAN_TYPE
 {
-  LinearProgram,    // Linear Program
-  QuadraticProgram, // Quadratic Program
-  DiagonalHessian   // Quadratic Program with diagonal Hessian
+  ZERO,    // Linear Program
+  DENSE,   // Quadratic Program
+  DIAGONAL // Quadratic Program with diagonal Hessian
 };
 inline std::ostream&
 operator<<(std::ostream& os, const SparseBackend& sparse_backend)
@@ -58,10 +58,10 @@ operator<<(std::ostream& os, const SparseBackend& sparse_backend)
 inline std::ostream&
 operator<<(std::ostream& os, const DenseBackend& dense_backend)
 {
-  if (dense_backend == DenseBackend::PrimalDualLdl) {
-    os << "PrimalDualLdl";
-  } else if (dense_backend == DenseBackend::PrimalLdl) {
-    os << "PrimalLdl";
+  if (dense_backend == DenseBackend::PrimalDualLDLT) {
+    os << "PrimalDualLDLT";
+  } else if (dense_backend == DenseBackend::PrimalLDLT) {
+    os << "PrimalLDLT";
   } else {
     os << "Automatic";
   }
@@ -192,7 +192,7 @@ struct Settings
    */
 
   Settings(
-    DenseBackend dense_backend = DenseBackend::PrimalDualLdl,
+    DenseBackend dense_backend = DenseBackend::PrimalDualLDLT,
     T default_mu_eq = 1.E-3,
     T default_mu_in = 1.E-1,
     T alpha_bcl = 0.1,
@@ -277,10 +277,10 @@ struct Settings
     , sparse_backend(sparse_backend)
   {
     switch (dense_backend) {
-      case DenseBackend::PrimalDualLdl:
+      case DenseBackend::PrimalDualLDLT:
         default_rho = 1.E-6;
         break;
-      case DenseBackend::PrimalLdl:
+      case DenseBackend::PrimalLDLT:
         default_rho = 1.E-5;
         break;
       case DenseBackend::Automatic:

--- a/include/proxsuite/proxqp/settings.hpp
+++ b/include/proxsuite/proxqp/settings.hpp
@@ -25,9 +25,10 @@ enum struct SparseBackend
 // Sparse backend specifications
 enum struct DenseBackend
 {
-  Automatic,     // the solver will select the appropriate dense backend.
+  Automatic,      // the solver will select the appropriate dense backend.
   PrimalDualLDLT, // Factorization of the full regularized KKT matrix.
-  PrimalLDLT,     // Factorize only the primal Hessian corresponding to H+rho I + 1/mu AT*A.
+  PrimalLDLT, // Factorize only the primal Hessian corresponding to H+rho I +
+              // 1/mu AT*A.
 };
 // MERIT FUNCTION
 enum struct MeritFunctionType

--- a/test/src/dense_maros_meszaros.cpp
+++ b/test/src/dense_maros_meszaros.cpp
@@ -86,6 +86,8 @@ TEST_CASE("dense maros meszaros using the api")
 {
   using T = double;
   using isize = proxqp::utils::isize;
+  proxsuite::proxqp::Timer<T> timer;
+  T elapsed_time = 0.0;
 
   for (auto const* file : files) {
     auto qp = load_qp(file);
@@ -115,12 +117,16 @@ TEST_CASE("dense maros meszaros using the api")
       isize dim = H.rows();
       isize n_eq = A.rows();
       isize n_in = C.rows();
-
-      proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+      timer.stop();
+      timer.start();
+      proxqp::dense::QP<T> qp{
+        dim, n_eq, n_in, false, proxsuite::proxqp::DenseBackend::Automatic
+      }; // creating QP object
       qp.init(H, g, A, b, C, l, u);
 
       qp.settings.eps_abs = 2e-8;
       qp.settings.eps_rel = 0;
+      // qp.settings.verbose = true;
       auto& eps = qp.settings.eps_abs;
 
       for (size_t it = 0; it < 2; ++it) {
@@ -153,6 +159,9 @@ TEST_CASE("dense maros meszaros using the api")
           CHECK(qp.results.info.iter == 0);
         }
       }
+      timer.stop();
+      elapsed_time += timer.elapsed().user;
     }
   }
+  std::cout << "timings total : \t" << elapsed_time * 1e-3 << "ms" << std::endl;
 }

--- a/test/src/dense_qp_eq.cpp
+++ b/test/src/dense_qp_eq.cpp
@@ -180,7 +180,7 @@ DOCTEST_TEST_CASE("linear problem with equality with equality constraints and "
     qp_random.g = -qp_random.A.transpose() * y_sol;
 
     proxqp::dense::QP<T> qp{
-      dim, n_eq, n_in, proxqp::ProblemType::LinearProgram
+      dim, n_eq, n_in, proxqp::HESSIAN_TYPE::ZERO
     }; // creating QP object
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;

--- a/test/src/dense_qp_eq.cpp
+++ b/test/src/dense_qp_eq.cpp
@@ -180,7 +180,7 @@ DOCTEST_TEST_CASE("linear problem with equality with equality constraints and "
     qp_random.g = -qp_random.A.transpose() * y_sol;
 
     proxqp::dense::QP<T> qp{
-      dim, n_eq, n_in, proxqp::HESSIAN_TYPE::ZERO
+      dim, n_eq, n_in, proxqp::HessianType::Zero
     }; // creating QP object
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;

--- a/test/src/dense_qp_eq.cpp
+++ b/test/src/dense_qp_eq.cpp
@@ -179,10 +179,11 @@ DOCTEST_TEST_CASE("linear problem with equality with equality constraints and "
       n_eq); // make sure the LP is bounded within the feasible set
     qp_random.g = -qp_random.A.transpose() * y_sol;
 
-    proxqp::dense::QP<T> qp{ dim, n_eq, n_in }; // creating QP object
+    proxqp::dense::QP<T> qp{
+      dim, n_eq, n_in, proxqp::ProblemType::LinearProgram
+    }; // creating QP object
     qp.settings.eps_abs = eps_abs;
     qp.settings.eps_rel = 0;
-    qp.settings.problem_type = proxqp::ProblemType::LP;
     qp.init(qp_random.H,
             qp_random.g,
             qp_random.A,

--- a/test/src/sparse_ruiz_equilibration.cpp
+++ b/test/src/sparse_ruiz_equilibration.cpp
@@ -74,7 +74,7 @@ TEST_CASE("upper part")
     settings.preconditioner_max_iter,
     settings.preconditioner_accuracy,
     stack);
-  HESSIAN_TYPE hessian_type(proxsuite::proxqp::HESSIAN_TYPE::DENSE);
+  HessianType HessianType(proxsuite::proxqp::HessianType::Dense);
   ruiz_dense.scale_qp_in_place(
     proxqp::dense::QpViewBoxMut<T>{
       { proxqp::from_eigen, H_scaled_dense },
@@ -91,7 +91,7 @@ TEST_CASE("upper part")
     execute_preconditioner,
     settings.preconditioner_max_iter,
     settings.preconditioner_accuracy,
-    hessian_type,
+    HessianType,
     box_constraints,
     stack);
 
@@ -165,7 +165,7 @@ TEST_CASE("lower part")
   proxqp::dense::Vec<T> u_scaled_box(0);
   proxqp::dense::Vec<T> l_scaled_box(0);
   proxqp::dense::Vec<T> eye(0);
-  HESSIAN_TYPE hessian_type(HESSIAN_TYPE::DENSE);
+  HessianType HessianType(HessianType::Dense);
   ruiz_dense.scale_qp_in_place(
     proxqp::dense::QpViewBoxMut<T>{
       { proxqp::from_eigen, H_scaled_dense },
@@ -182,7 +182,7 @@ TEST_CASE("lower part")
     execute_preconditioner,
     settings.preconditioner_max_iter,
     settings.preconditioner_accuracy,
-    hessian_type,
+    HessianType,
     box_constraints,
     stack);
 

--- a/test/src/sparse_ruiz_equilibration.cpp
+++ b/test/src/sparse_ruiz_equilibration.cpp
@@ -74,7 +74,7 @@ TEST_CASE("upper part")
     settings.preconditioner_max_iter,
     settings.preconditioner_accuracy,
     stack);
-  ProblemType problem_type(proxsuite::proxqp::ProblemType::QuadraticProgram);
+  HESSIAN_TYPE problem_type(proxsuite::proxqp::HESSIAN_TYPE::DENSE);
   ruiz_dense.scale_qp_in_place(
     proxqp::dense::QpViewBoxMut<T>{
       { proxqp::from_eigen, H_scaled_dense },
@@ -165,7 +165,7 @@ TEST_CASE("lower part")
   proxqp::dense::Vec<T> u_scaled_box(0);
   proxqp::dense::Vec<T> l_scaled_box(0);
   proxqp::dense::Vec<T> eye(0);
-  ProblemType problem_type(ProblemType::QuadraticProgram);
+  HESSIAN_TYPE problem_type(HESSIAN_TYPE::DENSE);
   ruiz_dense.scale_qp_in_place(
     proxqp::dense::QpViewBoxMut<T>{
       { proxqp::from_eigen, H_scaled_dense },

--- a/test/src/sparse_ruiz_equilibration.cpp
+++ b/test/src/sparse_ruiz_equilibration.cpp
@@ -74,6 +74,7 @@ TEST_CASE("upper part")
     settings.preconditioner_max_iter,
     settings.preconditioner_accuracy,
     stack);
+  ProblemType problem_type(proxsuite::proxqp::ProblemType::QuadraticProgram);
   ruiz_dense.scale_qp_in_place(
     proxqp::dense::QpViewBoxMut<T>{
       { proxqp::from_eigen, H_scaled_dense },
@@ -90,7 +91,7 @@ TEST_CASE("upper part")
     execute_preconditioner,
     settings.preconditioner_max_iter,
     settings.preconditioner_accuracy,
-    settings.problem_type,
+    problem_type,
     box_constraints,
     stack);
 
@@ -164,6 +165,7 @@ TEST_CASE("lower part")
   proxqp::dense::Vec<T> u_scaled_box(0);
   proxqp::dense::Vec<T> l_scaled_box(0);
   proxqp::dense::Vec<T> eye(0);
+  ProblemType problem_type(ProblemType::QuadraticProgram);
   ruiz_dense.scale_qp_in_place(
     proxqp::dense::QpViewBoxMut<T>{
       { proxqp::from_eigen, H_scaled_dense },
@@ -180,7 +182,7 @@ TEST_CASE("lower part")
     execute_preconditioner,
     settings.preconditioner_max_iter,
     settings.preconditioner_accuracy,
-    settings.problem_type,
+    problem_type,
     box_constraints,
     stack);
 

--- a/test/src/sparse_ruiz_equilibration.cpp
+++ b/test/src/sparse_ruiz_equilibration.cpp
@@ -74,7 +74,7 @@ TEST_CASE("upper part")
     settings.preconditioner_max_iter,
     settings.preconditioner_accuracy,
     stack);
-  HESSIAN_TYPE problem_type(proxsuite::proxqp::HESSIAN_TYPE::DENSE);
+  HESSIAN_TYPE hessian_type(proxsuite::proxqp::HESSIAN_TYPE::DENSE);
   ruiz_dense.scale_qp_in_place(
     proxqp::dense::QpViewBoxMut<T>{
       { proxqp::from_eigen, H_scaled_dense },
@@ -91,7 +91,7 @@ TEST_CASE("upper part")
     execute_preconditioner,
     settings.preconditioner_max_iter,
     settings.preconditioner_accuracy,
-    problem_type,
+    hessian_type,
     box_constraints,
     stack);
 
@@ -165,7 +165,7 @@ TEST_CASE("lower part")
   proxqp::dense::Vec<T> u_scaled_box(0);
   proxqp::dense::Vec<T> l_scaled_box(0);
   proxqp::dense::Vec<T> eye(0);
-  HESSIAN_TYPE problem_type(HESSIAN_TYPE::DENSE);
+  HESSIAN_TYPE hessian_type(HESSIAN_TYPE::DENSE);
   ruiz_dense.scale_qp_in_place(
     proxqp::dense::QpViewBoxMut<T>{
       { proxqp::from_eigen, H_scaled_dense },
@@ -182,7 +182,7 @@ TEST_CASE("lower part")
     execute_preconditioner,
     settings.preconditioner_max_iter,
     settings.preconditioner_accuracy,
-    problem_type,
+    hessian_type,
     box_constraints,
     stack);
 


### PR DESCRIPTION
Adds a new backend (named PrimalLdl) for solving quicker QPs with far more constraints than primal variables (the current one is named PrimalDualLdl).

As a benchmark I get on randomly generated problems on my machine (11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz):
```
dim: 100 n_eq: 200 n_in: 200 box: 100
timings QP PrimalLdl backend : 	3.45787ms
timings QP PrimalDualLdl:       3.83495ms
timings QP Automatic : 	        3.2373ms
dim: 200 n_eq: 400 n_in: 400 box: 200
timings QP PrimalLdl backend : 	18.2621ms
timings QP PrimalDualLdl:       24.4886ms
timings QP Automatic: 	        18.4161ms
dim: 300 n_eq: 600 n_in: 600 box: 300
timings QP PrimalLdl backend : 	51.3537ms
timings QP PrimalDualLdl: 	69.2859ms
timings QP Automatic: 	        51.7177ms
dim: 400 n_eq: 800 n_in: 800 box: 400
timings QP PrimalLdl backend : 	113.751ms
timings QP PrimalDualLdl: 	163.189ms
timings QP Automatic: 	        114.063ms
dim: 500 n_eq: 1000 n_in: 1000 box: 500
timings QP PrimalLdl backend : 	237.171ms
timings QP PrimalDualLdl: 	336.581ms
timings QP Automatic: 	        235.475ms
```
An automatic choice is proposed by default for dense QP constructors. It compares as an heuristic a typical complexity when using PrimalLdl or PrimalDualLdl backend and takes the cheaper choice. 

Simplify as well Hessian vector computation when the Hessian appears to be diagonal. 

As a benchmark one can get the following results on random problems:
```
dim: 100 n_eq: 50 n_in: 50 box: 100
timings QP with diagonal hessian feature : 	2.67296ms
timings QP without diagonal hessian feature : 	2.8467ms
dim: 200 n_eq: 100 n_in: 100 box: 200
timings QP with diagonal hessian feature : 	20.2506ms
timings QP without diagonal hessian feature : 	21.2964ms
dim: 300 n_eq: 150 n_in: 150 box: 300
timings QP with diagonal hessian feature : 	52.7303ms
timings QP without diagonal hessian feature : 	54.59ms
dim: 400 n_eq: 200 n_in: 200 box: 400
timings QP with diagonal hessian feature : 	125.668ms
timings QP without diagonal hessian feature : 	129.86ms
dim: 500 n_eq: 250 n_in: 250 box: 500
```

The modifications are unit tested in c++ and python and documented as well. 