### PR TITLE
Check model is_valid up to eps

### DIFF
--- a/include/proxsuite/proxqp/dense/helpers.hpp
+++ b/include/proxsuite/proxqp/dense/helpers.hpp
@@ -112,9 +112,10 @@ estimate_minimal_eigen_value_of_symmetric_matrix(
   T power_iteration_accuracy,
   isize nb_power_iteration)
 {
-  PROXSUITE_THROW_PRETTY((!H.isApprox(H.transpose(), 0.0)),
-                         std::invalid_argument,
-                         "H is not symmetric.");
+  PROXSUITE_THROW_PRETTY(
+    (!H.isApprox(H.transpose(), std::numeric_limits<T>::epsilon())),
+    std::invalid_argument,
+    "H is not symmetric.");
   if (H.size()) {
     PROXSUITE_CHECK_ARGUMENT_SIZE(
       H.rows(),

--- a/include/proxsuite/proxqp/dense/model.hpp
+++ b/include/proxsuite/proxqp/dense/model.hpp
@@ -120,9 +120,12 @@ struct Model
         H.rows(), dim, "H has not the expected number of rows.");
       PROXSUITE_CHECK_ARGUMENT_SIZE(
         H.cols(), dim, "H has not the expected number of cols.");
-      PROXSUITE_THROW_PRETTY((!H.isApprox(H.transpose(), 0.0)),
-                             std::invalid_argument,
-                             "H is not symmetric.");
+      PROXSUITE_THROW_PRETTY(
+        (!H.isApprox(
+          H.transpose(),
+          std::numeric_limits<typename decltype(H)::Scalar>::epsilon())),
+        std::invalid_argument,
+        "H is not symmetric.");
     }
     if (A.size()) {
       PROXSUITE_CHECK_ARGUMENT_SIZE(

--- a/include/proxsuite/proxqp/sparse/helpers.hpp
+++ b/include/proxsuite/proxqp/sparse/helpers.hpp
@@ -119,9 +119,10 @@ estimate_minimal_eigen_value_of_symmetric_matrix(SparseMat<T, I>& H,
                                                  T power_iteration_accuracy,
                                                  isize nb_power_iteration)
 {
-  PROXSUITE_THROW_PRETTY((!H.isApprox(H.transpose(), 0.0)),
-                         std::invalid_argument,
-                         "H is not symmetric.");
+  PROXSUITE_THROW_PRETTY(
+    (!H.isApprox(H.transpose(), std::numeric_limits<T>::epsilon())),
+    std::invalid_argument,
+    "H is not symmetric.");
   PROXSUITE_CHECK_ARGUMENT_SIZE(
     H.rows(),
     H.cols(),


### PR DESCRIPTION
We are checking if H is symmetric, currently up to a precision of 0.0. This is too strict and causes problems, see #271.