### PR TITLE
Correction of update status PROXQP_SOLVED_CLOSEST_FEASIBLE in dense backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Better dynamic module handling ([#419](https://github.com/Simple-Robotics/proxsuite/pull/419))
 
 ### Fixed
+- Correction of the status update for `PROXQP_SOLVED_CLOSEST_PRIMAL_FEASIBLE` ([#432])(https://github.com/Simple-Robotics/proxsuite/pull/432)
 - Use the right table to store `configure-args` cmeel argument ([#403](https://github.com/Simple-Robotics/proxsuite/pull/403))
 - Allow project to be used as an external CMake project (FetchContent) ([#408](https://github.com/Simple-Robotics/proxsuite/pull/408))
 - Fix -Wdeprecated-literal-operator warning ([#420](https://github.com/Simple-Robotics/proxsuite/pull/420))


### PR DESCRIPTION
This PR solves the unit test `ProxQP::dense: test primal infeasibility solving` with Eigen5.

In particular, the update of the `PROXQP_SOLVED_CLOSEST_FEASIBLE` status was not followed by a `break`, making the outer loop keep going until max iteration. 
In that case, the unit test was passing, by chance, with Eigen3, but no longer with Eigen5 (due to a little difference in the number of iterations between the two versions). 

Pros of the PR:
- Correction of the `PROXQP_SOLVED_CLOSEST_FEASIBLE` status logic,
- When the problem is primal infeasible, and `qp.settings.primal_infeasibility_solving = true;`, we reduce the computation time (up to a factor 1000, for example when `qp.settings.max_iter = 10000` and the problem is solved with `qp.results.info.iter_ext = 10`). Also, the solution is exact (in terms of `qp.results.info.pri_res` and `qp.results.info.dua_res`).