### PR TITLE
Replace torch.Tensor and fix handling of batched ineq. constraints in QPlayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### What's Changed
+* Change from torch.Tensor to torch.empty or torch.tensor and specify type explicitly ([#308](https://github.com/Simple-Robotics/proxsuite/pull/308))
+* Fix handling of batch of inequality constraints in `QPFunctionFn_infeas`. The derivations in qplayer was done for single-sided constraints, that's the reason for the concatenation but the expansion of batchsize dimension was not working properly ([#308](https://github.com/Simple-Robotics/proxsuite/pull/308))
 * Switch from self-hosted runner for macos-14-ARM to runner from github ([#306](https://github.com/Simple-Robotics/proxsuite/pull/306))
 
 ## [0.6.4] - 2024-03-01

--- a/bindings/python/proxsuite/torch/qplayer.py
+++ b/bindings/python/proxsuite/torch/qplayer.py
@@ -114,9 +114,9 @@ def QPFunction(
             if ctx.cpu is not None:
                 ctx.cpu = max(1, int(ctx.cpu / 2))
 
-            zhats = torch.empty((nBatch, ctx.nz)).type_as(Q)
-            lams = torch.empty((nBatch, ctx.neq)).type_as(Q)
-            nus = torch.empty((nBatch, ctx.nineq)).type_as(Q)
+            zhats = torch.empty((nBatch, ctx.nz), dtype=Q.dtype)
+            lams = torch.empty((nBatch, ctx.neq), dtype=Q.dtype)
+            nus = torch.empty((nBatch, ctx.nineq), dtype=Q.dtype)
 
             for i in range(nBatch):
                 qp = ctx.vector_of_qps.init_qp_in_place(ctx.nz, ctx.neq, ctx.nineq)
@@ -272,20 +272,20 @@ def QPFunction(
             assert neq > 0 or nineq > 0
             ctx.neq, ctx.nineq, ctx.nz = neq, nineq, nz
 
-            zhats = torch.Tensor(nBatch, ctx.nz).type_as(Q)
-            nus = torch.Tensor(nBatch, ctx.nineq).type_as(Q)
+            zhats = torch.empty((nBatch, ctx.nz), dtype=Q.dtype)
+            nus = torch.empty((nBatch, ctx.nineq), dtype=Q.dtype)
             lams = (
-                torch.Tensor(nBatch, ctx.neq).type_as(Q)
+                torch.empty(nBatch, ctx.neq, dtype=Q.dtype)
                 if ctx.neq > 0
-                else torch.Tensor()
+                else torch.empty()
             )
             s_e = (
-                torch.Tensor(nBatch, ctx.neq).type_as(Q)
+                torch.empty(nBatch, ctx.neq, dtype=Q.dtype)
                 if ctx.neq > 0
-                else torch.Tensor()
+                else torch.empty()
             )
-            slacks = torch.Tensor(nBatch, ctx.nineq).type_as(Q)
-            s_i = torch.Tensor(nBatch, ctx.nineq).type_as(Q)
+            slacks = torch.empty((nBatch, ctx.nineq), dtype=Q.dtype)
+            s_i = torch.empty((nBatch, ctx.nineq), dtype=Q.dtype)
 
             vector_of_qps = proxsuite.proxqp.dense.BatchQP()
 
@@ -338,13 +338,13 @@ def QPFunction(
 
             for i in range(nBatch):
                 si = -h[i] + G[i] @ vector_of_qps.get(i).results.x
-                zhats[i] = torch.Tensor(vector_of_qps.get(i).results.x)
-                nus[i] = torch.Tensor(vector_of_qps.get(i).results.z)
-                slacks[i] = torch.Tensor(si)
+                zhats[i] = torch.tensor(vector_of_qps.get(i).results.x)
+                nus[i] = torch.tensor(vector_of_qps.get(i).results.z)
+                slacks[i] = si.clone().detach()
                 if neq > 0:
-                    lams[i] = torch.Tensor(vector_of_qps.get(i).results.y)
-                    s_e[i] = torch.Tensor(vector_of_qps.get(i).results.se)
-                s_i[i] = torch.Tensor(vector_of_qps.get(i).results.si)
+                    lams[i] = torch.tensor(vector_of_qps.get(i).results.y)
+                    s_e[i] = torch.tensor(vector_of_qps.get(i).results.se)
+                s_i[i] = torch.tensor(vector_of_qps.get(i).results.si)
 
             ctx.lams = lams
             ctx.nus = nus

--- a/bindings/python/proxsuite/torch/utils.py
+++ b/bindings/python/proxsuite/torch/utils.py
@@ -2,18 +2,9 @@ import torch
 import numpy as np
 
 
-def extract_nBatch_double_sided(Q, p, A, b, G, l, u):
+def extract_nBatch(Q, p, A, b, G, l, u):
     dims = [3, 2, 3, 2, 3, 2, 2]
     params = [Q, p, A, b, G, l, u]
-    for param, dim in zip(params, dims):
-        if param.ndimension() == dim:
-            return param.size(0)
-    return 1
-
-
-def extract_nBatch_(Q, p, G, A, b):
-    dims = [3, 2, 3, 3, 2]
-    params = [Q, p, G, A, b]
     for param, dim in zip(params, dims):
         if param.ndimension() == dim:
             return param.size(0)
@@ -67,12 +58,3 @@ def expandParam(X, nBatch, nDim):
         return X.unsqueeze(0).expand(*([nBatch] + list(X.size()))), True
     else:
         raise RuntimeError("Unexpected number of dimensions.")
-
-
-def extract_nBatch(Q, p, G, h, A, b):
-    dims = [3, 2, 3, 2, 3, 2]
-    params = [Q, p, G, h, A, b]
-    for param, dim in zip(params, dims):
-        if param.ndimension() == dim:
-            return param.size(0)
-    return 1


### PR DESCRIPTION
following #297, where we started to replace `torch.Tensor`.

The PyTorch doc says: [torch.Tensor](https://pytorch.org/docs/stable/tensors.html#torch.Tensor) is an alias for the default tensor type (torch.FloatTensor).

For the rest of the tensors, we called either `.double()` or set `dtype=torch.64`. This is necessary, as these tensors contain the QP data which is passed to the proxsuite c++ bindings in `forward` and `backward` which are using the Scalar type double.

