### PR TITLE
Use std::declval instead of custom declval to avoid pack expansi…

### DIFF
--- a/include/proxsuite/linalg/veg/internal/macros.hpp
+++ b/include/proxsuite/linalg/veg/internal/macros.hpp
@@ -5,6 +5,7 @@
 #include "proxsuite/linalg/veg/internal/preprocessor.hpp"
 #include "proxsuite/linalg/veg/internal/prologue.hpp"
 #include <initializer_list>
+#include <utility>
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -128,7 +129,7 @@
 #endif
 
 #if defined(VEG_WITH_CXX17_SUPPORT)
-#define VEG_DECLVAL(...) (static_cast<__VA_ARGS__ (*)() noexcept>(nullptr)())
+#define VEG_DECLVAL(...) (std::declval<__VA_ARGS__>())
 #else
 #define VEG_DECLVAL(...)                                                       \
   (::proxsuite::linalg::veg::_detail::_meta::declval<__VA_ARGS__>())

--- a/include/proxsuite/linalg/veg/internal/macros.hpp
+++ b/include/proxsuite/linalg/veg/internal/macros.hpp
@@ -128,12 +128,7 @@
 #define VEG_HAS_CONCEPTS 0
 #endif
 
-#if defined(VEG_WITH_CXX17_SUPPORT)
 #define VEG_DECLVAL(...) (std::declval<__VA_ARGS__>())
-#else
-#define VEG_DECLVAL(...)                                                       \
-  (::proxsuite::linalg::veg::_detail::_meta::declval<__VA_ARGS__>())
-#endif
 
 #if defined(__clang__)
 #define VEG_ARROW(...)                                                         \
@@ -666,9 +661,6 @@ struct unref<T&>
   using type = T;
 };
 
-template<typename T>
-auto
-declval() VEG_ALWAYS_NOEXCEPT->T;
 } // namespace _meta
 } // namespace _detail
 


### PR DESCRIPTION
`cl` compiler doesn't succeed to do a parameter pack expansion whit our custom declval implementation.

To fix this issue, I have replaced the custom declval implementation by the standard one.
