### PR TITLE
Fix Visual Studio 17.13 build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 * Fix an arcane compilation issue on Clang-19 ([#379](https://github.com/Simple-Robotics/proxsuite/pull/379))
 * Replace `!= None` with `is not None` in Python bindings ([#375](https://github.com/Simple-Robotics/proxsuite/pull/375))
+* Fix Internal compiler error with Visual Studio 17.13 ([#384](https://github.com/Simple-Robotics/proxsuite/pull/384))
 
 ### Changed
 * Upgrade nanobind submodule to v2.5.0 ([#378](https://github.com/Simple-Robotics/proxsuite/pull/378))

--- a/include/proxsuite/linalg/veg/type_traits/constructible.hpp
+++ b/include/proxsuite/linalg/veg/type_traits/constructible.hpp
@@ -166,6 +166,12 @@ template<typename T>
 struct MoveFn
 {
   T&& value;
+  // We should define a constructor to avoid an Internal compiler error with
+  // Visual Studio 17.13
+  MoveFn(T&& v)
+    : value(VEG_FWD(v))
+  {
+  }
   VEG_INLINE constexpr auto operator()() const&& VEG_NOEXCEPT_IF(
     VEG_CONCEPT(nothrow_movable<T>)) -> T
   {


### PR DESCRIPTION
Visual studio 17.13 stop on an internal compiler error when building `veg/tuple.hpp`.

This patch add a workaround to allow to build.