### PR TITLE
Fix/dense box i scaled not reset on keep

### DIFF
--- a/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
+++ b/include/proxsuite/proxqp/dense/preconditioner/ruiz.hpp
@@ -502,6 +502,7 @@ struct RuizEquilibration
       if (box_constraints) {
         u_box.array() *= delta.tail(n).array();
         l_box.array() *= delta.tail(n).array();
+        i_scaled.setOnes();
         i_scaled.array() *= delta.tail(n).array();
         i_scaled.array() *= delta.head(n).array();
       }

--- a/test/src/dense_ruiz_equilibration.cpp
+++ b/test/src/dense_ruiz_equilibration.cpp
@@ -70,3 +70,80 @@ DOCTEST_TEST_CASE("ruiz preconditioner")
   DOCTEST_CHECK((A_new - qp.work.A_scaled).norm() <= Scalar(1e-10));
   DOCTEST_CHECK((b_new - qp.work.b_scaled).norm() <= Scalar(1e-10));
 }
+
+DOCTEST_TEST_CASE(
+  "ruiz preconditioner keeps the scaled box identity consistent")
+{
+  // Regression test: when update_preconditioner is false, the scaled identity
+  // of the box constraint block (work.i_scaled) used to be multiplied by delta
+  // again at every update instead of being derived from the unscaled model.
+  // The box multipliers were then off by the accumulated factor, and the error
+  // grew at every update even though the model never changed.
+  int dim = 20;
+  int n_eq = 0;
+  int n_in = 0;
+
+  Scalar sparsity_factor(0.75);
+  Scalar strong_convexity_factor(0.01);
+  proxqp::dense::Model<Scalar> qp_random =
+    proxqp::utils::dense_strongly_convex_qp(
+      dim, n_eq, n_in, sparsity_factor, strong_convexity_factor);
+
+  // box bounds tight enough to be active at the solution: the box always
+  // contains the origin, so the problem stays feasible
+  auto x_unconstrained = (-qp_random.H.ldlt().solve(qp_random.g)).eval();
+  Scalar bound = Scalar(0.5) * x_unconstrained.cwiseAbs().maxCoeff();
+  auto l_box =
+    Eigen::Matrix<Scalar, Eigen::Dynamic, 1>::Constant(dim, -bound).eval();
+  auto u_box =
+    Eigen::Matrix<Scalar, Eigen::Dynamic, 1>::Constant(dim, bound).eval();
+
+  proxqp::dense::QP<Scalar> qp{ dim, n_eq, n_in, true };
+  qp.settings.eps_abs = Scalar(1e-9);
+  qp.settings.eps_rel = Scalar(0);
+  qp.init(qp_random.H,
+          qp_random.g,
+          qp_random.A,
+          qp_random.b,
+          qp_random.C,
+          qp_random.l,
+          qp_random.u,
+          l_box,
+          u_box);
+  qp.solve();
+
+  DOCTEST_CHECK(qp.results.info.status ==
+                proxqp::QPSolverOutput::PROXQP_SOLVED);
+  // at least one box constraint has to be active for this test to be
+  // meaningful
+  DOCTEST_CHECK(qp.results.z.tail(dim).lpNorm<Eigen::Infinity>() > Scalar(0));
+
+  auto i_scaled_expected = qp.work.i_scaled.eval();
+
+  // the model is never modified, so every update below is a no-op and has to
+  // return the very same primal-dual solution
+  for (int iter = 0; iter < 5; ++iter) {
+    qp.update(qp_random.H,
+              qp_random.g,
+              qp_random.A,
+              qp_random.b,
+              qp_random.C,
+              qp_random.l,
+              qp_random.u,
+              l_box,
+              u_box,
+              false);
+    qp.solve();
+
+    DOCTEST_CHECK(
+      (qp.work.i_scaled - i_scaled_expected).lpNorm<Eigen::Infinity>() <=
+      Scalar(1e-14));
+
+    // stationarity of the returned primal-dual solution, box multipliers
+    // included
+    auto dual_residual =
+      (qp_random.H * qp.results.x + qp_random.g + qp.results.z.tail(dim))
+        .eval();
+    DOCTEST_CHECK(dual_residual.lpNorm<Eigen::Infinity>() <= Scalar(1e-8));
+  }
+}


### PR DESCRIPTION
## Problem

In the dense backend with box constraints, `update(..., update_preconditioner = false)` (the default since #250) returns box multipliers scaled by a factor which **compounds on every call**. Re-solving an unchanged model gives a growing dual error while `results.info.status` stays `PROXQP_SOLVED`. The primal solution is unaffected, so the error is invisible unless the stationarity residual is checked explicitly.

```cpp
// min 0.5 x' H x + g' x   s.t. -1 <= x <= 1,   H = diag(1, 100), g = (-3, -300)
// The data never changes, so every solve must return the same answer.
proxsuite::proxqp::dense::QP<double> qp(2, 0, 0, /* box_constraints = */ true);
qp.init(H, g, A, b, C, l, u, lb, ub);
for (int k = 0; k < 5; ++k) {
  if (k) qp.update(H, g, A, b, C, l, u, lb, ub, /* update_preconditioner = */ false);
  qp.solve();
  // print qp.work.i_scaled, qp.results.z, ||H x + g + z||
}
```

The exact multipliers are `z = (2, 200)`:

```
solve 1  i_scaled = [1.000000 0.991046]  z = [2.00000 200.00000]  ||Hx+g+z|| = 1.023e-12
solve 2  i_scaled = [1.000000 0.982172]  z = [2.00000 201.80701]  ||Hx+g+z|| = 1.807e+00
solve 3  i_scaled = [1.000000 0.973377]  z = [2.00000 203.63034]  ||Hx+g+z|| = 3.630e+00
solve 4  i_scaled = [1.000000 0.964662]  z = [2.00000 205.47015]  ||Hx+g+z|| = 5.470e+00
solve 5  i_scaled = [1.000000 0.956024]  z = [2.00000 207.32659]  ||Hx+g+z|| = 7.327e+00
```

`z(1)` follows `200 / 0.991046^k`, i.e. the returned multiplier is the true one divided by the
accumulated `i_scaled` drift.

## Cause

`dense/preconditioner/ruiz.hpp`, `scale_qp_in_place`: the branch taken when `execute_preconditioner == false` scales `i_scaled` without resetting it first, while the `true` branch resets it via `i_scaled.setOnes()`.

`i_scaled` is also the only scaled quantity that `dense/helpers.hpp::setup` does not refresh before scaling. The matrices/vectors `H_scaled`, `g_scaled`, `A_scaled`, `b_scaled`, `C_scaled`, `l/u_scaled` and `l/u_box_scaled` are all re-copied from the unscaled `qpmodel` on every update, so they start clean. `i_scaled` has no counterpart in the model to be copied from, and so carries the previous scaling into the next one.

After `k` updates it holds `(delta.head * delta.tail)^k` instead of `delta.head * delta.tail`.