### PR TITLE
[veg] Fix `-Wdeprecated-literal-operator` warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Use the right table to store `configure-args` cmeel argument ([#403](https://github.com/Simple-Robotics/proxsuite/pull/403))
 - Allow project to be used as an external CMake project (FetchContent) ([#408](https://github.com/Simple-Robotics/proxsuite/pull/408))
+- Fix -Wdeprecated-literal-operator warning ([#420](https://github.com/Simple-Robotics/proxsuite/pull/420))
 
 ### Removed
 - Don't release PyPy package on GNU/Linux anymore ([#403](https://github.com/Simple-Robotics/proxsuite/pull/403))

--- a/include/proxsuite/linalg/veg/internal/dyn_index.hpp
+++ b/include/proxsuite/linalg/veg/internal/dyn_index.hpp
@@ -259,7 +259,7 @@ struct binary_traits<Dyn, Fix<N>> : binary_traits<Dyn, Dyn>
 
 inline namespace literals {
 VEG_INLINE constexpr auto
-operator"" _v(unsigned long long n) VEG_NOEXCEPT->Dyn
+operator""_v(unsigned long long n) VEG_NOEXCEPT->Dyn
 {
   return isize(n);
 }

--- a/include/proxsuite/linalg/veg/internal/fix_index.hpp
+++ b/include/proxsuite/linalg/veg/internal/fix_index.hpp
@@ -326,7 +326,7 @@ namespace adl {
 inline namespace literals {
 template<char... Chars>
 VEG_INLINE constexpr auto
-operator"" _c() VEG_NOEXCEPT
+operator""_c() VEG_NOEXCEPT
 {
   return Fix<_detail::parse_int(
     _detail::char_seq<Chars...>::value, sizeof...(Chars), _detail::Error{})>{};

--- a/include/proxsuite/linalg/veg/internal/macros.hpp
+++ b/include/proxsuite/linalg/veg/internal/macros.hpp
@@ -1093,7 +1093,7 @@ HEDLEY_DIAGNOSTIC_PUSH
 template<typename Char,
          Char... Cs>
 constexpr auto
-operator""__veglib_const_literal_gnuc() noexcept // NOLINT
+operator""_veglib_const_literal_gnuc() noexcept // NOLINT
   -> proxsuite::linalg::veg::StrLiteralConstant<
     proxsuite::linalg::veg::CharUnit(Cs)...>
 {
@@ -1103,7 +1103,7 @@ operator""__veglib_const_literal_gnuc() noexcept // NOLINT
 HEDLEY_DIAGNOSTIC_POP
 
 #define __VEG_IMPL_UTF8_CONST(Literal) /* NOLINT */                            \
-  (u8##Literal##__veglib_const_literal_gnuc)
+  (u8##Literal##_veglib_const_literal_gnuc)
 
 #elif (defined(__clang__) && defined(VEG_WITH_CXX20_SUPPORT)) ||               \
   (defined(__cpp_nontype_template_args) &&                                     \
@@ -1157,7 +1157,7 @@ struct StrLiteralExpand<_meta::integer_sequence<usize, Is...>, L>
 
 template<proxsuite::linalg::veg::_detail::StrLiteralImpl S>
 constexpr auto
-operator""__veglib_const_literal_cpp20() noexcept ->
+operator""_veglib_const_literal_cpp20() noexcept ->
   typename proxsuite::linalg::veg::_detail::StrLiteralExpand< //
     proxsuite::linalg::veg::_detail::_meta::make_index_sequence<
       proxsuite::linalg::veg::_detail::StrLiteralLen<decltype(S)>::value>,
@@ -1166,7 +1166,7 @@ operator""__veglib_const_literal_cpp20() noexcept ->
   return {};
 }
 #define __VEG_IMPL_UTF8_CONST(Literal)                                         \
-  (u8##Literal##__veglib_const_literal_cpp20)
+  (u8##Literal##_veglib_const_literal_cpp20)
 
 #else
 


### PR DESCRIPTION
- **[veg] remove whitespace in user-define literals ""_c and ""_v**
