### PR TITLE
Fix python abi tag

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -39,6 +39,13 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
                LIBRARY_OUTPUT_DIRECTORY_RELEASE
                "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}"
                LIBRARY_OUTPUT_DIRECTORY_DEBUG
+               "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}"
+               # On Windows, shared library are treat as binary
+               RUNTIME_OUTPUT_DIRECTORY
+               "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}"
+               RUNTIME_OUTPUT_DIRECTORY_RELEASE
+               "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}"
+               RUNTIME_OUTPUT_DIRECTORY_DEBUG
                "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}")
   if(UNIX AND NOT APPLE)
     set_target_properties(instructionset PROPERTIES INSTALL_RPATH
@@ -96,6 +103,13 @@ function(CREATE_PYTHON_TARGET target_name COMPILE_OPTIONS dependencies)
                LIBRARY_OUTPUT_DIRECTORY_RELEASE
                "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}"
                LIBRARY_OUTPUT_DIRECTORY_DEBUG
+               "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}"
+               # On Windows, shared library are treat as binary
+               RUNTIME_OUTPUT_DIRECTORY
+               "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}"
+               RUNTIME_OUTPUT_DIRECTORY_RELEASE
+               "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}"
+               RUNTIME_OUTPUT_DIRECTORY_DEBUG
                "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}")
 
   if(UNIX AND NOT APPLE)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -32,6 +32,8 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
   set_target_properties(
     instructionset
     PROPERTIES OUTPUT_NAME instructionset
+               PREFIX ""
+               SUFFIX ${PYTHON_EXT_SUFFIX}
                LIBRARY_OUTPUT_DIRECTORY
                "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}"
                LIBRARY_OUTPUT_DIRECTORY_RELEASE
@@ -87,6 +89,8 @@ function(CREATE_PYTHON_TARGET target_name COMPILE_OPTIONS dependencies)
   set_target_properties(
     ${target_name}
     PROPERTIES OUTPUT_NAME ${target_name}
+               PREFIX ""
+               SUFFIX ${PYTHON_EXT_SUFFIX}
                LIBRARY_OUTPUT_DIRECTORY
                "${CMAKE_BINARY_DIR}/bindings/python/${PROJECT_NAME}"
                LIBRARY_OUTPUT_DIRECTORY_RELEASE


### PR DESCRIPTION
Add the ABI tag (“.cpython-39-x86_64-linux-gnu.so”) to Python bindings.

This is mandatory for PyPy interpreter.

Also, generate Python bindings in the right directory on Windows.