### PR TITLE
Fix infeasibility detection logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+* Fix infeasibility detection and add a unit test ([#328](https://github.com/Simple-Robotics/proxsuite/pull/328))
+
 ## [0.6.5] - 2024-05-31
 
 ### Added
@@ -13,7 +16,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 * Fixes compilation issue with GCC 14 on Arch ([#322](https://github.com/Simple-Robotics/proxsuite/pull/322))
-* Fix infeasibility detection and add unittest ([#328](https://github.com/Simple-Robotics/proxsuite/pull/328))
 
 ### What's Changed
 * Change from torch.Tensor to torch.empty or torch.tensor and specify type explicitly ([#308](https://github.com/Simple-Robotics/proxsuite/pull/308))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 * Fixes compilation issue with GCC 14 on Arch ([#322](https://github.com/Simple-Robotics/proxsuite/pull/322))
+* Fix infeasibility detection and add unittest ([#328](https://github.com/Simple-Robotics/proxsuite/pull/328))
 
 ### What's Changed
 * Change from torch.Tensor to torch.empty or torch.tensor and specify type explicitly ([#308](https://github.com/Simple-Robotics/proxsuite/pull/308))

--- a/include/proxsuite/proxqp/dense/utils.hpp
+++ b/include/proxsuite/proxqp/dense/utils.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 INRIA
+// Copyright (c) 2022-2024 INRIA
 //
 /**
  * @file utils.hpp
@@ -289,7 +289,7 @@ global_primal_residual_infeasibility(
   //
   // the variables in entry are changed in place
 
-  bool res = infty_norm(dy.to_eigen()) != 0 && infty_norm(dz.to_eigen()) != 0;
+  bool res = infty_norm(dy.to_eigen()) != 0 || infty_norm(dz.to_eigen()) != 0;
   if (!res) {
     return res;
   }

--- a/include/proxsuite/proxqp/sparse/utils.hpp
+++ b/include/proxsuite/proxqp/sparse/utils.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022-2023 INRIA
+// Copyright (c) 2022-2024 INRIA
 //
 /** \file */
 
@@ -488,7 +488,7 @@ global_primal_residual_infeasibility(VectorViewMut<T> ATdy,
   //
   // the variables in entry are changed in place
 
-  bool res = infty_norm(dy.to_eigen()) != 0 && infty_norm(dz.to_eigen()) != 0;
+  bool res = infty_norm(dy.to_eigen()) != 0 || infty_norm(dz.to_eigen()) != 0;
   if (!res) {
     return res;
   }

--- a/test/src/dense_qp_with_eq_and_in.cpp
+++ b/test/src/dense_qp_with_eq_and_in.cpp
@@ -172,7 +172,7 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with degenerate inequality "
     << "---testing sparse random strongly convex qp with degenerate "
        "inequality constraints and increasing dimension using the API---"
     << std::endl;
-  T sparsity_factor = 0.15;
+  T sparsity_factor = 0.45;
   T eps_abs = T(1e-9);
   T strong_convexity_factor(1e-2);
   proxqp::utils::rand::set_seed(1);

--- a/test/src/dense_qp_with_eq_and_in.cpp
+++ b/test/src/dense_qp_with_eq_and_in.cpp
@@ -197,6 +197,8 @@ DOCTEST_TEST_CASE("sparse random strongly convex qp with degenerate inequality "
             qp_random.l,
             qp_random.u);
     qp.solve();
+    DOCTEST_CHECK(qp.results.info.status ==
+                  proxqp::QPSolverOutput::PROXQP_SOLVED);
     T pri_res = std::max(
       (qp_random.A * qp.results.x - qp_random.b).lpNorm<Eigen::Infinity>(),
       (helpers::positive_part(qp_random.C * qp.results.x - qp_random.u) +


### PR DESCRIPTION
we have a first check in our helper function `global_primal_residual_infeasibility` that returns if a problem is supposed to be feasible. 

I think the logic we want to check is
```
inf_norm(dy) == 0 AND infty_norm(dz) == 0
```
in this case, the problem is feasible.

However, we negate this statement as the output of the function is used to set the variable called `is_primal_infeasible`, [here](https://github.com/Simple-Robotics/proxsuite/blob/main/include/proxsuite/proxqp/dense/solver.hpp#L1028). 

If we negate the statement above, and should be replaced by OR. The fix I propose here solves the issue in #327 and proxqp returns `PROXQP_PRIMAL_INFEASIBLE` as expected. 