### PR TITLE
Replace `!= None` with `is not None` in Python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 * Fix an arcane compilation issue on Clang-19 ([#379](https://github.com/Simple-Robotics/proxsuite/pull/379))
+* Replace `!= None` with `is not None` in Python bindings ([#375](https://github.com/Simple-Robotics/proxsuite/pull/375))
 
 ### Changed
 * Upgrade nanobind submodule to v2.5.0 ([#378](https://github.com/Simple-Robotics/proxsuite/pull/378))

--- a/bindings/python/proxsuite/torch/qplayer.py
+++ b/bindings/python/proxsuite/torch/qplayer.py
@@ -194,9 +194,9 @@ def QPFunction(
                 for i in range(nBatch):
                     rhs = np.zeros(n_tot)
                     rhs[:dim] = dl_dzhat[i]
-                    if dl_dlams != None:
+                    if dl_dlams is not None:
                         rhs[dim : dim + neq] = dl_dlams[i]
-                    if dl_dnus != None:
+                    if dl_dnus is not None:
                         rhs[dim + neq :] = dl_dnus[i]
                     vector_of_loss_derivatives.append(rhs)
 
@@ -212,9 +212,9 @@ def QPFunction(
                 for i in range(nBatch):
                     rhs = np.zeros(n_tot)
                     rhs[:dim] = dl_dzhat[i].cpu()
-                    if dl_dlams != None:
+                    if dl_dlams is not None:
                         rhs[dim : dim + neq] = dl_dlams[i].cpu()
-                    if dl_dnus != None:
+                    if dl_dnus is not None:
                         rhs[dim + neq :] = dl_dnus[i].cpu()
                     qpi = ctx.vector_of_qps.get(i)
                     proxsuite.proxqp.dense.compute_backward(
@@ -472,13 +472,13 @@ def QPFunction(
 
                 rhs = np.zeros(kkt.shape[0])
                 rhs[:dim] = -dl_dzhat[i]
-                if dl_dlams != None:
+                if dl_dlams is not None:
                     if n_eq != 0:
                         rhs[dim : dim + n_eq] = -dl_dlams[i]
                 active_set = None
                 if n_in != 0:
                     active_set = -z_i[:n_in_sol] + z_i[n_in_sol:] >= 0
-                if dl_dnus != None:
+                if dl_dnus is not None:
                     if n_in != 0:
                         # we must convert dl_dnus to a uni sided version
                         # to do so we reconstitute the active set
@@ -488,10 +488,10 @@ def QPFunction(
                         rhs[dim + n_eq + n_in_sol : dim + n_eq + n_in][active_set] = (
                             -dl_dnus[i][active_set]
                         )
-                if dl_ds_e != None:
+                if dl_ds_e is not None:
                     if dl_ds_e.shape[0] != 0:
                         rhs[dim + n_eq + n_in : dim + 2 * n_eq + n_in] = -dl_ds_e[i]
-                if dl_ds_i != None:
+                if dl_ds_i is not None:
                     if dl_ds_i.shape[0] != 0:
                         # we must convert dl_dnus to a uni sided version
                         # to do so we reconstitute the active set


### PR DESCRIPTION
In Python it is better to compare to ~~not~~ _None_ (typo fixed, thanks @nim65s) with `is` or `is not` rather than `==` and `!=` (e.g. the comparison operators may not be defined).

In this code it changes nothing, because tensors are from PyTorch:

```py
In [1]: import torch

In [2]: x = torch.tensor([1, 2, 3])

In [3]: x is not None
Out[3]: True

In [4]: x != None
Out[4]: True
```

But with NumPy arrays it would yield, for instance:

```py
In [1]: x = np.array([1, 2, 3])

In [2]: x is not None
Out[2]: True

In [3]: x != None
Out[3]: array([ True,  True,  True])

In [4]: if x != None:
   ...:     pass
   ...: 
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[4], line 1
----> 1 if x != None:
      2     pass

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```