### PR TITLE
Fix an arcane bug on clang 19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+* Fix an arcane compilation issue on Clang-19 ([#379](https://github.com/Simple-Robotics/proxsuite/pull/379))
+
 ## [0.7.1] - 2025-01-28
 
 ### Fixed

--- a/include/proxsuite/linalg/veg/tuple.hpp
+++ b/include/proxsuite/linalg/veg/tuple.hpp
@@ -754,7 +754,7 @@ private:
     proxsuite::linalg::veg::meta::false_type /*unused*/,
     Tuples&&... tups) VEG_NOEXCEPT -> Concat<Tuples...>
   {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || (defined(__clang__) && __clang_major__ >= 19)
     return cat::from_ref_to_result(
       Tag<proxsuite::linalg::veg::meta::type_sequence_cat<Tuple, Tuples...>>{},
       cat::apply(_detail::_tuple::tuple_fwd(VEG_FWD(tups))...));


### PR DESCRIPTION
Clang 19 now requires the list of template arguments after a `template` keyword prefixing a name. This applies to the `cat::template ...` static function call in tuple.hpp.

Related: https://github.com/llvm/llvm-project/commit/f46d1463b835560d90ad3ac02b63c771e4ebe566, https://github.com/tstack/lnav/issues/1328
