### PR TITLE
Fix `mu_update` for `PrimalLDLT` backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+* Fix mu update function for PrimalLDLT backend ([#349](https://github.com/Simple-Robotics/proxsuite/pull/349))
 * Allow use of installed pybind11, cereal and jrl-cmakemodules via cmake
 * Add compatibility with jrl-cmakemodules workspace ([#339](https://github.com/Simple-Robotics/proxsuite/pull/339))
 * Specifically mention that timings are in microseconds ([#340](https://github.com/Simple-Robotics/proxsuite/pull/340))

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -195,7 +195,7 @@ mu_update(const Model<T>& qpmodel,
       {
         LDLT_TEMP_MAT_UNINIT(T, new_cols, qpmodel.dim, qpwork.n_c, stack);
         qpwork.dw_aug.head(qpmodel.dim).setOnes();
-        T delta_mu(mu_in_new - qpresults.info.mu_in_inv);
+        T delta_mu(1 / mu_in_new - qpresults.info.mu_in_inv);
         qpwork.dw_aug.head(qpmodel.dim).array() *= delta_mu;
         for (isize i = 0; i < n_constraints; ++i) {
           isize j = qpwork.current_bijection_map[i];

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -212,14 +212,14 @@ mu_update(const Model<T>& qpmodel,
           }
         }
         qpwork.ldl.rank_r_update(
-          new_cols, qpwork.dw_aug.head(qpmodel.dim), stack);
+          new_cols, qpwork.dw_aug.head(qpwork.n_c), stack);
       }
       // mu update for A
       {
         LDLT_TEMP_MAT_UNINIT(T, new_cols, qpmodel.dim, qpmodel.n_eq, stack);
         new_cols = qpwork.A_scaled.transpose();
         qpwork.ldl.rank_r_update(
-          new_cols, qpwork.dw_aug.head(qpmodel.dim), stack);
+          new_cols, qpwork.dw_aug.head(qpmodel.n_eq), stack);
       }
     } break;
     case DenseBackend::Automatic:

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -195,7 +195,7 @@ mu_update(const Model<T>& qpmodel,
       {
         LDLT_TEMP_MAT_UNINIT(T, new_cols, qpmodel.dim, qpwork.n_c, stack);
         qpwork.dw_aug.head(qpmodel.dim).setOnes();
-        T delta_mu(1 / mu_in_new - qpresults.info.mu_in_inv);
+        T delta_mu(T(1) / mu_in_new - qpresults.info.mu_in_inv);
         qpwork.dw_aug.head(qpmodel.dim).array() *= delta_mu;
         for (isize i = 0; i < n_constraints; ++i) {
           isize j = qpwork.current_bijection_map[i];

--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 INRIA
+// Copyright (c) 2022-2024 INRIA
 //
 /**
  * @file solver.hpp
@@ -217,6 +217,9 @@ mu_update(const Model<T>& qpmodel,
       // mu update for A
       {
         LDLT_TEMP_MAT_UNINIT(T, new_cols, qpmodel.dim, qpmodel.n_eq, stack);
+        qpwork.dw_aug.head(qpmodel.n_eq).setOnes();
+        T delta_mu(1 / mu_eq_new - qpresults.info.mu_eq_inv);
+        qpwork.dw_aug.head(qpmodel.n_eq).array() *= delta_mu;
         new_cols = qpwork.A_scaled.transpose();
         qpwork.ldl.rank_r_update(
           new_cols, qpwork.dw_aug.head(qpmodel.n_eq), stack);


### PR DESCRIPTION
as pointed out in #348, there is currently a mismatch when calling the `rank_r_update`. 

I discussed it with @Bambade, and we propose this PR to fix it, and correct another typo that was found while analyzing the function. 

We also add the example from #348 as a new unittest for the  `PrimalLDLT` backend, where we trigger a `mu_update`.