### PR TITLE
Fix invalid escape sequences in qplayer docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - replace `std::numeric_limits<T>::infinity()` by `std::numeric_limits<T>::max()` ([#413](https://github.com/Simple-Robotics/proxsuite/pull/413))
 - Upgraded nanobind dependency version (submodule) to v2.9.2 ([#418](https://github.com/Simple-Robotics/proxsuite/pull/418))
 - Better dynamic module handling ([#419](https://github.com/Simple-Robotics/proxsuite/pull/419))
+- Fix `SyntaxError` on importing `proxsuite.torch.qplayer` caused by invalid escape sequences in the `QPFunction` docstring ([#458](https://github.com/Simple-Robotics/proxsuite/pull/461))
 
 ### Fixed
 - Correction of the status update for `PROXQP_SOLVED_CLOSEST_PRIMAL_FEASIBLE` ([#432](https://github.com/Simple-Robotics/proxsuite/pull/432))

--- a/bindings/python/proxsuite/torch/qplayer.py
+++ b/bindings/python/proxsuite/torch/qplayer.py
@@ -18,7 +18,7 @@ def QPFunction(
     omp_parallel=False,
     structural_feasibility=True,
 ):
-    """!
+    r"""!
     Solve a batch of Quadratic Programming (QP) problems.
 
     This function solves QP problems of the form:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,5 @@ configure-args = ["-DBUILD_TESTING:BOOL=OFF","-DBUILD_PYTHON_INTERFACE:BOOL=ON",
 
 [tool.ruff.lint]
 ignore = [ "E741" ]
+extend-select = ["W605"]
 exclude = [ "cmake-module/*", "bindings/python/external/nanobind/*" ]


### PR DESCRIPTION
Closes #458.

The QPFunction docstring in `proxsuite/torch/qplayer.py` contains LaTeX and Doxygen markup with backslashes.
Without the r prefix, Python treats these as string escapes, which raises a SyntaxWarning on 3.12+ (silent DeprecationWarning before) 