### PR TITLE
Set `primal_infeasibility_solving` to False for feasible forward in `QPFunction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### What's Changed
+* Changed `primal_infeasibility_solving` to `False` for feasible QPs ([#302](https://github.com/Simple-Robotics/proxsuite/pull/302))
+
 ## [0.6.3] - 2024-01-23
 
 ### Fixed

--- a/bindings/python/proxsuite/torch/qplayer.py
+++ b/bindings/python/proxsuite/torch/qplayer.py
@@ -120,7 +120,7 @@ def QPFunction(
 
             for i in range(nBatch):
                 qp = ctx.vector_of_qps.init_qp_in_place(ctx.nz, ctx.neq, ctx.nineq)
-                qp.settings.primal_infeasibility_solving = True
+                qp.settings.primal_infeasibility_solving = False
                 qp.settings.max_iter = maxIter
                 qp.settings.max_iter_in = 100
                 default_rho = 5.0e-5


### PR DESCRIPTION
For  `QPFunction`, we accept a parameter called `structural_feasibility` which defaults to `True`. Based on this, we will either use the class `QPFunctionFn` or `QPFunctionFn_infeas` with their corresponding `forward` and `backward` methods. 

If we decide, that the QPs to solve are structurally feasible, it is consistent to set `primal_infeasibility_solving` to `False`. 