### PR TITLE
Use VS2022 in CI

### DIFF
--- a/.github/workflows/ci-linux-osx-win-conda.yml
+++ b/.github/workflows/ci-linux-osx-win-conda.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release, Debug]
-        name: [ubuntu-latest, macos-latest, windows-latest-clang-cl, windows-latest, macos-15-intel]
+        name: [ubuntu-latest, macos-latest, windows-2022-clang-cl, windows-2022, macos-15-intel]
         cxx_std: [17, 20]
         continue_on_error: [false]
 
@@ -31,11 +31,11 @@ jobs:
             os: macos-latest
           - name: macos-15-intel
             os: macos-15-intel
-          - name: windows-latest-clang-cl
-            os: windows-latest
+          - name: windows-2022-clang-cl
+            os: windows-2022
             compiler: clang-cl
-          - name: windows-latest
-            os: windows-latest
+          - name: windows-2022
+            os: windows-2022
             compiler: cl
           - name: macos-latest
             os: macos-latest
@@ -70,11 +70,11 @@ jobs:
         auto-activate-base: false
         auto-update-conda: true
 
-    - name: Install dependencies [Conda/Windows-latest]
-      if: contains(matrix.os, 'windows-latest')
+    - name: Install dependencies [Conda/Windows-2022]
+      if: contains(matrix.os, 'windows-2022')
       shell: bash -l {0}
       run: |
-        # Use VS2022 on Windows-latest
+        # Use VS2022 on Windows-2022
         conda install vs2022_win-64
 
     - name: Install julia [Linux]


### PR DESCRIPTION
- Github migrate windows-latest to windows image using vs2026. Right now, it's not the default compiler used by conda and workflow will fail.