### PR TITLE
Fix typo #254 

### DIFF
--- a/include/proxsuite/proxqp/dense/utils.hpp
+++ b/include/proxsuite/proxqp/dense/utils.hpp
@@ -217,13 +217,16 @@ global_primal_residual(const Model<T>& qpmodel,
     helpers::negative_part(
       qpwork.primal_residual_in_scaled_up.head(qpmodel.n_in) - qpmodel.l);
   if (box_constraints) {
-    primal_feasibility_in_rhs_0 = std::max(
-      primal_feasibility_in_rhs_0, infty_norm(qpresults.si.tail(qpmodel.dim)));
     qpresults.si.tail(qpmodel.dim) =
       helpers::positive_part(
         qpwork.primal_residual_in_scaled_up.tail(qpmodel.dim) - qpmodel.u_box) +
       helpers::negative_part(
         qpwork.primal_residual_in_scaled_up.tail(qpmodel.dim) - qpmodel.l_box);
+    primal_feasibility_in_rhs_0 =
+      std::max(primal_feasibility_in_rhs_0,
+               infty_norm(qpresults.x - qpresults.si.tail(qpmodel.dim)));
+    primal_feasibility_in_rhs_0 =
+      std::max(primal_feasibility_in_rhs_0, infty_norm(qpresults.x));
   }
   // qpwork.primal_residual_eq_scaled -= qpmodel.b;
   qpresults.se -= qpmodel.b;

--- a/include/proxsuite/proxqp/dense/utils.hpp
+++ b/include/proxsuite/proxqp/dense/utils.hpp
@@ -222,9 +222,11 @@ global_primal_residual(const Model<T>& qpmodel,
         qpwork.primal_residual_in_scaled_up.tail(qpmodel.dim) - qpmodel.u_box) +
       helpers::negative_part(
         qpwork.primal_residual_in_scaled_up.tail(qpmodel.dim) - qpmodel.l_box);
+    qpwork.active_part_z.tail(qpmodel.dim) =
+      qpresults.x - qpresults.si.tail(qpmodel.dim);
     primal_feasibility_in_rhs_0 =
       std::max(primal_feasibility_in_rhs_0,
-               infty_norm(qpresults.x - qpresults.si.tail(qpmodel.dim)));
+               infty_norm(qpwork.active_part_z.tail(qpmodel.dim)));
     primal_feasibility_in_rhs_0 =
       std::max(primal_feasibility_in_rhs_0, infty_norm(qpresults.x));
   }


### PR DESCRIPTION
Fix the typo pointed out in #254 when using a relative stopping criterion and box constraints with ProxQP dense backend.

The relative value follows the same formula as proposed in the [OSQP paper ](https://web.stanford.edu/~boyd/papers/pdf/osqp.pdf)(page 14 of the "unscalled termination criteria" paragraph). 