### PR TITLE
release: updates

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -15,12 +15,14 @@ jobs:
     strategy:
       matrix:
         arch: ["x86_64", "aarch64"]
-        build: ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "pp38-*", "pp39-*"]
+        build: ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "pp38-*", "pp39-*", "pp310-*"]
         exclude:
           - arch: "aarch64"
             build: "pp38-*"
           - arch: "aarch64"
             build: "pp39-*"
+          - arch: "aarch64"
+            build: "pp310-*"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -10,37 +10,25 @@ on:
 
 jobs:
   build-wheel:
-    name: "Build ${{ matrix.build }} wheels on ${{ matrix.os }} ${{ matrix.arch }}"
-    runs-on: "${{ matrix.os }}-latest"
+    name: "Build ${{ matrix.build }} wheels on ${{ matrix.arch }}"
+    runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        os: ["ubuntu"]
-        arch: ["x86_64"]
-        build: ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*", "pp38-*", "pp39-*"]
-        include:
+        arch: ["x86_64", "aarch64"]
+        build: ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "pp38-*", "pp39-*"]
+        exclude:
           - arch: "aarch64"
-            os: "ubuntu"
-            build: "cp38-manylinux*"
+            build: "pp38-*"
           - arch: "aarch64"
-            os: "ubuntu"
-            build: "cp39-manylinux*"
-          - arch: "aarch64"
-            os: "ubuntu"
-            build: "cp310-manylinux*"
-          - arch: "aarch64"
-            os: "ubuntu"
-            build: "cp311-manylinux*"
-          - arch: "aarch64"
-            os: "ubuntu"
-            build: "cp312-manylinux*"
+            build: "pp39-*"
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Set up QEMU
         if: matrix.arch == 'aarch64'
         uses: docker/setup-qemu-action@v2
@@ -58,7 +46,7 @@ jobs:
           CIBW_MANYLINUX_PYPY_X86_64_IMAGE: "quay.io/pypa/manylinux2014_x86_64"
           CIBW_MANYLINUX_AARCH64_IMAGE: "quay.io/pypa/manylinux_2_28_aarch64"
           CIBW_REPAIR_WHEEL_COMMAND: ""
-          CIBW_ENVIRONMENT: "CMEEL_JOBS=2 CMEEL_RUN_TESTS=OFF"
+          CIBW_ENVIRONMENT: "CMEEL_JOBS=2 CMEEL_RUN_TESTS=OFF CMEEL_CMAKE_ARGS=-DBUILD_WITH_OPENMP_SUPPORT=ON"
 
       - uses: actions/upload-artifact@v3
         with:
@@ -69,10 +57,10 @@ jobs:
     needs: "build-wheel"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - uses: actions/download-artifact@v3
 
       - name: Publish package to PyPI

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -68,9 +68,6 @@ jobs:
         if: |
           github.repository == 'Simple-Robotics/proxsuite' &&
           (github.event_name == 'release' && github.event.action == 'published')
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
 
   check:
     if: always()

--- a/.github/workflows/release-osx-win.yml
+++ b/.github/workflows/release-osx-win.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build ${{ matrix.os }} ${{ matrix.python-version }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [macos-13, macos-14, windows-2019, windows-latest]
         include:
           - os: windows-2019
@@ -89,10 +89,10 @@ jobs:
     needs: "build-wheel"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - uses: actions/download-artifact@v3
 
       - name: Publish package to PyPI

--- a/.github/workflows/release-osx-win.yml
+++ b/.github/workflows/release-osx-win.yml
@@ -100,9 +100,6 @@ jobs:
         if: |
           github.repository == 'Simple-Robotics/proxsuite' &&
           (github.event_name == 'release' && github.event.action == 'published')
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
 
   check:
     if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 * Stub files for Python bindings, using [nanobind's native support](https://nanobind.readthedocs.io/en/latest/typing.html#stub-generation) ([#340](https://github.com/Simple-Robotics/proxsuite/pull/340))
+* Python 3.13 support on PyPI ([#361](https://github.com/Simple-Robotics/proxsuite/pull/361))
 * Add `solve_no_gil` for dense backend (multithreading via python) ([#363](https://github.com/Simple-Robotics/proxsuite/pull/363))
 * Add benchmarks for `solve_no_gil` vs `solve_in_parallel` (openmp) ([#363](https://github.com/Simple-Robotics/proxsuite/pull/363))
 


### PR DESCRIPTION
Hi,

I think we would need some python 3.13 release on PyPI.

While here, I updated a few other things in the release workflows.

Also, the PYPI_TOKEN should be removed in favor of then new "Trusted Publisher Management": https://pypi.org/manage/project/proxsuite/settings/publishing/