### PR TITLE
ci: setup miniconda with conda-forge and remove defaults

### DIFF
--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -61,13 +61,13 @@ jobs:
       with:
         miniforge-version: latest
         activate-environment: proxsuite
+        channels: conda-forge
+        conda-remove-defaults: "true"
 
 
     - name: Install dependencies [Conda]
       shell: bash -l {0}
       run: |
-        # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
-        conda config --remove channels defaults
         # Compilation related dependencies
         conda install cmake compilers make pkg-config doxygen ninja graphviz typing_extensions llvm-openmp clang
         # Main dependencies

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,15 +15,13 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          python-version: "3.10"
           activate-environment: doc
+          channels: conda-forge
+          conda-remove-defaults: "true"
 
       - name: Dependencies
         shell: bash -l {0}
         run: |
-          # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
-          conda config --remove channels defaults
-
           # Compilation related dependencies
           conda install cmake make pkg-config doxygen graphviz
 

--- a/.github/workflows/release-osx-win.yml
+++ b/.github/workflows/release-osx-win.yml
@@ -40,13 +40,13 @@ jobs:
           miniforge-version: latest
           python-version: ${{ matrix.python-version }}
           activate-environment: proxsuite
+          channels: conda-forge
+          conda-remove-defaults: "true"
 
       - name: Install dependencies [Conda]
         if: contains(matrix.os, 'macos') || contains(matrix.os, 'windows')
         shell: bash -l {0}
         run: |
-          # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
-          conda config --remove channels defaults
           conda install doxygen graphviz eigen simde cmake compilers typing_extensions
 
       - name: Print environment [Conda]


### PR DESCRIPTION
avoids a bunch of warnings in the ci output