### PR TITLE
Unit tests, Maros Meszaros: Redefine function load_qp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Recursive stub generation for Python bindings ([#419](https://github.com/Simple-Robotics/proxsuite/pull/419))
 
 ### Changed
+- Redefine the `load_qp` function in the Maros-Meszaros unit tests ([#433])(https://github.com/Simple-Robotics/proxsuite/pull/433)
 - Change the default branch to `devel` ([#395](https://github.com/Simple-Robotics/proxsuite/pull/395))
 - Change `dual_feasibility` test threshold in `sparse_maros_meszaros` unit test ([#403](https://github.com/Simple-Robotics/proxsuite/pull/403))
 - replace `std::numeric_limits<T>::infinity()` by `std::numeric_limits<T>::max()` ([#413](https://github.com/Simple-Robotics/proxsuite/pull/413))

--- a/test/src/dense_maros_meszaros.cpp
+++ b/test/src/dense_maros_meszaros.cpp
@@ -90,12 +90,11 @@ TEST_CASE("dense maros meszaros using the api")
   T elapsed_time = 0.0;
 
   for (auto const* file : files) {
-    auto qp = load_qp(file);
+    auto qp = load_qp(file, true);
     isize n = qp.P.rows();
     isize n_eq_in = qp.A.rows();
 
-    const bool skip = n > 1000 || n_eq_in > 1000;
-    if (skip) {
+    if (qp.skip) {
       std::cout << " path: " << qp.filename << " n: " << n
                 << " n_eq+n_in: " << n_eq_in << " - skipping" << std::endl;
     } else {
@@ -103,7 +102,7 @@ TEST_CASE("dense maros meszaros using the api")
                 << " n_eq+n_in: " << n_eq_in << std::endl;
     }
 
-    if (!skip) {
+    if (!qp.skip) {
 
       auto preprocessed = preprocess_qp(qp);
       auto& H = preprocessed.H;

--- a/test/src/sparse_maros_meszaros.cpp
+++ b/test/src/sparse_maros_meszaros.cpp
@@ -117,12 +117,11 @@ TEST_CASE("sparse maros meszaros using the API")
   const T eps_abs_with_duality_gap = 1e-5;
 
   for (auto const* file : files) {
-    auto qp_raw = load_qp(file);
+    auto qp_raw = load_qp(file, true);
     isize n = qp_raw.P.rows();
     isize n_eq_in = qp_raw.A.rows();
 
-    bool skip = (n > 1000 || n_eq_in > 1000);
-    if (skip) {
+    if (qp_raw.skip) {
       std::cout << " path: " << qp_raw.filename << " n: " << n
                 << " n_eq+n_in: " << n_eq_in << " - SKIPPING" << std::endl;
     } else {
@@ -130,7 +129,7 @@ TEST_CASE("sparse maros meszaros using the API")
                 << " n_eq+n_in: " << n_eq_in << std::endl;
     }
 
-    if (!skip) {
+    if (!qp_raw.skip) {
 
       auto preprocessed = preprocess_qp_sparse(VEG_FWD(qp_raw));
       auto& H = preprocessed.H;


### PR DESCRIPTION
This PR solved the execution time of the Maros Meszaros unit tests with Eigen5.

In the files, all the problems are called in `files[]`, then loaded in the `load_qp` function. Then, depending on the problem size, the instance can be skipped, or not. 

With Eigen3: The `load_qp` function is fast.
With Eigen5: Its execution time seems proportional to the problems size, due to an internal loop.

The proposed correction:
- Check the size internally, before to enter the loop. 
- => Eigen5 unit test becomes as fast as the Eigen3 one. 

Note:
- CI fails with ArchLinux on the `ProxQP::dense: test primal infeasibility solving` test. Indeed, this test is run with Eigen5. A fix for this test is proposed in PR https://github.com/Simple-Robotics/proxsuite/pull/432.