### PR TITLE
 CMake: allow use of installed dependencies, take 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-* Allow use of installed cereal and jrl-cmakemodules via cmake
+* Allow use of installed pybind11, cereal and jrl-cmakemodules via cmake
 * Add compatibility with jrl-cmakemodules workspace ([#339](https://github.com/Simple-Robotics/proxsuite/pull/339))
 * Specifically mention that timings are in microseconds ([#340](https://github.com/Simple-Robotics/proxsuite/pull/340))
 * Fix cereal include directory in cmake ([#340](https://github.com/Simple-Robotics/proxsuite/pull/340))

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -95,8 +95,7 @@ function(CREATE_PYTHON_TARGET target_name COMPILE_OPTIONS dependencies)
   endif(BUILD_WITH_OPENMP_SUPPORT)
 
   if(cereal_FOUND)
-    target_include_directories(${target_name} SYSTEM
-                               PRIVATE ${CEREAL_INCLUDE_DIRS})
+    target_link_libraries(${target_name} PRIVATE cereal::cereal)
   else()
     target_include_directories(
       ${target_name} SYSTEM

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -14,9 +14,12 @@ else()
       ${CMAKE_INSTALL_PREFIX}/${PYTHON_SITELIB}/${PROJECT_NAME})
 endif()
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/external/pybind11)
-add_subdirectory(external/pybind11
-                 ${CMAKE_CURRENT_BINARY_DIR}/external/pybind11)
+find_package(pybind11 CONFIG)
+if(NOT pybind11_FOUND)
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/external/pybind11)
+  add_subdirectory(external/pybind11
+                   ${CMAKE_CURRENT_BINARY_DIR}/external/pybind11)
+endif()
 
 add_custom_target(${PROJECT_NAME}_python)
 


### PR DESCRIPTION
Hi,

Here are a couple CMake fixes for installs with python bindings and where cereal and pybind11 are already available on the system.