### PR TITLE
Update nanobind version to allow updating numpy

### DIFF
--- a/.github/workflows/conda/environment.yml
+++ b/.github/workflows/conda/environment.yml
@@ -16,5 +16,5 @@ dependencies:
   - eigen
   - simde
   - libmatio
-  - numpy<2.4
+  - numpy
   - scipy

--- a/.github/workflows/conda/environment.yml
+++ b/.github/workflows/conda/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
+  - python-gil
   - cmake
   - compilers
   - make

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -21,15 +21,12 @@ jobs:
       fail-fast: false
       matrix:
         arch: ["x86_64", "aarch64"]
-        build: ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
+        build: ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
         include:
           - arch: "x86_64"
             os: ubuntu-latest
           - arch: "aarch64"
             os: ubuntu-24.04-arm
-        exclude:
-          - arch: "aarch64"
-            build: "cp38-*"
 
     steps:
       - uses: actions/checkout@v6
@@ -66,10 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        exclude:
-          - os: "ubuntu-24.04-arm"
-            python-version: "3.8"
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release-osx-win.yml
+++ b/.github/workflows/release-osx-win.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-version: latest
+          miniforge-version: 25.11.0-1
           python-version: ${{ matrix.python-version }}
           activate-environment: proxsuite
           channels: conda-forge

--- a/.github/workflows/release-osx-win.yml
+++ b/.github/workflows/release-osx-win.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [macos-15-intel, macos-14, windows-2022]
         include:
           - os: windows-2022

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -9,6 +9,7 @@ option(GENERATE_PYTHON_STUBS "Generate Python stubs" OFF)
 
 FINDPYTHON(REQUIRED)
 set(Python_INCLUDE_DIRS ${Python3_INCLUDE_DIRS})
+set(Python_VERSION ${Python3_VERSION})
 # Nanobind expects these targets instead of Python3::*
 # https://github.com/jrl-umi3218/jrl-cmakemodules/issues/708
 add_library(Python::Module ALIAS Python3::Module)


### PR DESCRIPTION
Nanobind 2.11 include a fix about 0 size vector handling in numpy 2.4