### PR TITLE
include cassert in fwd.hpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Change from torch.Tensor to torch.empty or torch.tensor and specify type explicitly ([#308](https://github.com/Simple-Robotics/proxsuite/pull/308))
 * Fix handling of batch of inequality constraints in `QPFunctionFn_infeas`. The derivations in qplayer was done for single-sided constraints, that's the reason for the concatenation but the expansion of batchsize dimension was not working properly ([#308](https://github.com/Simple-Robotics/proxsuite/pull/308))
 * Switch from self-hosted runner for macos-14-ARM to runner from github ([#306](https://github.com/Simple-Robotics/proxsuite/pull/306))
+* Fix missing cassert for some compilers ([#316](https://github.com/Simple-Robotics/proxsuite/pull/316))
 
 ## [0.6.4] - 2024-03-01
 

--- a/include/proxsuite/fwd.hpp
+++ b/include/proxsuite/fwd.hpp
@@ -29,6 +29,7 @@
 #endif
 
 #include <Eigen/Core>
+#include <cassert>
 
 #ifdef PROXSUITE_EIGEN_CHECK_MALLOC
 #ifdef EIGEN_RUNTIME_NO_MALLOC_WAS_NOT_DEFINED


### PR DESCRIPTION
I was getting a compilation error due to a missing `#include <cassert>`. I added it to the fwd.hpp file which fixes the issue.