### PR TITLE
Issue 449: fix various equality comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix -Wdeprecated-literal-operator warning ([#420](https://github.com/Simple-Robotics/proxsuite/pull/420))
 - Fix compilation error with Apple Clang compiler ([#431](https://github.com/Simple-Robotics/proxsuite/pull/431))
 - Fix `settings.primal_infeasibility_solving` documentation ([#438](https://github.com/Simple-Robotics/proxsuite/pull/438))
+- Various fixes for equality comparisons for `Results` and `Settings` objects ([#450]https://github.com/Simple-Robotics/proxsuite/pull/450)
 
 ### Removed
 - Don't release PyPy package on GNU/Linux anymore ([#403](https://github.com/Simple-Robotics/proxsuite/pull/403))

--- a/bindings/python/src/expose-results.hpp
+++ b/bindings/python/src/expose-results.hpp
@@ -57,7 +57,9 @@ exposeResults(nanobind::module_ m)
             &Info<T>::minimal_H_eigenvalue_estimate,
             "By default it equals 0, in order to get an estimate, set "
             "appropriately the setting option "
-            "find_H_minimal_eigenvalue.");
+            "find_H_minimal_eigenvalue.")
+    .def(nanobind::self == nanobind::self)
+    .def(nanobind::self != nanobind::self);
 
   ::nanobind::class_<Results<T>>(m, "Results")
     .def(::nanobind::init<isize, isize, isize>(),

--- a/include/proxsuite/proxqp/results.hpp
+++ b/include/proxsuite/proxqp/results.hpp
@@ -7,6 +7,7 @@
 #ifndef PROXSUITE_PROXQP_RESULTS_HPP
 #define PROXSUITE_PROXQP_RESULTS_HPP
 
+#include <algorithm>
 #include <proxsuite/helpers/optional.hpp>
 #include <Eigen/Core>
 #include <proxsuite/linalg/veg/type_traits/core.hpp>
@@ -238,6 +239,12 @@ operator==(const Results<T>& results1, const Results<T>& results2)
   bool value = results1.x == results2.x && results1.y == results2.y &&
                results1.z == results2.z && results1.se == results2.se &&
                results1.si == results2.si && results1.info == results2.info;
+  if (value) {
+    auto const& ac1 = results1.active_constraints;
+    auto const& ac2 = results2.active_constraints;
+    value = ac1.len() == ac2.len() &&
+            std::equal(ac1.ptr(), ac1.ptr() + ac1.len(), ac2.ptr());
+  }
   return value;
 }
 

--- a/include/proxsuite/proxqp/results.hpp
+++ b/include/proxsuite/proxqp/results.hpp
@@ -218,7 +218,8 @@ operator==(const Info<T>& info1, const Info<T>& info2)
     info1.solve_time == info2.solve_time && info1.run_time == info2.run_time &&
     info1.objValue == info2.objValue && info1.pri_res == info2.pri_res &&
     info1.dua_res == info2.dua_res && info1.duality_gap == info2.duality_gap &&
-    info1.duality_gap == info2.duality_gap &&
+    info1.iterative_residual == info2.iterative_residual &&
+    info1.sparse_backend == info2.sparse_backend &&
     info1.minimal_H_eigenvalue_estimate == info2.minimal_H_eigenvalue_estimate;
   return value;
 }
@@ -235,7 +236,8 @@ bool
 operator==(const Results<T>& results1, const Results<T>& results2)
 {
   bool value = results1.x == results2.x && results1.y == results2.y &&
-               results1.z == results2.z && results1.info == results2.info;
+               results1.z == results2.z && results1.se == results2.se &&
+               results1.si == results2.si && results1.info == results2.info;
   return value;
 }
 

--- a/include/proxsuite/proxqp/settings.hpp
+++ b/include/proxsuite/proxqp/settings.hpp
@@ -324,7 +324,7 @@ operator==(const Settings<T>& settings1, const Settings<T>& settings2)
     settings1.default_mu_eq == settings2.default_mu_eq &&
     settings1.default_mu_in == settings2.default_mu_in &&
     settings1.alpha_bcl == settings2.alpha_bcl &&
-    settings1.alpha_bcl == settings2.alpha_bcl &&
+    settings1.beta_bcl == settings2.beta_bcl &&
     settings1.refactor_dual_feasibility_threshold ==
       settings2.refactor_dual_feasibility_threshold &&
     settings1.refactor_rho_threshold == settings2.refactor_rho_threshold &&
@@ -333,7 +333,7 @@ operator==(const Settings<T>& settings1, const Settings<T>& settings2)
     settings1.mu_max_eq_inv == settings2.mu_max_eq_inv &&
     settings1.mu_max_in_inv == settings2.mu_max_in_inv &&
     settings1.mu_update_factor == settings2.mu_update_factor &&
-    settings1.mu_update_factor == settings2.mu_update_factor &&
+    settings1.mu_update_inv_factor == settings2.mu_update_inv_factor &&
     settings1.cold_reset_mu_eq == settings2.cold_reset_mu_eq &&
     settings1.cold_reset_mu_in == settings2.cold_reset_mu_in &&
     settings1.cold_reset_mu_eq_inv == settings2.cold_reset_mu_eq_inv &&


### PR DESCRIPTION
Addresses https://github.com/Simple-Robotics/proxsuite/issues/449.

I haven't added any tests around this; it might become a little bit of a burden to maintain exhaustive tests comparing the equality of every possible field. But there's also a middle ground where we test a few "obvious" comparisons. Let me know what you think; I'd be happy to add some, but I also think these changes are fairly self-explanatory.

AI disclaimer: I discovered these issues by letting Claude (with Opus 4.6) poke around the repo looking for obvious bugs/inconsistencies.