### PR TITLE
Fix CI (step from Eigen3 to Eigen5)

### DIFF
--- a/include/proxsuite/proxqp/dense/solver.hpp
+++ b/include/proxsuite/proxqp/dense/solver.hpp
@@ -1508,7 +1508,13 @@ qp_solve( //
           break;
         }
       } else {
-        qpresults.info.status = QPSolverOutput::PROXQP_SOLVED;
+        if (qpsettings.primal_infeasibility_solving &&
+            qpresults.info.status == QPSolverOutput::PROXQP_PRIMAL_INFEASIBLE) {
+          qpresults.info.status =
+            QPSolverOutput::PROXQP_SOLVED_CLOSEST_PRIMAL_FEASIBLE;
+        } else {
+          qpresults.info.status = QPSolverOutput::PROXQP_SOLVED;
+        }
         break;
       }
     }
@@ -1593,8 +1599,8 @@ qp_solve( //
       scaled_eps =
         infty_norm(qpwork.rhs.head(qpmodel.dim)) * qpsettings.eps_abs;
     }
-    T primal_feasibility_lhs_new(primal_feasibility_lhs);
 
+    T primal_feasibility_lhs_new(primal_feasibility_lhs);
     global_primal_residual(qpmodel,
                            qpresults,
                            qpsettings,
@@ -1607,63 +1613,24 @@ qp_solve( //
                            primal_feasibility_eq_lhs,
                            primal_feasibility_in_lhs);
 
-    is_primal_feasible =
-      primal_feasibility_lhs_new <=
-      (scaled_eps + qpsettings.eps_rel * std::max(primal_feasibility_eq_rhs_0,
-                                                  primal_feasibility_in_rhs_0));
+    T dual_feasibility_lhs_new(dual_feasibility_lhs);
+    global_dual_residual(qpresults,
+                         qpwork,
+                         qpmodel,
+                         box_constraints,
+                         ruiz,
+                         dual_feasibility_lhs_new,
+                         dual_feasibility_rhs_0,
+                         dual_feasibility_rhs_1,
+                         dual_feasibility_rhs_3,
+                         rhs_duality_gap,
+                         duality_gap,
+                         hessian_type);
+
     qpresults.info.pri_res = primal_feasibility_lhs_new;
-    if (is_primal_feasible) {
-      T dual_feasibility_lhs_new(dual_feasibility_lhs);
+    qpresults.info.dua_res = dual_feasibility_lhs_new;
+    qpresults.info.duality_gap = duality_gap;
 
-      global_dual_residual(qpresults,
-                           qpwork,
-                           qpmodel,
-                           box_constraints,
-                           ruiz,
-                           dual_feasibility_lhs_new,
-                           dual_feasibility_rhs_0,
-                           dual_feasibility_rhs_1,
-                           dual_feasibility_rhs_3,
-                           rhs_duality_gap,
-                           duality_gap,
-                           hessian_type);
-      qpresults.info.dua_res = dual_feasibility_lhs_new;
-      qpresults.info.duality_gap = duality_gap;
-
-      is_dual_feasible =
-        dual_feasibility_lhs_new <=
-        (qpsettings.eps_abs +
-         qpsettings.eps_rel *
-           std::max(
-             std::max(dual_feasibility_rhs_3, dual_feasibility_rhs_0),
-             std::max(dual_feasibility_rhs_1, qpwork.dual_feasibility_rhs_2)));
-
-      if (is_dual_feasible) {
-        if (qpsettings.check_duality_gap) {
-          if (std::fabs(qpresults.info.duality_gap) <=
-              qpsettings.eps_duality_gap_abs +
-                qpsettings.eps_duality_gap_rel * rhs_duality_gap) {
-            if (qpsettings.primal_infeasibility_solving &&
-                qpresults.info.status ==
-                  QPSolverOutput::PROXQP_PRIMAL_INFEASIBLE) {
-              qpresults.info.status =
-                QPSolverOutput::PROXQP_SOLVED_CLOSEST_PRIMAL_FEASIBLE;
-            } else {
-              qpresults.info.status = QPSolverOutput::PROXQP_SOLVED;
-            }
-          }
-        } else {
-          if (qpsettings.primal_infeasibility_solving &&
-              qpresults.info.status ==
-                QPSolverOutput::PROXQP_PRIMAL_INFEASIBLE) {
-            qpresults.info.status =
-              QPSolverOutput::PROXQP_SOLVED_CLOSEST_PRIMAL_FEASIBLE;
-          } else {
-            qpresults.info.status = QPSolverOutput::PROXQP_SOLVED;
-          }
-        }
-      }
-    }
     if (qpsettings.bcl_update) {
       bcl_update(qpsettings,
                  qpresults,
@@ -1690,24 +1657,8 @@ qp_solve( //
                       new_bcl_mu_in_inv,
                       new_bcl_mu_eq_inv);
     }
+
     // COLD RESTART
-
-    T dual_feasibility_lhs_new(dual_feasibility_lhs);
-
-    global_dual_residual(qpresults,
-                         qpwork,
-                         qpmodel,
-                         box_constraints,
-                         ruiz,
-                         dual_feasibility_lhs_new,
-                         dual_feasibility_rhs_0,
-                         dual_feasibility_rhs_1,
-                         dual_feasibility_rhs_3,
-                         rhs_duality_gap,
-                         duality_gap,
-                         hessian_type);
-    qpresults.info.dua_res = dual_feasibility_lhs_new;
-    qpresults.info.duality_gap = duality_gap;
 
     if (primal_feasibility_lhs_new >= primal_feasibility_lhs &&
         dual_feasibility_lhs_new >= dual_feasibility_lhs &&

--- a/test/src/dense_maros_meszaros.cpp
+++ b/test/src/dense_maros_meszaros.cpp
@@ -90,12 +90,11 @@ TEST_CASE("dense maros meszaros using the api")
   T elapsed_time = 0.0;
 
   for (auto const* file : files) {
-    auto qp = load_qp(file);
+    auto qp = load_qp(file, true);
     isize n = qp.P.rows();
     isize n_eq_in = qp.A.rows();
 
-    const bool skip = n > 1000 || n_eq_in > 1000;
-    if (skip) {
+    if (qp.skip) {
       std::cout << " path: " << qp.filename << " n: " << n
                 << " n_eq+n_in: " << n_eq_in << " - skipping" << std::endl;
     } else {
@@ -103,7 +102,7 @@ TEST_CASE("dense maros meszaros using the api")
                 << " n_eq+n_in: " << n_eq_in << std::endl;
     }
 
-    if (!skip) {
+    if (!qp.skip) {
 
       auto preprocessed = preprocess_qp(qp);
       auto& H = preprocessed.H;

--- a/test/src/sparse_maros_meszaros.cpp
+++ b/test/src/sparse_maros_meszaros.cpp
@@ -117,12 +117,11 @@ TEST_CASE("sparse maros meszaros using the API")
   const T eps_abs_with_duality_gap = 1e-5;
 
   for (auto const* file : files) {
-    auto qp_raw = load_qp(file);
+    auto qp_raw = load_qp(file, true);
     isize n = qp_raw.P.rows();
     isize n_eq_in = qp_raw.A.rows();
 
-    bool skip = (n > 1000 || n_eq_in > 1000);
-    if (skip) {
+    if (qp_raw.skip) {
       std::cout << " path: " << qp_raw.filename << " n: " << n
                 << " n_eq+n_in: " << n_eq_in << " - SKIPPING" << std::endl;
     } else {
@@ -130,7 +129,7 @@ TEST_CASE("sparse maros meszaros using the API")
                 << " n_eq+n_in: " << n_eq_in << std::endl;
     }
 
-    if (!skip) {
+    if (!qp_raw.skip) {
 
       auto preprocessed = preprocess_qp_sparse(VEG_FWD(qp_raw));
       auto& H = preprocessed.H;


### PR DESCRIPTION
This PR addresses the change of Eigen version (from Eigen3 to Eigen5). 

The fixes are:
(1): Unit test: `ProxQP::dense: test primal infeasibility solving`: From failed to solved. 
(2): Unit tests: `dense maros meszaros using the api` and `sparse maros meszaros using the API`: Fix long run_time. 

The commits:
(1): Commit 5ae94fb01bf0c5bfa2be258ef44dfe939b9d60cb corrects the status update (`PROXQP_SOLVED_CLOSEST_PRIMAL_FEASIBLE`) in the dense backend.
(2): Commit da4a4b229276f4cc694e0425467f8a27b4ba264f redefines the function `load_qp`, in the Maros-Meszaros unit tests, to skip the large problems internally, and not after calling the function. With Eigen5, the complexity of `load_qp` is linear w.r.t. the problem size, making the execution of the CI very long.