### PR TITLE
Build and release wheels for python 3.12 on all platforms

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -14,11 +14,8 @@ jobs:
       matrix:
         os: ["ubuntu"]
         arch: ["x86_64"]
-        build: ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*", "pp37-*", "pp38-*", "pp39-*"]
+        build: ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*", "pp38-*", "pp39-*"]
         include:
-          - arch: "aarch64"
-            os: "ubuntu"
-            build: "cp37-manylinux*"
           - arch: "aarch64"
             os: "ubuntu"
             build: "cp38-manylinux*"
@@ -31,6 +28,9 @@ jobs:
           - arch: "aarch64"
             os: "ubuntu"
             build: "cp311-manylinux*"
+          - arch: "aarch64"
+            os: "ubuntu"
+            build: "cp312-manylinux*"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-osx-win.yml
+++ b/.github/workflows/release-osx-win.yml
@@ -12,16 +12,14 @@ jobs:
     name: Build ${{ matrix.os }} ${{ matrix.python-version }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [macos-13, macos-14, windows-2019, windows-latest]
         include:
           - os: windows-2019
             toolset: ClangCl
           - os: windows-latest
             toolset: v143
-        exclude:
-          - os: macos-14
-            python-version: 3.7
+
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+* Pip wheels for Python 3.12 and stop support Python 3.7 ([#324](https://github.com/Simple-Robotics/proxsuite/pull/324))
+
 ### Fixed
 * Fixes compilation issue with GCC 14 on Arch ([#322](https://github.com/Simple-Robotics/proxsuite/pull/322))
 


### PR DESCRIPTION
remove python 3.7 as it has reached end of life in June 2023 https://devguide.python.org/versions/