### PR TITLE
Use nanobind's new recursive stub generation, fix dynamic module handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Recursive stub generation for Python bindings ([#419](https://github.com/Simple-Robotics/proxsuite/pull/419))
+
 ### Changed
 - Change the default branch to `devel` ([#395](https://github.com/Simple-Robotics/proxsuite/pull/395))
 - Change `dual_feasibility` test threshold in `sparse_maros_meszaros` unit test ([#403](https://github.com/Simple-Robotics/proxsuite/pull/403))
 - replace `std::numeric_limits<T>::infinity()` by `std::numeric_limits<T>::max()` ([#413](https://github.com/Simple-Robotics/proxsuite/pull/413))
 - Upgraded nanobind dependency version (submodule) to v2.9.2 ([#418](https://github.com/Simple-Robotics/proxsuite/pull/418))
+- Better dynamic module handling ([#419](https://github.com/Simple-Robotics/proxsuite/pull/419))
 
 ### Fixed
 - Use the right table to store `configure-args` cmeel argument ([#403](https://github.com/Simple-Robotics/proxsuite/pull/403))

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -108,12 +108,18 @@ function(list_filter list regular_expression dest_list)
   set(${dest_list} ${list} PARENT_SCOPE)
 endfunction(list_filter)
 
-function(create_python_target target_name COMPILE_OPTIONS dependencies)
+function(
+  create_python_target
+  target_name
+  compile_options
+  dependencies
+  generate_stubs
+)
   nanobind_add_module(${target_name} ${PYWRAP_SOURCES} ${PYWRAP_HEADERS})
   add_dependencies(${PROJECT_NAME}_python ${target_name})
 
   target_link_libraries(${target_name} PUBLIC ${dependencies})
-  target_compile_options(${target_name} PRIVATE ${COMPILE_OPTIONS})
+  target_compile_options(${target_name} PRIVATE ${compile_options})
   target_link_libraries(${target_name} PRIVATE proxsuite)
   target_compile_definitions(
     ${target_name}
@@ -134,7 +140,7 @@ function(create_python_target target_name COMPILE_OPTIONS dependencies)
     if(LINK_PYTHON_INTERFACE_TO_OPENMP)
       target_link_libraries(${target_name} PRIVATE ${OpenMP_CXX_LIBRARIES})
     endif(LINK_PYTHON_INTERFACE_TO_OPENMP)
-  else(BUILD_WITH_OPENMP_SUPPORT)
+  else()
     list_filter("${PYWRAP_HEADERS}" "expose-parallel" PYWRAP_HEADERS)
   endif(BUILD_WITH_OPENMP_SUPPORT)
 
@@ -174,7 +180,7 @@ function(create_python_target target_name COMPILE_OPTIONS dependencies)
   endif()
 
   install(TARGETS ${target_name} DESTINATION ${${PYWRAP}_INSTALL_DIR})
-  if((${target_name} STREQUAL "proxsuite_pywrap") AND GENERATE_PYTHON_STUBS)
+  if(${generate_stubs})
     set(
       stub_outputs
       ${target_name}/__init__.pyi
@@ -211,7 +217,7 @@ else()
   set(AVX512_COMPILE_OPTION "-mavx512f")
 endif()
 
-create_python_target(proxsuite_pywrap "" proxsuite)
+create_python_target(proxsuite_pywrap "" proxsuite ${GENERATE_PYTHON_STUBS})
 if(
   BUILD_WITH_VECTORIZATION_SUPPORT
   AND ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(x86)|(X86)|(amd64)|(AMD64)"
@@ -221,6 +227,7 @@ if(
       proxsuite_pywrap_avx2
       "${AVX2_COMPILE_OPTION};${FMA_COMPILE_OPTION}"
       proxsuite-vectorized
+      False
     )
   endif(BUILD_BINDINGS_WITH_AVX2_SUPPORT)
   if(BUILD_BINDINGS_WITH_AVX512_SUPPORT)
@@ -228,6 +235,7 @@ if(
       proxsuite_pywrap_avx512
       "${AVX512_COMPILE_OPTION};${FMA_COMPILE_OPTION}"
       proxsuite-vectorized
+      False
     )
   endif(BUILD_BINDINGS_WITH_AVX512_SUPPORT)
 endif()

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -227,7 +227,7 @@ if(
       proxsuite_pywrap_avx2
       "${AVX2_COMPILE_OPTION};${FMA_COMPILE_OPTION}"
       proxsuite-vectorized
-      False
+      FALSE
     )
   endif(BUILD_BINDINGS_WITH_AVX2_SUPPORT)
   if(BUILD_BINDINGS_WITH_AVX512_SUPPORT)
@@ -235,7 +235,7 @@ if(
       proxsuite_pywrap_avx512
       "${AVX512_COMPILE_OPTION};${FMA_COMPILE_OPTION}"
       proxsuite-vectorized
-      False
+      FALSE
     )
   endif(BUILD_BINDINGS_WITH_AVX512_SUPPORT)
 endif()

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -108,7 +108,7 @@ function(list_filter list regular_expression dest_list)
   set(${dest_list} ${list} PARENT_SCOPE)
 endfunction(list_filter)
 
-function(CREATE_PYTHON_TARGET target_name COMPILE_OPTIONS dependencies)
+function(create_python_target target_name COMPILE_OPTIONS dependencies)
   nanobind_add_module(${target_name} ${PYWRAP_SOURCES} ${PYWRAP_HEADERS})
   add_dependencies(${PROJECT_NAME}_python ${target_name})
 
@@ -174,16 +174,26 @@ function(CREATE_PYTHON_TARGET target_name COMPILE_OPTIONS dependencies)
   endif()
 
   install(TARGETS ${target_name} DESTINATION ${${PYWRAP}_INSTALL_DIR})
-  if(GENERATE_PYTHON_STUBS)
+  if((${target_name} STREQUAL "proxsuite_pywrap") AND GENERATE_PYTHON_STUBS)
+    set(
+      stub_outputs
+      ${target_name}/__init__.pyi
+      ${target_name}/helpers.pyi
+      ${target_name}/proxqp/__init__.pyi
+      ${target_name}/proxqp/dense.pyi
+      ${target_name}/proxqp/sparse.pyi
+    )
     nanobind_add_stub(
       ${target_name}_stub
       MODULE ${target_name}
-      OUTPUT ${target_name}.pyi
+      OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}
+      OUTPUT ${stub_outputs}
+      RECURSIVE
       PYTHON_PATH $<TARGET_FILE_DIR:${target_name}>
       DEPENDS ${target_name}
     )
     install(
-      FILES ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.pyi
+      DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${target_name}
       DESTINATION ${${PYWRAP}_INSTALL_DIR}
     )
   endif()
@@ -201,20 +211,20 @@ else()
   set(AVX512_COMPILE_OPTION "-mavx512f")
 endif()
 
-CREATE_PYTHON_TARGET(proxsuite_pywrap "" proxsuite)
+create_python_target(proxsuite_pywrap "" proxsuite)
 if(
   BUILD_WITH_VECTORIZATION_SUPPORT
   AND ${CMAKE_SYSTEM_PROCESSOR} MATCHES "(x86)|(X86)|(amd64)|(AMD64)"
 )
   if(BUILD_BINDINGS_WITH_AVX2_SUPPORT)
-    CREATE_PYTHON_TARGET(
+    create_python_target(
       proxsuite_pywrap_avx2
       "${AVX2_COMPILE_OPTION};${FMA_COMPILE_OPTION}"
       proxsuite-vectorized
     )
   endif(BUILD_BINDINGS_WITH_AVX2_SUPPORT)
   if(BUILD_BINDINGS_WITH_AVX512_SUPPORT)
-    CREATE_PYTHON_TARGET(
+    create_python_target(
       proxsuite_pywrap_avx512
       "${AVX512_COMPILE_OPTION};${FMA_COMPILE_OPTION}"
       proxsuite-vectorized

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -39,6 +39,7 @@ if(NOT nanobind_FOUND)
     external/nanobind
     ${CMAKE_CURRENT_BINARY_DIR}/external/nanobind
   )
+  message(STATUS "Will use nanobind submodule.")
 else()
   message(STATUS "Found installed nanobind.")
 endif()

--- a/bindings/python/proxsuite/__init__.py
+++ b/bindings/python/proxsuite/__init__.py
@@ -43,13 +43,14 @@ _submodule = _load_main_module()
 
 
 def __getattr__(name: str):
+    # reroute proxsuite module's attributes to be that of the loaded submodule.
     return getattr(_submodule, name)
 
 
 def __dir__():
-    # implement this for instropection
-    # e.g. autocomplete in IPython.
-    # Respect the submodule's __all__ if available
+    # returns iterable of all accessible attributes in the module.
+    # implement this for instropection, for e.g. autocomplete in interpreters (IPython).
+    # Respect the submodule's __all__ (list of public attributes), if available
     if hasattr(_submodule, "__all__"):
         return _submodule.__all__
     # otherwise, return all attributes

--- a/bindings/python/proxsuite/__init__.py
+++ b/bindings/python/proxsuite/__init__.py
@@ -50,8 +50,5 @@ def __getattr__(name: str):
 def __dir__():
     # returns iterable of all accessible attributes in the module.
     # implement this for instropection, for e.g. autocomplete in interpreters (IPython).
-    # Respect the submodule's __all__ (list of public attributes), if available
-    if hasattr(_submodule, "__all__"):
-        return _submodule.__all__
-    # otherwise, return all attributes
+    # We return the attributes from the submodule.
     return dir(_submodule)


### PR DESCRIPTION
Follow-up to #418 

The new dynamic module handling leverages the [PEP562](https://peps.python.org/pep-0562/) module-level `__getattr__` and `__dir__` for Python 3.7+, instead of messing with the module globals.

See [relevant Python docs page](https://docs.python.org/3/reference/datamodel.html#customizing-module-attribute-access).

On the static type checking side, we greatly improve support by generating a correct stubs hierarchy using nanobind's new [recursive stub generation](https://github.com/wjakob/nanobind/pull/1148). We help the static type checker grab all of the declared attributes with a star-import statement in the bindings' master `__init__` file:

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from .proxsuite_pywrap import *  # noqa
```

As a result, we do not generate stubs for every single nanobind extension module anymore, but only for the always-available `proxsuite_pywrap` (which has no platform-specific compilation flags).