### PR TITLE
Fix: initialize active_set_up/low in Workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Initialize `active_set_up` and `active_set_low` in dense `Workspace` ([#476](https://github.com/Simple-Robotics/proxsuite/pull/476))
+
 ### Added
 - Docker images `ghcr.io/Simple-Robotics/proxsuite` ([#470](https://github.com/Simple-Robotics/proxsuite/pull/470))
 

--- a/include/proxsuite/proxqp/dense/workspace.hpp
+++ b/include/proxsuite/proxqp/dense/workspace.hpp
@@ -307,6 +307,8 @@ struct Workspace
     Cdx.setZero();
     Adx.setZero();
     active_part_z.setZero();
+    active_set_up.setConstant(false);
+    active_set_low.setConstant(false);
     dw_aug.setZero();
     rhs.setZero();
     err.setZero();
@@ -366,6 +368,8 @@ struct Workspace
       current_bijection_map(i) = i;
       new_bijection_map(i) = i;
       active_inequalities(i) = false;
+      active_set_up(i) = false;
+      active_set_low(i) = false;
     }
 
     constraints_changed = false;


### PR DESCRIPTION
Previous state of branch devel was not initializing the boolean arrays `active_set_up`, `active_set_low` (dense backend).

The fix: Init with false (`active_set_up.setConstant(false);` in Workspace). This matches the behavior of the sparse backend.