### PR TITLE
Fix build with Cl and C++20

### DIFF
--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -119,15 +119,15 @@ jobs:
 
     - name: Configure [Conda/Windows]
       if: contains(matrix.os, 'windows-')
-      shell: bash -l {0}
+      # It's better to use CMD to have all MSVC variables setup
+      shell: cmd /C CALL {0}
       run: |
-        echo $(where ccache)
         git submodule update --init
         mkdir build
         cd build
-        export CC=${{ matrix.compiler }}
-        export CXX=${{ matrix.compiler }}
-        cmake .. -GNinja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.cxx_std }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_SITELIB=${CONDA_PREFIX}/Lib/site-packages -DPYTHON_EXECUTABLE=${CONDA_PREFIX}/python.exe -DOpenMP_ROOT=$CONDA_PREFIX -DBUILD_WITH_OPENMP_SUPPORT:BOOL=ON -DLINK_PYTHON_INTERFACE_TO_OPENMP:BOOL=ON -DBUILD_DOCUMENTATION:BOOL=ON -DINSTALL_DOCUMENTATION:BOOL=ON
+        set CC=${{ matrix.compiler }}
+        set CXX=${{ matrix.compiler }}
+        cmake .. -GNinja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%/Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.cxx_std }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_SITELIB=%CONDA_PREFIX%/Lib/site-packages -DPYTHON_EXECUTABLE=%CONDA_PREFIX%/python.exe -DOpenMP_ROOT=%CONDA_PREFIX% -DBUILD_WITH_OPENMP_SUPPORT:BOOL=ON -DLINK_PYTHON_INTERFACE_TO_OPENMP:BOOL=ON -DBUILD_DOCUMENTATION:BOOL=ON -DINSTALL_DOCUMENTATION:BOOL=ON
 
     - name: Build [Conda]
       shell: bash -l {0}

--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -129,8 +129,17 @@ jobs:
         set CXX=${{ matrix.compiler }}
         cmake .. -GNinja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%/Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.cxx_std }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_SITELIB=%CONDA_PREFIX%/Lib/site-packages -DPYTHON_EXECUTABLE=%CONDA_PREFIX%/python.exe -DOpenMP_ROOT=%CONDA_PREFIX% -DBUILD_WITH_OPENMP_SUPPORT:BOOL=ON -DLINK_PYTHON_INTERFACE_TO_OPENMP:BOOL=ON -DBUILD_DOCUMENTATION:BOOL=ON -DINSTALL_DOCUMENTATION:BOOL=ON
 
-    - name: Build [Conda]
+    - name: Build [Conda/Linux&macOS]
+      if: contains(matrix.os, 'macos-') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
+      run: |
+        cd build
+        cmake --build . --config ${{ matrix.build_type }} -v -j 1
+
+    - name: Build [Conda/Windows]
+      if: contains(matrix.os, 'windows-')
+      # It's better to use CMD to have all MSVC variables setup
+      shell: cmd /C CALL {0}
       run: |
         cd build
         cmake --build . --config ${{ matrix.build_type }} -v -j 1

--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -26,11 +26,14 @@ jobs:
             os: macos-latest
           - name: macos-14
             os: macos-14
+          # proxsuite doesn't build with vs2019, so we use clang-cl instead
           - name: windows-2019-clang-cl
             os: windows-2019
             compiler: clang-cl
+          # proxsuite should work with vs2022
           - name: windows-latest
             os: windows-latest
+            compiler: cl
           - name: macos-latest
             os: macos-latest
             build_type: Debug
@@ -95,7 +98,7 @@ jobs:
         env
 
     - name: Configure [Conda/Linux&macOS]
-      if: contains(matrix.os, 'macos-latest') || contains(matrix.os, 'ubuntu')
+      if: contains(matrix.os, 'macos-') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
         echo $(whereis ccache)
@@ -104,18 +107,6 @@ jobs:
         mkdir build
         cd build
         cmake .. -GNinja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_STANDARD=${{ matrix.cxx_std }} -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_EXECUTABLE=$(which python3) -DBUILD_DOCUMENTATION:BOOL=ON -DINSTALL_DOCUMENTATION:BOOL=ON -DTEST_JULIA_INTERFACE:BOOL=OFF -DOpenMP_ROOT=$CONDA_PREFIX
-
-    - name: Configure [Conda/macOS14]
-      if: contains(matrix.os, 'macos-14')
-      shell: bash -l {0}
-      run: |
-        echo $(whereis ccache)
-        echo $(which ccache)
-        git submodule update --init
-        mkdir build
-        cd build
-        cmake .. -GNinja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_STANDARD=${{ matrix.cxx_std }} -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_EXECUTABLE=$(which python3) -DBUILD_DOCUMENTATION:BOOL=ON -DINSTALL_DOCUMENTATION:BOOL=ON -DTEST_JULIA_INTERFACE:BOOL=OFF -DOpenMP_ROOT=$CONDA_PREFIX
-
 
     - name: Configure [Conda/macOS-debug/CheckMalloc]
       if: contains(matrix.os, 'macos-latest') && contains(matrix.build_type, 'Debug')
@@ -126,41 +117,17 @@ jobs:
         cd build
         cmake .. -GNinja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCHECK_RUNTIME_MALLOC:BOOL=ON -DCMAKE_CXX_STANDARD=${{ matrix.cxx_std }} -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_EXECUTABLE=$(which python3) -DBUILD_DOCUMENTATION:BOOL=ON -DINSTALL_DOCUMENTATION:BOOL=ON -DTEST_JULIA_INTERFACE:BOOL=OFF -DBUILD_WITH_OPENMP_SUPPORT:BOOL=ON -DOpenMP_ROOT=$CONDA_PREFIX
 
-    - name: Configure [Conda/Windows-2019]
-      if: contains(matrix.os, 'windows-2019')
+    - name: Configure [Conda/Windows]
+      if: contains(matrix.os, 'windows-')
       shell: bash -l {0}
       run: |
         echo $(where ccache)
         git submodule update --init
         mkdir build
         cd build
-        export CXX=clang-cl
-        export CC=clang-cl
-        cmake .. -G"Ninja" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.cxx_std }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_SITELIB=${CONDA_PREFIX}/Lib/site-packages -DPYTHON_EXECUTABLE=${CONDA_PREFIX}/python.exe -DOpenMP_ROOT=$CONDA_PREFIX -DBUILD_WITH_OPENMP_SUPPORT:BOOL=ON -DLINK_PYTHON_INTERFACE_TO_OPENMP:BOOL=ON -DBUILD_DOCUMENTATION:BOOL=ON -DINSTALL_DOCUMENTATION:BOOL=ON
-
-    - name: Configure [Conda/Windows-latest]
-      if: contains(matrix.os, 'windows-latest') && contains(matrix.cxx_std, '20')
-      shell: bash -l {0}
-      run: |
-        echo $(where ccache)
-        git submodule update --init
-        mkdir build
-        cd build
-        export CXX=clang-cl
-        export CC=clang-cl
-        cmake .. -G"Ninja" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.cxx_std }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_SITELIB=${CONDA_PREFIX}/Lib/site-packages -DPYTHON_EXECUTABLE=${CONDA_PREFIX}/python.exe -DOpenMP_ROOT=$CONDA_PREFIX -DBUILD_WITH_OPENMP_SUPPORT:BOOL=ON -DLINK_PYTHON_INTERFACE_TO_OPENMP:BOOL=ON -DBUILD_DOCUMENTATION:BOOL=ON -DINSTALL_DOCUMENTATION:BOOL=ON
-
-    - name: Configure [Conda/Windows-latest]
-      if: contains(matrix.os, 'windows-latest') && contains(matrix.cxx_std, '17')
-      shell: bash -l {0}
-      run: |
-        echo $(where ccache)
-        git submodule update --init
-        mkdir build
-        cd build
-        export CXX=clang-cl
-        export CC=clang-cl
-        cmake .. -G"Ninja" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.cxx_std }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_SITELIB=${CONDA_PREFIX}/Lib/site-packages -DPYTHON_EXECUTABLE=${CONDA_PREFIX}/python.exe -DOpenMP_ROOT=$CONDA_PREFIX -DBUILD_WITH_OPENMP_SUPPORT:BOOL=ON -DLINK_PYTHON_INTERFACE_TO_OPENMP:BOOL=ON -DBUILD_DOCUMENTATION:BOOL=ON -DINSTALL_DOCUMENTATION:BOOL=ON
+        export CC=${{ matrix.compiler }}
+        export CXX=${{ matrix.compiler }}
+        cmake .. -GNinja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.cxx_std }} -DBUILD_PYTHON_INTERFACE:BOOL=ON -DPYTHON_SITELIB=${CONDA_PREFIX}/Lib/site-packages -DPYTHON_EXECUTABLE=${CONDA_PREFIX}/python.exe -DOpenMP_ROOT=$CONDA_PREFIX -DBUILD_WITH_OPENMP_SUPPORT:BOOL=ON -DLINK_PYTHON_INTERFACE_TO_OPENMP:BOOL=ON -DBUILD_DOCUMENTATION:BOOL=ON -DINSTALL_DOCUMENTATION:BOOL=ON
 
     - name: Build [Conda]
       shell: bash -l {0}

--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -62,21 +62,17 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-version: latest
         activate-environment: proxsuite
-        channels: conda-forge
-        conda-remove-defaults: "true"
+        environment-file: .github/workflows/conda/environment.yml
+        auto-activate-base: false
+        auto-update-conda: true
 
-
-    - name: Install dependencies [Conda]
+    - name: Install dependencies [Conda/Windows-latest]
+      if: contains(matrix.os, 'windows-latest')
       shell: bash -l {0}
       run: |
-        # Compilation related dependencies
-        conda install cmake compilers make pkg-config doxygen ninja graphviz typing_extensions llvm-openmp clang
-        # Main dependencies
-        conda install eigen simde
-        # Test dependencies
-        conda install libmatio numpy scipy
+        # Use VS2022 on Windows-latest
+        conda install vs2022_win-64
 
     - name: Install julia [Linux]
       if: contains(matrix.os, 'ubuntu')
@@ -119,7 +115,7 @@ jobs:
 
     - name: Configure [Conda/Windows]
       if: contains(matrix.os, 'windows-')
-      # It's better to use CMD to have all MSVC variables setup
+      # It's better to use CMD to have all VS variables setup
       shell: cmd /C CALL {0}
       run: |
         git submodule update --init
@@ -138,7 +134,7 @@ jobs:
 
     - name: Build [Conda/Windows]
       if: contains(matrix.os, 'windows-')
-      # It's better to use CMD to have all MSVC variables setup
+      # It's better to use CMD to have all VS variables setup
       shell: cmd /C CALL {0}
       run: |
         cd build

--- a/.github/workflows/conda/environment.yml
+++ b/.github/workflows/conda/environment.yml
@@ -1,0 +1,20 @@
+name: proxsuite
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - cmake
+  - compilers
+  - make
+  - pkg-config
+  - doxygen
+  - ninja
+  - graphviz
+  - typing_extensions
+  - llvm-openmp
+  - clang
+  - eigen
+  - simde
+  - libmatio
+  - numpy
+  - scipy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+* Fix Windows build with MSVC compiler and C++20 standard ([#368](https://github.com/Simple-Robotics/proxsuite/pull/368))
+
 ## [0.7.0] - 2025-01-21
 
 ### Fixed

--- a/include/proxsuite/linalg/veg/internal/macros.hpp
+++ b/include/proxsuite/linalg/veg/internal/macros.hpp
@@ -477,7 +477,7 @@
 #define __VEG_IMPL_PREFIX_explicit
 
 #define __VEG_IMPL_PARAM_EXPAND(I, _, Param)                                   \
-  __VEG_PP_TAIL Param __VEG_PP_HEAD Param
+  __VEG_PP_ID(__VEG_PP_TAIL Param) __VEG_PP_ID(__VEG_PP_HEAD Param)
 #if VEG_HAS_CONCEPTS
 #define __VEG_IMPL_TEMPLATE(Attr_Name, TParams, Constraint, ...)               \
   template<__VEG_PP_REMOVE_PAREN(TParams)>                                     \


### PR DESCRIPTION
Fix https://github.com/Simple-Robotics/proxsuite/issues/367

Cl compiler doesn't expand `__VA_ARGS__` like clang or gcc. It's well [documented](https://learn.microsoft.com/en-us/cpp/preprocessor/variadic-macros?view=msvc-170) but hard to catch.

@aescande have introduce the `__VEG_PP_ID` macro to overcome this issue without activating the [/Zc:preprocessor](https://learn.microsoft.com/en-us/cpp/build/reference/zc-preprocessor?view=msvc-170) compiler flags.

# TODO
- [x] Find a fix
- [x] Activate cl CI steps to avoid regression