### PR TITLE
[do not merge] Do post release for windows and py3.10

### DIFF
--- a/.github/workflows/release-osx-win.yml
+++ b/.github/workflows/release-osx-win.yml
@@ -20,11 +20,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: [macos-13, macos-14, windows-2019, windows-latest]
+        python-version: ["3.10"]
+        os: [windows-latest]
         include:
-          - os: windows-2019
-            toolset: ClangCl
           - os: windows-latest
             toolset: v143
 
@@ -32,6 +30,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Do post-release version for 0.7.2
+        run: sed -i 's/^version = "\(0.7.2\)"/version = "\1.post1"/' pyproject.toml
 
       - name: Set ownership
         run: |
@@ -107,11 +108,15 @@ jobs:
           merge-multiple: true
           path: dist
 
+      - name: Check package with twine
+        run: |
+          pip install twine
+          # checks if files can be unzipped and if metadata is correct
+          twine check --strict dist/*
+
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: |
-          github.repository == 'Simple-Robotics/proxsuite' &&
-          (github.event_name == 'release' && github.event.action == 'published')
+
 
   check:
     if: always()


### PR DESCRIPTION
this pr targets to upload a post release on pypi (for 0.7.2, 0.7.1, 0.7.0) to fix the corrupted wheels that were uploaded. the error was fixed for future releases.